### PR TITLE
perf(core): Improved performance of validateVariantOptionIds

### DIFF
--- a/packages/core/src/service/helpers/utils/channel-aware-orm-utils.ts
+++ b/packages/core/src/service/helpers/utils/channel-aware-orm-utils.ts
@@ -14,11 +14,14 @@ export function findByIdsInChannel<T extends ChannelAware | VendureEntity>(
     ids: ID[],
     channelId: ID,
     findOptions?: FindManyOptions<T>,
+    eager = true,
 ) {
     const qb = connection.getRepository(entity).createQueryBuilder('product');
     FindOptionsUtils.applyFindManyOptionsOrConditionsToQueryBuilder(qb, findOptions);
-    // tslint:disable-next-line:no-non-null-assertion
-    FindOptionsUtils.joinEagerRelations(qb, qb.alias, qb.expressionMap.mainAlias!.metadata);
+    if (eager) {
+        // tslint:disable-next-line:no-non-null-assertion
+        FindOptionsUtils.joinEagerRelations(qb, qb.alias, qb.expressionMap.mainAlias!.metadata);
+    }
     return qb
         .leftJoin('product.channels', 'channel')
         .andWhere('channel.id = :channelId', { channelId })
@@ -35,11 +38,14 @@ export function findOneInChannel<T extends ChannelAware | VendureEntity>(
     id: ID,
     channelId: ID,
     findOptions?: FindManyOptions<T>,
+    eager = true,
 ) {
     const qb = connection.getRepository(entity).createQueryBuilder('product');
     FindOptionsUtils.applyFindManyOptionsOrConditionsToQueryBuilder(qb, findOptions);
-    // tslint:disable-next-line:no-non-null-assertion
-    FindOptionsUtils.joinEagerRelations(qb, qb.alias, qb.expressionMap.mainAlias!.metadata);
+    if (eager) {
+        // tslint:disable-next-line:no-non-null-assertion
+        FindOptionsUtils.joinEagerRelations(qb, qb.alias, qb.expressionMap.mainAlias!.metadata);
+    }
     return qb
         .leftJoin('product.channels', 'channel')
         .andWhere('product.id = :id', { id })

--- a/packages/core/src/service/helpers/utils/get-entity-or-throw.ts
+++ b/packages/core/src/service/helpers/utils/get-entity-or-throw.ts
@@ -24,6 +24,7 @@ export async function getEntityOrThrow<T extends VendureEntity | ChannelAware>(
     id: ID,
     channelId: ID,
     findOptions?: FindOneOptions<T>,
+    eager?: boolean,
 ): Promise<T>;
 export async function getEntityOrThrow<T extends VendureEntity>(
     connection: Connection,
@@ -31,10 +32,18 @@ export async function getEntityOrThrow<T extends VendureEntity>(
     id: ID,
     findOptionsOrChannelId?: FindOneOptions<T> | ID,
     maybeFindOptions?: FindOneOptions<T>,
+    eager?: boolean,
 ): Promise<T> {
     let entity: T | undefined;
     if (isId(findOptionsOrChannelId)) {
-        entity = await findOneInChannel(connection, entityType, id, findOptionsOrChannelId, maybeFindOptions);
+        entity = await findOneInChannel(
+            connection,
+            entityType,
+            id,
+            findOptionsOrChannelId,
+            maybeFindOptions,
+            eager,
+        );
     } else {
         entity = await connection.getRepository(entityType).findOne(id, findOptionsOrChannelId);
     }


### PR DESCRIPTION
This pull request tries to implement the idea mentioned in https://github.com/vendure-ecommerce/vendure/issues/328#issuecomment-623290422.

Step one and two are done at the same time as before as one is required to do the join anyway.
I wasn't able to think of a case where performing the two steps separately would require less memory but I might be missing something.

In addition to the ideas mention I added the eager option to getEntityOrThrow to further decrease the memory required. Is this okay or should this parameter be implemented differently / i.e. a separate function be added with this functionality?