### PR TITLE
fix(i18n): Leading slash fot i18n bundles is redundant

### DIFF
--- a/admin-ui/src/app/app.module.ts
+++ b/admin-ui/src/app/app.module.ts
@@ -22,7 +22,7 @@ export class BaseHrefHolder {
 export function HttpLoaderFactory(http: HttpClient, location: PlatformLocation) {
     // Dynamically get the baseHref, which is configured in the angular.json file
     const baseHref = location.getBaseHrefFromDOM();
-    return new CustomHttpTranslationLoader(http, baseHref + '/i18n-messages/');
+    return new CustomHttpTranslationLoader(http, baseHref + 'i18n-messages/');
 }
 
 @NgModule({


### PR DESCRIPTION
This is fixing an issue I found when deploying the static site: bundles fetched were `/admin//i18n-messages/<lang.json>`, provoking an error.