### PR TITLE
feat: Added custom sender and generator option to emailPlugin config

### DIFF
--- a/packages/email-plugin/src/email-processor.ts
+++ b/packages/email-plugin/src/email-processor.ts
@@ -4,10 +4,16 @@ import fs from 'fs-extra';
 import { deserializeAttachments } from './attachment-utils';
 import { isDevModeOptions } from './common';
 import { loggerCtx } from './constants';
-import { EmailSender } from './email-sender';
+import { DefaultEmailSender } from './email-sender';
 import { HandlebarsMjmlGenerator } from './handlebars-mjml-generator';
 import { TemplateLoader } from './template-loader';
-import { EmailPluginOptions, EmailTransportOptions, IntermediateEmailDetails } from './types';
+import {
+    EmailGenerator,
+    EmailPluginOptions,
+    EmailSender,
+    EmailTransportOptions,
+    IntermediateEmailDetails,
+} from './types';
 
 /**
  * This class combines the template loading, generation, and email sending - the actual "work" of
@@ -17,15 +23,19 @@ import { EmailPluginOptions, EmailTransportOptions, IntermediateEmailDetails } f
 export class EmailProcessor {
     protected templateLoader: TemplateLoader;
     protected emailSender: EmailSender;
-    protected generator: HandlebarsMjmlGenerator;
+    protected generator: EmailGenerator;
     protected transport: EmailTransportOptions;
 
     constructor(protected options: EmailPluginOptions) {}
 
     async init() {
         this.templateLoader = new TemplateLoader(this.options.templatePath);
-        this.emailSender = new EmailSender();
-        this.generator = new HandlebarsMjmlGenerator();
+        this.emailSender = this.options.customEmailSender
+            ? this.options.customEmailSender
+            : new DefaultEmailSender();
+        this.generator = this.options.customEmailGenerator
+            ? this.options.customEmailGenerator
+            : new HandlebarsMjmlGenerator();
         if (this.generator.onInit) {
             await this.generator.onInit.call(this.generator, this.options);
         }

--- a/packages/email-plugin/src/email-processor.ts
+++ b/packages/email-plugin/src/email-processor.ts
@@ -30,11 +30,9 @@ export class EmailProcessor {
 
     async init() {
         this.templateLoader = new TemplateLoader(this.options.templatePath);
-        this.emailSender = this.options.customEmailSender
-            ? this.options.customEmailSender
-            : new DefaultEmailSender();
-        this.generator = this.options.customEmailGenerator
-            ? this.options.customEmailGenerator
+        this.emailSender = this.options.emailSender ? this.options.emailSender : new DefaultEmailSender();
+        this.generator = this.options.emailGenerator
+            ? this.options.emailGenerator
             : new HandlebarsMjmlGenerator();
         if (this.generator.onInit) {
             await this.generator.onInit.call(this.generator, this.options);

--- a/packages/email-plugin/src/email-sender.ts
+++ b/packages/email-plugin/src/email-sender.ts
@@ -12,7 +12,13 @@ import { Stream } from 'stream';
 import { format } from 'util';
 
 import { loggerCtx } from './constants';
-import { EmailDetails, EmailTransportOptions, SendmailTransportOptions, SMTPTransportOptions } from './types';
+import {
+    EmailDetails,
+    EmailSender,
+    EmailTransportOptions,
+    SendmailTransportOptions,
+    SMTPTransportOptions,
+} from './types';
 
 export type StreamTransportInfo = {
     envelope: {
@@ -26,7 +32,7 @@ export type StreamTransportInfo = {
 /**
  * Uses the configured transport to send the generated email.
  */
-export class EmailSender {
+export class DefaultEmailSender implements EmailSender {
     private _smtpTransport: Mail | undefined;
     private _sendMailTransport: Mail | undefined;
 

--- a/packages/email-plugin/src/plugin.spec.ts
+++ b/packages/email-plugin/src/plugin.spec.ts
@@ -643,7 +643,7 @@ describe('EmailPlugin', () => {
             fakeSender.send = send;
 
             await initPluginWithHandlers([handler], {
-                customEmailSender: fakeSender,
+                emailSender: fakeSender,
             });
 
             eventBus.publish(new MockEvent(ctx, true));

--- a/packages/email-plugin/src/plugin.spec.ts
+++ b/packages/email-plugin/src/plugin.spec.ts
@@ -20,7 +20,7 @@ import { orderConfirmationHandler } from './default-email-handlers';
 import { EmailEventHandler } from './event-handler';
 import { EmailEventListener } from './event-listener';
 import { EmailPlugin } from './plugin';
-import { EmailPluginOptions } from './types';
+import { EmailDetails, EmailPluginOptions, EmailSender, EmailTransportOptions } from './types';
 
 describe('EmailPlugin', () => {
     let eventBus: EventBus;
@@ -624,7 +624,41 @@ describe('EmailPlugin', () => {
             expect(testingLogger.errorSpy.mock.calls[0][0]).toContain(`something went horribly wrong!`);
         });
     });
+
+    describe('custom sender', () => {
+        it('should allow a custom sender to be utilized', async () => {
+            const ctx = RequestContext.deserialize({
+                _channel: { code: DEFAULT_CHANNEL_CODE },
+                _languageCode: LanguageCode.en,
+            } as any);
+            const handler = new EmailEventListener('test')
+                .on(MockEvent)
+                .setFrom('"test from" <noreply@test.com>')
+                .setRecipient(() => 'test@test.com')
+                .setSubject('Hello')
+                .setTemplateVars(event => ({ subjectVar: 'foo' }));
+
+            const fakeSender = new FakeCustomSender();
+            const send = jest.fn();
+            fakeSender.send = send;
+
+            await initPluginWithHandlers([handler], {
+                customEmailSender: fakeSender,
+            });
+
+            eventBus.publish(new MockEvent(ctx, true));
+            await pause();
+            expect(send.mock.calls[0][0].subject).toBe('Hello');
+            expect(send.mock.calls[0][0].recipient).toBe('test@test.com');
+            expect(send.mock.calls[0][0].from).toBe('"test from" <noreply@test.com>');
+            expect(onSend).toHaveBeenCalledTimes(0);
+        });
+    });
 });
+
+class FakeCustomSender implements EmailSender {
+    send: (email: EmailDetails<'unserialized'>, options: EmailTransportOptions) => void;
+}
 
 const pause = () => new Promise(resolve => setTimeout(resolve, 100));
 

--- a/packages/email-plugin/src/types.ts
+++ b/packages/email-plugin/src/types.ts
@@ -64,13 +64,13 @@ export interface EmailPluginOptions {
      * An optional allowed EmailSender, used to allow custom implementations of the send functionality
      * while still utilizing the existing emailPlugin functionality.
      */
-    customEmailSender?: EmailSender;
+    emailSender?: EmailSender;
     /**
      * @description
      * An optional allowed EmailGenerator, used to allow custom email generation functionality to
      * better match with custom email sending functionality.
      */
-    customEmailGenerator?: EmailGenerator;
+    emailGenerator?: EmailGenerator;
 }
 
 /**

--- a/packages/email-plugin/src/types.ts
+++ b/packages/email-plugin/src/types.ts
@@ -59,6 +59,18 @@ export interface EmailPluginOptions {
      * email.
      */
     globalTemplateVars?: { [key: string]: any };
+    /**
+     * @description
+     * An optional allowed EmailSender, used to allow custom implementations of the send functionality
+     * while still utilizing the existing emailPlugin functionality.
+     */
+    customEmailSender?: EmailSender;
+    /**
+     * @description
+     * An optional allowed EmailGenerator, used to allow custom email generation functionality to
+     * better match with custom email sending functionality.
+     */
+    customEmailGenerator?: EmailGenerator;
 }
 
 /**
@@ -260,6 +272,10 @@ export interface TestingTransportOptions {
      * Callback to be invoked when an email would be sent.
      */
     onSend: (details: EmailDetails) => void;
+}
+
+export interface EmailSender {
+    send: (email: EmailDetails, options: EmailTransportOptions) => void;
 }
 
 /**


### PR DESCRIPTION
@michaelbromley - is this what you had in mind? The default options are still instantiated if nothing is passed to the plugin via `EmailPluginOptions`. For a developer to replace these items, they would simply need to create a class that implements `EmailSender` (which I extracted into an interface and renamed the original to `DefaultEmailSender`) and a class that implements EmailGenerator and pass instances of them into the plugin at the VendureConfig level. 

Please let me know if there is a more preferable way to go about this. Thanks!