### PR TITLE
fix(ui-devkit) Fix generation of shared module file

### DIFF
--- a/packages/ui-devkit/src/compiler/scaffold.ts
+++ b/packages/ui-devkit/src/compiler/scaffold.ts
@@ -93,7 +93,8 @@ ${extensions
     .map(e =>
         e.ngModules
             .filter(m => m.type === 'shared')
-            .map(m => `import { ${m.ngModuleName} } from '${getModuleFilePath(e.id, m)}';\n`),
+            .map(m => `import { ${m.ngModuleName} } from '${getModuleFilePath(e.id, m)}';\n`)
+			.join(''),
     )
     .join('')}
 


### PR DESCRIPTION
**Describe the bug**
When generating the shared extension module the different extension modules are joined together correctly but if one extension contains multiple modules the default `join` inserts commas which results in a compilation error.

**To Reproduce**
Export multiple ngModules from one extension.

EDIT: It's the default behavior in JS: https://jsfiddle.net/kyp8L5bx/

**Expected behavior**
The imports should be joined together with a '' instead of a comma