### PR TITLE
fix(core) Fix swiss and congolese currency codes

### DIFF
--- a/packages/core/src/api/schema/common/currency-code.graphql
+++ b/packages/core/src/api/schema/common/currency-code.graphql
@@ -58,7 +58,7 @@ enum CurrencyCode {
     "Canadian dollar"
     CAD
     "Congolese franc"
-    CHE
+    CDF
     "Swiss franc"
     CHF
     "Chilean peso"

--- a/packages/core/src/api/schema/common/currency-code.graphql
+++ b/packages/core/src/api/schema/common/currency-code.graphql
@@ -60,7 +60,7 @@ enum CurrencyCode {
     "Congolese franc"
     CHE
     "Swiss franc"
-    CHW
+    CHF
     "Chilean peso"
     CLP
     "Renminbi (Chinese) yuan"


### PR DESCRIPTION
I'm currently experimenting with vendure and so far like it quite a lot.
I currently think of migrating an existing e-commerce shop and am now checking whether I can implement all required features. While setting up a demo system I noticed that the swiss currency code is set to `CHW` instead of `CHF`. This is probably because ISO 4217 defines three currency codes for switzerland but `CHF` is the one usually used.

<img width="744" alt="Screen Shot 2020-04-13 at 15 42 00" src="https://user-images.githubusercontent.com/2634739/79124766-535a8480-7d9d-11ea-901c-d985c541df05.png">

Also I noticed that the name used in the channel settings ("WIR euros") can't be found inside the repository so I'm not sure where to do this change/update.
