### PR TITLE
Fixes in migration guide

### DIFF
--- a/docs/content/blog/2020-10-08-announcing-vendure-0-16-0/index.md
+++ b/docs/content/blog/2020-10-08-announcing-vendure-0-16-0/index.md
@@ -285,7 +285,7 @@ Due to the new features described above, there are some **major breaking changes
    // If you are using a UUID strategy, replace 1 with 
    // the ID of the default channel.
     await queryRunner.query(
-      'INSERT INTO `order_channels_channel` (orderId, channelId) SELECT id, 1 FROM `order`',
+      'INSERT INTO `customer_channels_channel` (customerId, channelId) SELECT id, 1 FROM `customer`',
       undefined,
     );
    ```
@@ -293,7 +293,7 @@ Due to the new features described above, there are some **major breaking changes
    or if using Postgres:
     ```TypeScript
      await queryRunner.query(
-       'INSERT INTO "order_channels_channel" ("orderId", "channelId") SELECT id, 1 FROM "order"',
+       'INSERT INTO "customer_channels_channel" ("customerId", "channelId") SELECT id, 1 FROM "customer"',
        undefined,
      );
     ```
@@ -391,7 +391,7 @@ If you are using the helper functions `getEntityOrThrow` or `findOneInChannel`, 
 
 ```diff
 - const order = await getEntityOrThrow(this.connection, Order, orderId);
-+ const order = await this.connection.getEntityOrThrow(Order, orderId);
++ const order = await this.connection.getEntityOrThrow(ctx, Order, orderId);
 ``` 
 
 ### Update to new Vendure Service APIs


### PR DESCRIPTION
The migration to channel aware customers query was not correct. Fixed.
Added mandatory ctx object to new style "this.connection.getEntityOrThrow()".

Additionally after generating migration script I had to update the queries to update gaps in old data. Here with these bold values:
**await queryRunner.query(`UPDATE "order" SET "state"='Delivered' WHERE "state"='Fulfilled'`, undefined);**
await queryRunner.query(`ALTER TABLE "fulfillment" ADD "state" character varying NOT NULL **DEFAULT 'Delivered'**`, undefined);

_So maybe you want to include those updates in guide as well._