### PR TITLE
feat(core): Allow to pass validationRules to shop and admin GraphQL API

### DIFF
--- a/packages/core/src/api/api.module.ts
+++ b/packages/core/src/api/api.module.ts
@@ -37,6 +37,7 @@ import { ValidateCustomFieldsInterceptor } from './middleware/validate-custom-fi
             debug: configService.apiOptions.shopApiDebug,
             typePaths: ['shop-api', 'common'].map(p => path.join(__dirname, 'schema', p, '*.graphql')),
             resolverModule: ShopApiModule,
+            validationRules: configService.apiOptions.shopApiValidationRules,
         })),
         configureGraphQLModule(configService => ({
             apiType: 'admin',
@@ -45,6 +46,7 @@ import { ValidateCustomFieldsInterceptor } from './middleware/validate-custom-fi
             debug: configService.apiOptions.adminApiDebug,
             typePaths: ['admin-api', 'common'].map(p => path.join(__dirname, 'schema', p, '*.graphql')),
             resolverModule: AdminApiModule,
+            validationRules: configService.apiOptions.adminApiValidationRules,
         })),
     ],
     providers: [

--- a/packages/core/src/api/config/configure-graphql-module.ts
+++ b/packages/core/src/api/config/configure-graphql-module.ts
@@ -2,7 +2,7 @@ import { DynamicModule } from '@nestjs/common';
 import { ModuleRef } from '@nestjs/core';
 import { GqlModuleOptions, GraphQLModule, GraphQLTypesLoader } from '@nestjs/graphql';
 import { notNullOrUndefined } from '@vendure/common/lib/shared-utils';
-import { buildSchema, extendSchema, GraphQLSchema, printSchema } from 'graphql';
+import { buildSchema, extendSchema, GraphQLSchema, printSchema, ValidationContext } from 'graphql';
 import path from 'path';
 
 import { ConfigModule } from '../../config/config.module';
@@ -44,6 +44,7 @@ export interface GraphQLApiOptions {
     playground: boolean | any;
     // tslint:disable-next-line:ban-types
     resolverModule: Function;
+    validationRules: ((context: ValidationContext) => any)[];
 }
 
 /**
@@ -114,6 +115,7 @@ async function createGraphQLOptions(
             new AssetInterceptorPlugin(configService),
             ...configService.apiOptions.apolloServerPlugins,
         ],
+        validationRules: options.validationRules,
     } as GqlModuleOptions;
 
     /**

--- a/packages/core/src/config/default-config.ts
+++ b/packages/core/src/config/default-config.ts
@@ -48,9 +48,11 @@ export const defaultConfig: RuntimeVendureConfig = {
         adminApiPath: 'admin-api',
         adminApiPlayground: false,
         adminApiDebug: false,
+        adminApiValidationRules: [],
         shopApiPath: 'shop-api',
         shopApiPlayground: false,
         shopApiDebug: false,
+        shopApiValidationRules: [],
         channelTokenKey: 'vendure-token',
         cors: {
             origin: true,

--- a/packages/core/src/config/vendure-config.ts
+++ b/packages/core/src/config/vendure-config.ts
@@ -110,7 +110,7 @@ export interface ApiOptions {
     /**
      * @description
      * Custom functions to use as additional validation rules when validating the schema for the admin GraphQL API
-     * [ApolloServer playground](https://www.apollographql.com/docs/apollo-server/api/apollo-server/#constructoroptions-apolloserver).
+     * [ApolloServer validation rules](https://www.apollographql.com/docs/apollo-server/api/apollo-server/#validationrules).
      *
      * @default []
      */
@@ -118,7 +118,7 @@ export interface ApiOptions {
     /**
      * @description
      * Custom functions to use as additional validation rules when validating the schema for the shop GraphQL API
-     * [ApolloServer playground](https://www.apollographql.com/docs/apollo-server/api/apollo-server/#constructoroptions-apolloserver).
+     * [ApolloServer validation rules](https://www.apollographql.com/docs/apollo-server/api/apollo-server/#validationrules).
      *
      * @default []
      */

--- a/packages/core/src/config/vendure-config.ts
+++ b/packages/core/src/config/vendure-config.ts
@@ -3,6 +3,7 @@ import { CorsOptions } from '@nestjs/common/interfaces/external/cors-options.int
 import { LanguageCode } from '@vendure/common/lib/generated-types';
 import { PluginDefinition } from 'apollo-server-core';
 import { RequestHandler } from 'express';
+import { ValidationContext } from 'graphql';
 import { ConnectionOptions } from 'typeorm';
 
 import { PermissionDefinition } from '../common/permission-definition';
@@ -106,6 +107,22 @@ export interface ApiOptions {
      * @default false
      */
     shopApiDebug?: boolean;
+    /**
+     * @description
+     * Custom functions to use as additional validation rules when validating the schema for the admin GraphQL API
+     * [ApolloServer playground](https://www.apollographql.com/docs/apollo-server/api/apollo-server/#constructoroptions-apolloserver).
+     *
+     * @default []
+     */
+    adminApiValidationRules?: ((context: ValidationContext) => any)[];
+    /**
+     * @description
+     * Custom functions to use as additional validation rules when validating the schema for the shop GraphQL API
+     * [ApolloServer playground](https://www.apollographql.com/docs/apollo-server/api/apollo-server/#constructoroptions-apolloserver).
+     *
+     * @default []
+     */
+    shopApiValidationRules?: ((context: ValidationContext) => any)[];
     /**
      * @description
      * The name of the property which contains the token of the


### PR DESCRIPTION
Our goal with this PR is to use packages like [https://www.npmjs.com/package/graphql-depth-limit](url), to prevent large queries from bringing down the server. 