### PR TITLE
feat: Extended S3Config to accept aws-sdk configuration properties

### DIFF
--- a/packages/asset-server-plugin/src/s3-asset-storage-strategy.ts
+++ b/packages/asset-server-plugin/src/s3-asset-storage-strategy.ts
@@ -1,5 +1,6 @@
 import { AssetStorageStrategy, Logger } from '@vendure/core';
 import { Request } from 'express';
+import * as path from 'path';
 import { Readable, Stream } from 'stream';
 
 import { loggerCtx } from './constants';
@@ -202,7 +203,7 @@ export class S3AssetStorageStrategy implements AssetStorageStrategy {
     private getObjectParams(identifier: string) {
         return {
             Bucket: this.s3Config.bucket,
-            Key: identifier.replace(/^\//, '').replace(/\//g, '\\'),
+            Key: path.join(identifier.replace(/^\//, '')),
         };
     }
 


### PR DESCRIPTION
Allows a more generic use of the S3 standard. 

As an example, it enables the usage of [MinIO](https://min.io/), an open source object storage which can be useful in several ways, e.g. for local development using storage buckets or as a part of a Kubernetes cluster.
It can also be used as a gateway to other object storages like Google Cloud Storage or Azure. This way, Vendure supports several new storage engines without the need for custom asset storage strategies.

Example usage:
```typescript
storageStrategyFactory: configureS3AssetStorage({
    bucket: process.env.STORAGE_BUCKET || 'default',
    credentials: {
      accessKeyId: process.env.STORAGE_ACCESSKEY || 'default',
      secretAccessKey: process.env.STORAGE_SECRETKEY || 'default',
    },
    nativeS3Configuration: {
      endpoint: process.env.STORAGE_ENDPOINT || 'http://localhost:9000',
      s3ForcePathStyle: true,
      signatureVersion: 'v4',
    },
  }),
```