### PR TITLE
bug(admin-ui): Asset drag/drop support in safari

### DIFF
--- a/packages/admin-ui/src/lib/core/src/shared/components/asset-file-input/asset-file-input.component.ts
+++ b/packages/admin-ui/src/lib/core/src/shared/components/asset-file-input/asset-file-input.component.ts
@@ -45,7 +45,7 @@ export class AssetFileInputComponent implements OnInit {
     }
 
     @HostListener('document:dragleave', ['$event'])
-    onDragLeave(event: DragEvent) {
+    onDragLeave(event: any) {
         if (!event.clientX && !event.clientY) {
             this.dragging = false;
         }
@@ -55,11 +55,11 @@ export class AssetFileInputComponent implements OnInit {
      * Preventing this event is required to make dropping work.
      * See https://developer.mozilla.org/en-US/docs/Web/API/HTML_Drag_and_Drop_API#Define_a_drop_zone
      */
-    onDragOver(event: DragEvent) {
+    onDragOver(event: any) {
         event.preventDefault();
     }
 
-    onDrop(event: DragEvent) {
+    onDrop(event: any) {
         event.preventDefault();
         this.dragging = false;
         this.overDropZone = false;


### PR DESCRIPTION
**STR:**

1.  custom-built admin-ui, `ts-node compile-admin-ui.ts`:
```
import { compileUiExtensions } from '@vendure/ui-devkit/compiler';
import path from 'path'

compileUiExtensions({
    outputPath: path.join(__dirname, 'dist/admin-ui'),
    extensions: [{
        translations: {
            ru: path.join(__dirname, 'translations/ru.json'),
        }
    }],
}).compile!()
```
2. connect admin-ui plugin in `vendure-config.ts`:
```
AdminUiPlugin.init({
  app: {
    path: path.join(__dirname, 'admin-ui/dist')
  },
  ...
});
```

3. open admin web page from Safari browser 13.0.5

**ART:** 
-  blank page
- https://stackoverflow.com/questions/56137343/angular-not-working-on-safari-browser-but-working-well-on-other-browsers

**ERT:**
- page opens as usual 