### PR TITLE
fix(api-port): Api port removed from Api request if === 80

### DIFF
--- a/admin-ui/src/app/data/data.module.ts
+++ b/admin-ui/src/app/data/data.module.ts
@@ -29,7 +29,13 @@ export function createApollo(
 ): ApolloClientOptions<any> {
     const { apiHost, apiPort, adminApiPath, tokenMethod } = getAppConfig();
     const host = apiHost === 'auto' ? `${location.protocol}//${location.hostname}` : apiHost;
-    const port = apiPort === 'auto' ? (location.port === '' ? '' : `:${location.port}`) : `:${apiPort}`;
+    const port = apiPort
+        ? apiPort === 'auto'
+            ? location.port === ''
+                ? ''
+                : `:${location.port}`
+            : `:${apiPort}`
+        : '';
     const apolloCache = new InMemoryCache({
         fragmentMatcher: new IntrospectionFragmentMatcher({
             introspectionQueryResultData: introspectionResult,


### PR DESCRIPTION
This makes possible to make requests to `https://demo.vendure.io/admin-api` instead of `https://demo.vendure.io:80/admin-api` (`auto` binds the port to the location port number, while `80` would add the port to the host): with this modif, I managed deploying a static site (on AWS S3) pointing to demo vendure API (for the moment)