### PR TITLE
Fix overflow that made website unusable on sm devices

### DIFF
--- a/packages/admin-ui/src/lib/core/src/components/user-menu/user-menu.component.scss
+++ b/packages/admin-ui/src/lib/core/src/components/user-menu/user-menu.component.scss
@@ -10,6 +10,9 @@
 .user-name {
     color: $color-grey-200;
     margin-right: 12px;
+    @media screen and (max-width: $breakpoint-small) {
+        display: none;
+    }
 }
 
 .trigger clr-icon {


### PR DESCRIPTION
For small devices in conjunction with long username (which is usual case as we use emails as usernames) the header causes big overflow that renders ui almost unusable.
![vendure_mobile_overflow](https://user-images.githubusercontent.com/15977485/96898168-b5ecb580-148f-11eb-9e33-ed60a1163d3a.JPG)

As fix in this PR I hid username altogether as it's not crucial information.
![vendure_mobile](https://user-images.githubusercontent.com/15977485/96898174-b6854c00-148f-11eb-9f4d-ec30a762cb61.JPG)

_If the display of currently logged-in admin is wanted, I would include it in main menu for sm devices._