### PR TITLE
fix(elasticsearch): Default score 0

### DIFF
--- a/packages/elasticsearch-plugin/src/elasticsearch.service.ts
+++ b/packages/elasticsearch-plugin/src/elasticsearch.service.ts
@@ -294,7 +294,7 @@ export class ElasticsearchService implements OnModuleInit, OnModuleDestroy {
             priceWithTax: {
                 value: source.priceWithTax,
             },
-            score: hit._score,
+            score: hit._score || 0,
         };
 
         this.addCustomMappings(result, source, this.options.customProductVariantMappings);
@@ -328,7 +328,7 @@ export class ElasticsearchService implements OnModuleInit, OnModuleDestroy {
                 max: source.priceWithTaxMax,
             },
             channelIds: [],
-            score: hit._score,
+            score: hit._score || 0,
         };
         this.addCustomMappings(result, source, this.options.customProductMappings);
         return result;


### PR DESCRIPTION
When searching elastic with an empty search term, elastic does not return a score. When requesting the score in the GraphQL API, an error is thrown. This PR replaces the score with 0 in case there is none.