### PR TITLE
feat(asset-server): Add S3 upload options in configuration

### DIFF
--- a/packages/asset-server-plugin/src/s3-asset-storage-strategy.ts
+++ b/packages/asset-server-plugin/src/s3-asset-storage-strategy.ts
@@ -50,6 +50,13 @@ export interface S3Config {
      * Using type `any` in order to avoid the need to include `aws-sdk` dependency in general.
      */
     nativeS3Configuration?: any;
+    /**
+     * @description
+     * Configuration object passed directly to the AWS SDK.
+     * ManagedUpload.ManagedUploadOptions can be used after importing aws-sdk.
+     * Using type `any` in order to avoid the need to include `aws-sdk` dependency in general.
+     */
+    nativeS3UploadConfiguration?: any;
 }
 
 /**
@@ -148,22 +155,28 @@ export class S3AssetStorageStrategy implements AssetStorageStrategy {
 
     async writeFileFromBuffer(fileName: string, data: Buffer): Promise<string> {
         const result = await this.s3
-            .upload({
-                Bucket: this.s3Config.bucket,
-                Key: fileName,
-                Body: data,
-            })
+            .upload(
+                {
+                    Bucket: this.s3Config.bucket,
+                    Key: fileName,
+                    Body: data,
+                },
+                this.s3Config.nativeS3UploadConfiguration,
+            )
             .promise();
         return result.Key;
     }
 
     async writeFileFromStream(fileName: string, data: Stream): Promise<string> {
         const result = await this.s3
-            .upload({
-                Bucket: this.s3Config.bucket,
-                Key: fileName,
-                Body: data,
-            })
+            .upload(
+                {
+                    Bucket: this.s3Config.bucket,
+                    Key: fileName,
+                    Body: data,
+                },
+                this.s3Config.nativeS3UploadConfiguration,
+            )
             .promise();
         return result.Key;
     }


### PR DESCRIPTION
This allows us to pass more native S3 options. 

For example, we are using `{ partSize: 1024 * 1024 * 100 }` to specify no `resumable` uploads are allowed to AWS/GCS for files smaller than 100MiB. Without this config, uploads tend to fail for files larger than a few megabyte.