### PR TITLE
feat(elasticsearch): LanguageCode support in CustomMappings

### DIFF
--- a/packages/elasticsearch-plugin/src/indexer.controller.ts
+++ b/packages/elasticsearch-plugin/src/indexer.controller.ts
@@ -772,7 +772,7 @@ export class ElasticsearchIndexerController implements OnModuleInit, OnModuleDes
         };
         const customMappings = Object.entries(this.options.customProductVariantMappings);
         for (const [name, def] of customMappings) {
-            item[name] = def.valueFn(v);
+            item[name] = def.valueFn(v, languageCode);
         }
         return item;
     }
@@ -826,7 +826,7 @@ export class ElasticsearchIndexerController implements OnModuleInit, OnModuleDes
 
         const customMappings = Object.entries(this.options.customProductMappings);
         for (const [name, def] of customMappings) {
-            item[name] = def.valueFn(variants[0].product, variants);
+            item[name] = def.valueFn(variants[0].product, variants, languageCode);
         }
         return item;
     }

--- a/packages/elasticsearch-plugin/src/options.ts
+++ b/packages/elasticsearch-plugin/src/options.ts
@@ -1,5 +1,5 @@
 import { ClientOptions } from '@elastic/elasticsearch';
-import { DeepRequired, ID, Product, ProductVariant } from '@vendure/core';
+import { DeepRequired, ID, LanguageCode, Product, ProductVariant } from '@vendure/core';
 import deepmerge from 'deepmerge';
 
 import { CustomMapping, ElasticSearchInput } from './types';
@@ -101,7 +101,7 @@ export interface ElasticsearchOptions {
      * ```
      */
     customProductMappings?: {
-        [fieldName: string]: CustomMapping<[Product, ProductVariant[]]>;
+        [fieldName: string]: CustomMapping<[Product, ProductVariant[], LanguageCode]>;
     };
     /**
      * @description
@@ -127,7 +127,7 @@ export interface ElasticsearchOptions {
      * ```
      */
     customProductVariantMappings?: {
-        [fieldName: string]: CustomMapping<[ProductVariant]>;
+        [fieldName: string]: CustomMapping<[ProductVariant, LanguageCode]>;
     };
 }
 


### PR DESCRIPTION
This simple change allows us to add translated CustomMappings to Products and ProductVariants in Elastic