### PR TITLE
Update getting-started.md because of problems with Windows OS

### DIFF
--- a/docs/content/docs/getting-started.md
+++ b/docs/content/docs/getting-started.md
@@ -9,6 +9,9 @@ weight: 0
  
 * [Node.js](https://nodejs.org/en/) **v8.9.0** or above
 * If you want to use MySQL, MariaDB, or Postgres as your data store, then you'll need an instance available locally. However, if you are just testing out Vendure, we recommend using SQLite, which has no external requirements.
+* For windows users: make sure you have **windows build tools installed**
+  * ```npm install --global --production windows-build-tools```
+  * this should be done with administrative rights
  
 ## Installation with @vendure/create
 


### PR DESCRIPTION
Because of problems when executing vendure installation on Windows, getting started guide should be updated. 
The installation process needs a specific python version (node-gyp). Installation of **windows-build-tools** ensures this.