### PR TITLE
perf: improve order quantity update performance

### DIFF
--- a/packages/core/src/service/helpers/order-modifier/order-modifier.ts
+++ b/packages/core/src/service/helpers/order-modifier/order-modifier.ts
@@ -150,18 +150,18 @@ export class OrderModifier {
             if (!orderLine.items) {
                 orderLine.items = [];
             }
+            const newOrderItems = [];
             for (let i = currentQuantity; i < quantity; i++) {
-                const orderItem = await this.connection.getRepository(ctx, OrderItem).save(
-                    new OrderItem({
-                        listPrice: orderLine.productVariant.price,
-                        listPriceIncludesTax: orderLine.productVariant.priceIncludesTax,
-                        adjustments: [],
-                        taxLines: [],
-                        line: orderLine,
-                    }),
-                );
-                orderLine.items.push(orderItem);
+                newOrderItems.push(new OrderItem({
+                    listPrice: orderLine.productVariant.price,
+                    listPriceIncludesTax: orderLine.productVariant.priceIncludesTax,
+                    adjustments: [],
+                    taxLines: [],
+                    line: orderLine,
+                }));
             }
+            await this.connection.getRepository(ctx, OrderItem).createQueryBuilder().insert().values(newOrderItems);
+            orderLine.items = orderLine.items.concat(newOrderItems);
         } else if (quantity < currentQuantity) {
             if (order.active) {
                 // When an Order is still active, it is fine to just delete

--- a/packages/core/src/service/services/order.service.ts
+++ b/packages/core/src/service/services/order.service.ts
@@ -1329,8 +1329,8 @@ export class OrderService {
             updatedOrderLine ? [updatedOrderLine] : [],
         );
         await this.connection.getRepository(ctx, Order).save(order, { reload: false });
-        await this.connection.getRepository(ctx, OrderItem).save(updatedItems, { reload: false });
-        await this.connection.getRepository(ctx, ShippingLine).save(order.shippingLines, { reload: false });
+        await this.connection.getRepository(ctx, OrderItem).createQueryBuilder().insert().values(updatedItems);
+        await this.connection.getRepository(ctx, ShippingLine).createQueryBuilder().insert().values(order.shippingLines);
         return order;
     }
 


### PR DESCRIPTION
We encountered a drastic performance decrease when updating order item quantities by large numbers. 
Example: adding 100, 100 and 900 items:
![Schermafbeelding 2021-02-11 om 18 25 49](https://user-images.githubusercontent.com/66438062/107673974-c3c08380-6c96-11eb-99fb-5f95654f5224.png)

Also, CPU and memory spike up:
![image](https://user-images.githubusercontent.com/66438062/107674064-d935ad80-6c96-11eb-80c0-856b0651ee01.png)
(note: chart not related to the previous image with requests)

After investigation, saving a list of entities (order items) seems to be a bottleneck. Two improvements are suggested:
* The loop containing a `.save()` now stores the new order items in an array, saving all at once later on.
* Saving all items at once via `.save(orderItems)` did not improve performance drastically. It appears TypeORM has a performance [issue](https://github.com/typeorm/typeorm/issues/1115) saving bulk items via `.save()`. Using the query builder however improves the performance.

Some execution times (in ms) between `.save()` and `.insert()` on the order items:
<img width="1746" src="https://user-images.githubusercontent.com/66438062/107674960-d8514b80-6c97-11eb-9c54-84e9a470dfbc.png">
<img width="1757" src="https://user-images.githubusercontent.com/66438062/107674972-db4c3c00-6c97-11eb-869f-7ce4d8192a3a.png">


Next to the creation loop of order items, the price/promotion calculation afterwards was a second performance bottleneck (having a call of ~12s results in ~7s order item loop and ~5s price calculation). The same approach, saving bulk items at once through the query builder, improves the performance.