### PR TITLE
refactor: Update shipping calculator typing

### DIFF
--- a/packages/core/src/config/shipping-method/shipping-calculator.ts
+++ b/packages/core/src/config/shipping-method/shipping-calculator.ts
@@ -56,7 +56,7 @@ export class ShippingCalculator<T extends ShippingCalculatorArgs = {}> extends C
      *
      * @internal
      */
-    calculate(order: Order, args: ConfigArg[]): CalculateShippingFnResponse {
+    calculate(order: Order, args: ConfigArg[]): CalculateShippingFnResult {
         return this.calculateFn(order, argsArrayToHash(args));
     }
 }
@@ -87,7 +87,7 @@ export interface ShippingCalculationResult {
     metadata?: Record<string, any>;
 }
 
-export type CalculateShippingFnResponse =
+export type CalculateShippingFnResult =
     | ShippingCalculationResult
     | Promise<ShippingCalculationResult | undefined>
     | undefined;
@@ -105,4 +105,4 @@ export type CalculateShippingFnResponse =
 export type CalculateShippingFn<T extends ShippingCalculatorArgs> = (
     order: Order,
     args: ConfigArgValues<T>,
-) => CalculateShippingFnResponse;
+) => CalculateShippingFnResult;

--- a/packages/core/src/config/shipping-method/shipping-calculator.ts
+++ b/packages/core/src/config/shipping-method/shipping-calculator.ts
@@ -56,10 +56,7 @@ export class ShippingCalculator<T extends ShippingCalculatorArgs = {}> extends C
      *
      * @internal
      */
-    calculate(
-        order: Order,
-        args: ConfigArg[],
-    ): ShippingCalculationResult | Promise<ShippingCalculationResult> | undefined {
+    calculate(order: Order, args: ConfigArg[]): CalculateShippingFnResponse {
         return this.calculateFn(order, argsArrayToHash(args));
     }
 }
@@ -90,6 +87,11 @@ export interface ShippingCalculationResult {
     metadata?: Record<string, any>;
 }
 
+export type CalculateShippingFnResponse =
+    | ShippingCalculationResult
+    | Promise<ShippingCalculationResult | undefined>
+    | undefined;
+
 /**
  * @description
  * A function which implements the specific shipping calculation logic. It takes an {@link Order} and
@@ -103,4 +105,4 @@ export interface ShippingCalculationResult {
 export type CalculateShippingFn<T extends ShippingCalculatorArgs> = (
     order: Order,
     args: ConfigArgValues<T>,
-) => ShippingCalculationResult | Promise<ShippingCalculationResult> | undefined;
+) => CalculateShippingFnResponse;


### PR DESCRIPTION
I realize that when I fix the issue #398 with the PR #407 I forget to add `undefined` in `calculate` function of the shipping calculator. So to fix that I create a `CalculateShippingFnResponse` type to use in all responses in this file.