### PR TITLE
feat(core): Add order line limit to Vendure configuration

### DIFF
--- a/packages/core/src/config/default-config.ts
+++ b/packages/core/src/config/default-config.ts
@@ -108,6 +108,7 @@ export const defaultConfig: RuntimeVendureConfig = {
     },
     orderOptions: {
         orderItemsLimit: 999,
+        orderLineItemsLimit: 999,
         orderItemPriceCalculationStrategy: new DefaultOrderItemPriceCalculationStrategy(),
         mergeStrategy: new MergeOrdersStrategy(),
         checkoutMergeStrategy: new UseGuestStrategy(),

--- a/packages/core/src/config/vendure-config.ts
+++ b/packages/core/src/config/vendure-config.ts
@@ -384,6 +384,17 @@ export interface OrderOptions {
     orderItemsLimit?: number;
     /**
      * @description
+     * The maximum number of items allowed per order line. This option is an addition
+     * on the `orderItemsLimit` for more granular control. Note `orderItemsLimit` is still
+     * important in order to prevent excessive resource usage.
+     *
+     * Attempting to exceed this limit will cause Vendure to throw a {@link OrderItemsLimitError}.
+     *
+     * @default 999
+     */
+    orderLineItemsLimit?: number;
+    /**
+     * @description
      * Defines the logic used to calculate the unit price of an OrderItem when adding an
      * item to an Order.
      *


### PR DESCRIPTION
Yet another quite small generic feature to limit orders per order line. 
Could be a choice to not have this in the core, just a suggestion.