### PR TITLE
fix(core): RememberMe args not passed correctly for NativeAuthenticationStrategy

### DIFF
--- a/packages/core/src/api/resolvers/base/base-auth.resolver.ts
+++ b/packages/core/src/api/resolvers/base/base-auth.resolver.ts
@@ -58,6 +58,7 @@ export class BaseAuthResolver {
             ctx,
             {
                 input: { [NATIVE_AUTH_STRATEGY_NAME]: args },
+                rememberMe: args.rememberMe,
             },
             req,
             res,


### PR DESCRIPTION
When using the NativeAuthenticationStrategy, the remember me parameter resides under `input`. The `authenticateAndCreateSession( ... )` method expects `MutationAuthenticateArgs` to be passed, where rememberMe is on the same level as `input`.