### PR TITLE
Refine new order list filters

### DIFF
--- a/packages/admin-ui/i18n-coverage.json
+++ b/packages/admin-ui/i18n-coverage.json
@@ -1,44 +1,44 @@
 {
-  "generatedOn": "2020-11-16T09:51:15.905Z",
-  "lastCommit": "33be882c37ebe9e4c92f270b7431438fef0786a7",
+  "generatedOn": "2020-11-18T10:02:11.129Z",
+  "lastCommit": "078de4094b9eaa486e8337fc90c575302a91b590",
   "translationStatus": {
     "cs": {
-      "tokenCount": 687,
-      "translatedCount": 669,
-      "percentage": 97
+      "tokenCount": 688,
+      "translatedCount": 687,
+      "percentage": 100
     },
     "de": {
-      "tokenCount": 687,
+      "tokenCount": 688,
       "translatedCount": 597,
       "percentage": 87
     },
     "en": {
-      "tokenCount": 687,
+      "tokenCount": 688,
       "translatedCount": 687,
       "percentage": 100
     },
     "es": {
-      "tokenCount": 687,
+      "tokenCount": 688,
       "translatedCount": 455,
       "percentage": 66
     },
     "pl": {
-      "tokenCount": 687,
+      "tokenCount": 688,
       "translatedCount": 552,
       "percentage": 80
     },
     "pt_BR": {
-      "tokenCount": 687,
+      "tokenCount": 688,
       "translatedCount": 643,
-      "percentage": 94
+      "percentage": 93
     },
     "zh_Hans": {
-      "tokenCount": 687,
+      "tokenCount": 688,
       "translatedCount": 536,
       "percentage": 78
     },
     "zh_Hant": {
-      "tokenCount": 687,
+      "tokenCount": 688,
       "translatedCount": 536,
       "percentage": 78
     }

--- a/packages/admin-ui/src/lib/order/src/components/order-list/order-list.component.ts
+++ b/packages/admin-ui/src/lib/order/src/components/order-list/order-list.component.ts
@@ -41,7 +41,15 @@ export class OrderListComponent
             label: _('order.filter-preset-open'),
             config: {
                 active: false,
-                states: this.orderStates.filter(s => s !== 'Delivered'),
+                states: this.orderStates.filter(s => s !== 'Delivered' && s !== 'Cancelled' && s !== 'Shipped'),
+            },
+        },
+        {
+            name: 'shipped',
+            label: _('order.filter-preset-shipped'),
+            config: {
+                active: false,
+                states: ['Shipped'],
             },
         },
         {
@@ -49,7 +57,7 @@ export class OrderListComponent
             label: _('order.filter-preset-completed'),
             config: {
                 active: false,
-                states: ['Delivered'],
+                states: ['Delivered', 'Cancelled'],
             },
         },
         {

--- a/packages/admin-ui/src/lib/static/i18n-messages/cs.json
+++ b/packages/admin-ui/src/lib/static/i18n-messages/cs.json
@@ -548,6 +548,7 @@
     "filter-preset-active": "Aktivní",
     "filter-preset-completed": "Uzavřené",
     "filter-preset-open": "Otevřené",
+    "filter-preset-shipped": "Expedované",
     "fulfill": "Zpracovat",
     "fulfill-order": "Zpracovat objednávku",
     "fulfillment": "Zpracování",

--- a/packages/admin-ui/src/lib/static/i18n-messages/de.json
+++ b/packages/admin-ui/src/lib/static/i18n-messages/de.json
@@ -548,6 +548,7 @@
     "filter-preset-active": "",
     "filter-preset-completed": "",
     "filter-preset-open": "",
+    "filter-preset-shipped": "",
     "fulfill": "Ausführen",
     "fulfill-order": "Auftragsausführung",
     "fulfillment": "Ausführung",

--- a/packages/admin-ui/src/lib/static/i18n-messages/en.json
+++ b/packages/admin-ui/src/lib/static/i18n-messages/en.json
@@ -548,6 +548,7 @@
     "filter-preset-active": "Active",
     "filter-preset-completed": "Completed",
     "filter-preset-open": "Open",
+    "filter-preset-shipped": "Shipped",
     "fulfill": "Fulfill",
     "fulfill-order": "Fulfill order",
     "fulfillment": "Fulfillment",

--- a/packages/admin-ui/src/lib/static/i18n-messages/es.json
+++ b/packages/admin-ui/src/lib/static/i18n-messages/es.json
@@ -548,6 +548,7 @@
     "filter-preset-active": "",
     "filter-preset-completed": "",
     "filter-preset-open": "",
+    "filter-preset-shipped": "",
     "fulfill": "",
     "fulfill-order": "",
     "fulfillment": "",

--- a/packages/admin-ui/src/lib/static/i18n-messages/pl.json
+++ b/packages/admin-ui/src/lib/static/i18n-messages/pl.json
@@ -548,6 +548,7 @@
     "filter-preset-active": "",
     "filter-preset-completed": "",
     "filter-preset-open": "",
+    "filter-preset-shipped": "",
     "fulfill": "Zrealizuj",
     "fulfill-order": "Zrealizuj zamówienie",
     "fulfillment": "Realizacja",

--- a/packages/admin-ui/src/lib/static/i18n-messages/pt_BR.json
+++ b/packages/admin-ui/src/lib/static/i18n-messages/pt_BR.json
@@ -548,6 +548,7 @@
     "filter-preset-active": "",
     "filter-preset-completed": "",
     "filter-preset-open": "",
+    "filter-preset-shipped": "",
     "fulfill": "Executar",
     "fulfill-order": "Executar o pedido",
     "fulfillment": "Execução",

--- a/packages/admin-ui/src/lib/static/i18n-messages/zh_Hans.json
+++ b/packages/admin-ui/src/lib/static/i18n-messages/zh_Hans.json
@@ -548,6 +548,7 @@
     "filter-preset-active": "",
     "filter-preset-completed": "",
     "filter-preset-open": "",
+    "filter-preset-shipped": "",
     "fulfill": "已配货",
     "fulfill-order": "接受订单",
     "fulfillment": "配货记录",

--- a/packages/admin-ui/src/lib/static/i18n-messages/zh_Hant.json
+++ b/packages/admin-ui/src/lib/static/i18n-messages/zh_Hant.json
@@ -548,6 +548,7 @@
     "filter-preset-active": "",
     "filter-preset-completed": "",
     "filter-preset-open": "",
+    "filter-preset-shipped": "",
     "fulfill": "已配貨",
     "fulfill-order": "接受訂單",
     "fulfillment": "配貨記錄",


### PR DESCRIPTION
- move "Cancelled" from _Open_ to _Closed_.
- add new "Shipped" - reasoning behind is that "Shipped" orders are not of interest to shop managers-by this time they done their part with fulfilling the order. Keeping "Partially Shipped" and "Partially Fulfilled" in _Open_, as there is still some actions to be done. Even if need of manual marking of "delivered", they are still not as important as orders that are awaiting/in the processing.

Improvement here would also be that these presets would be configurable by devs to match an use-case exactly.