### PR TITLE
docs: Fix 'Adding new ActionBar buttons' example code

### DIFF
--- a/docs/content/docs/developer-guide/plugins/extending-the-admin-ui.md
+++ b/docs/content/docs/developer-guide/plugins/extending-the-admin-ui.md
@@ -208,6 +208,7 @@ export function addNavItems(navBuilderService: NavBuilderService) {
             locationId: 'product-detail',
             buttonStyle: 'outline',
             routerLink: ['./reviews'],
+            requiresPermission: 'SuperAdmin'
         });
     };
 }


### PR DESCRIPTION
docs: Add 'requirePermission' property in 'Adding new ActionBar buttons' example code, because invisible button.