### PR TITLE
feat(core): add promotion state and promotion action-condition dependency

### DIFF
--- a/packages/core/src/common/types/adjustment-source.ts
+++ b/packages/core/src/common/types/adjustment-source.ts
@@ -3,6 +3,8 @@ import { ID } from '@vendure/common/lib/shared-types';
 
 import { VendureEntity } from '../../entity/base/base.entity';
 
+export type TestResult = boolean | object;
+
 export abstract class AdjustmentSource extends VendureEntity {
     type: AdjustmentType;
 
@@ -18,6 +20,6 @@ export abstract class AdjustmentSource extends VendureEntity {
         };
     }
 
-    abstract test(...args: any[]): boolean | Promise<boolean>;
+    abstract test(...args: any[]): TestResult | Promise<TestResult>;
     abstract apply(...args: any[]): Adjustment | undefined | Promise<Adjustment | undefined>;
 }

--- a/packages/core/src/config/promotion/actions/buy-x-get-y-free-action.ts
+++ b/packages/core/src/config/promotion/actions/buy-x-get-y-free-action.ts
@@ -1,0 +1,27 @@
+import { LanguageCode } from '@vendure/common/lib/generated-types';
+import { ID } from '@vendure/common/lib/shared-types';
+
+import { idsAreEqual } from '../../../common/utils';
+import { OrderItem } from '../../../entity';
+import { PromotionItemAction } from '../promotion-action';
+
+export const buyXGetYFreeAction = new PromotionItemAction({
+    code: 'buy_x_get_y_free',
+    description: [{ languageCode: LanguageCode.en, value: 'Buy { amountX } of { variantIdsX } products, get { amountY } of { variantIdsY } products free' }],
+    args: {},
+    conditions: {
+        'buy_x_get_y_free': { required: true },
+    },
+    execute(ctx, orderItem, orderLine, args, state) {
+        const freeItemIds  = state.buy_x_get_y_free.freeItemIds as ID[];
+        if (idsContainsItem(freeItemIds, orderItem)) {
+            const unitPrice = ctx.channel.pricesIncludeTax ? orderLine.unitPriceWithTax : orderLine.unitPrice;
+            return -unitPrice;
+        }
+        return 0;
+    },
+});
+
+function idsContainsItem(ids: ID[], item: OrderItem): boolean {
+    return !!ids.find(id => idsAreEqual(id, item.id));
+}

--- a/packages/core/src/config/promotion/conditions/buy-x-get-y-free-condition.ts
+++ b/packages/core/src/config/promotion/conditions/buy-x-get-y-free-condition.ts
@@ -1,0 +1,62 @@
+import { LanguageCode } from '@vendure/common/lib/generated-types';
+import { ID } from '@vendure/common/lib/shared-types';
+
+import { PromotionCondition } from '../promotion-condition';
+
+export const buyXGetYFreeCondition = new PromotionCondition({
+    code: 'buy_x_get_y_free',
+    description: [
+        { languageCode: LanguageCode.en, value: 'Buy { amountX } of { variantIdsX } products, get { amountY } of { variantIdsY } products free' },
+    ],
+    args: {
+        amountX: {
+            type: 'int',
+            defaultValue: 2,
+        },
+        variantIdsX: {
+            type: 'ID',
+            list: true,
+            ui: { component: 'product-selector-form-input' },
+            label: [{ languageCode: LanguageCode.en, value: 'Product variants X' }],
+        },
+        amountY: {
+            type: 'int',
+            defaultValue: 1,
+        },
+        variantIdsY: {
+            type: 'ID',
+            list: true,
+            ui: { component: 'product-selector-form-input' },
+            label: [{ languageCode: LanguageCode.en, value: 'Product variants Y' }],
+        },
+    },
+    async check(ctx, order, args) {
+        const xIds = createIdentityMap(args.variantIdsX);
+        const yIds = createIdentityMap(args.variantIdsY);
+        let matches = 0;
+        const freeItemCandidates = [];
+        for (const line of order.lines) {
+            const variantId = line.productVariant.id;
+            if (variantId in xIds) {
+                matches += line.quantity;
+            }
+            if (variantId in yIds) {
+                freeItemCandidates.push(...line.items);
+            }
+        }
+        const quantity = Math.floor(matches / args.amountX);
+        if (!quantity || !freeItemCandidates.length) return false;
+        const freeItemIds = freeItemCandidates.sort((a, b) => {
+            const unitPriceA = ctx.channel.pricesIncludeTax ? a.unitPriceWithTax : a.unitPrice;
+            const unitPriceB = ctx.channel.pricesIncludeTax ? b.unitPriceWithTax : b.unitPrice;
+            if (unitPriceA < unitPriceB) return -1;
+            if (unitPriceA > unitPriceB) return 1;
+            return 0;
+        }).map(({ id }) => id).slice(0, quantity * args.amountY);
+        return { freeItemIds };
+    },
+});
+
+function createIdentityMap(ids: ID[]): Record<ID, ID> {
+    return ids.reduce((map: Record<ID, ID>, id) => ({ ...map, [id]: id }), {});
+}

--- a/packages/core/src/config/promotion/index.ts
+++ b/packages/core/src/config/promotion/index.ts
@@ -1,8 +1,10 @@
+import { buyXGetYFreeAction } from './actions/buy-x-get-y-free-action';
 import { discountOnItemWithFacets } from './actions/facet-values-percentage-discount-action';
 import { freeShipping } from './actions/free-shipping-action';
 import { orderFixedDiscount } from './actions/order-fixed-discount-action';
 import { orderPercentageDiscount } from './actions/order-percentage-discount-action';
 import { productsPercentageDiscount } from './actions/product-percentage-discount-action';
+import { buyXGetYFreeCondition } from './conditions/buy-x-get-y-free-condition';
 import { containsProducts } from './conditions/contains-products-condition';
 import { customerGroup } from './conditions/customer-group-condition';
 import { hasFacetValues } from './conditions/has-facet-values-condition';
@@ -25,10 +27,12 @@ export const defaultPromotionActions = [
     discountOnItemWithFacets,
     productsPercentageDiscount,
     freeShipping,
+    buyXGetYFreeAction,
 ];
 export const defaultPromotionConditions = [
     minimumOrderAmount,
     hasFacetValues,
     containsProducts,
     customerGroup,
+    buyXGetYFreeCondition,
 ];

--- a/packages/core/src/config/promotion/promotion-action.ts
+++ b/packages/core/src/config/promotion/promotion-action.ts
@@ -20,8 +20,7 @@ import { PromotionConditionState } from './promotion-condition';
 export type ConditionConfig = {
     [name: string]: { required?: boolean };
 }
-export type ConditionRequiredKeys<U extends ConditionConfig, value extends true | false> =
-    NonNullable<{ [K in keyof U]: value extends U[K]['required'] ? K : never }[keyof U]>;
+
 export type ConditionalState<U extends ConditionConfig> = {
     [K in keyof U]: U[K]['required'] extends true ? PromotionConditionState : PromotionConditionState | undefined;
 }

--- a/packages/core/src/config/promotion/promotion-condition.ts
+++ b/packages/core/src/config/promotion/promotion-condition.ts
@@ -1,5 +1,4 @@
 import { ConfigArg } from '@vendure/common/lib/generated-types';
-import { ConfigArgType, ID } from '@vendure/common/lib/shared-types';
 
 import { RequestContext } from '../../api/common/request-context';
 import {
@@ -8,8 +7,9 @@ import {
     ConfigurableOperationDef,
     ConfigurableOperationDefOptions,
 } from '../../common/configurable-operation';
-import { OrderLine } from '../../entity';
 import { Order } from '../../entity/order/order.entity';
+
+export type CheckPromotionConditionResult = boolean | PromotionConditionState;
 
 /**
  * @description
@@ -22,7 +22,7 @@ export type CheckPromotionConditionFn<T extends ConfigArgs> = (
     ctx: RequestContext,
     order: Order,
     args: ConfigArgValues<T>,
-) => boolean | Promise<boolean>;
+) => CheckPromotionConditionResult | Promise<CheckPromotionConditionResult>;
 
 /**
  * @description
@@ -36,6 +36,8 @@ export interface PromotionConditionConfig<T extends ConfigArgs> extends Configur
     check: CheckPromotionConditionFn<T>;
     priorityValue?: number;
 }
+
+export type PromotionConditionState = Record<string, unknown>;
 
 /**
  * @description
@@ -65,7 +67,7 @@ export class PromotionCondition<T extends ConfigArgs = ConfigArgs> extends Confi
         this.priorityValue = config.priorityValue || 0;
     }
 
-    async check(ctx: RequestContext, order: Order, args: ConfigArg[]): Promise<boolean> {
+    async check(ctx: RequestContext, order: Order, args: ConfigArg[]): Promise<CheckPromotionConditionResult> {
         return this.checkFn(ctx, order, this.argsArrayToHash(args));
     }
 }

--- a/packages/core/src/service/services/promotion.service.ts
+++ b/packages/core/src/service/services/promotion.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { ApplyCouponCodeResult } from '@vendure/common/lib/generated-shop-types';
 import {
+    ConfigurableOperation,
     ConfigurableOperationDefinition,
     CreatePromotionInput,
     CreatePromotionResult,
@@ -14,6 +15,7 @@ import { ID, PaginatedList } from '@vendure/common/lib/shared-types';
 import { unique } from '@vendure/common/lib/unique';
 
 import { RequestContext } from '../../api/common/request-context';
+import { UserInputError } from '../../common';
 import { ErrorResultUnion, JustErrorResults } from '../../common/error/error-result';
 import { MissingConditionsError } from '../../common/error/generated-graphql-admin-errors';
 import {
@@ -25,7 +27,7 @@ import { AdjustmentSource } from '../../common/types/adjustment-source';
 import { ListQueryOptions } from '../../common/types/common-types';
 import { assertFound } from '../../common/utils';
 import { ConfigService } from '../../config/config.service';
-import { PromotionAction } from '../../config/promotion/promotion-action';
+import { ConditionConfig, PromotionAction } from '../../config/promotion/promotion-action';
 import { PromotionCondition } from '../../config/promotion/promotion-condition';
 import { Order } from '../../entity/order/order.entity';
 import { Promotion } from '../../entity/promotion/promotion.entity';
@@ -101,6 +103,9 @@ export class PromotionService {
         ctx: RequestContext,
         input: CreatePromotionInput,
     ): Promise<ErrorResultUnion<CreatePromotionResult, Promotion>> {
+        const conditions = input.conditions.map(c => this.configArgService.parseInput('PromotionCondition', c));
+        const actions = input.actions.map(a => this.configArgService.parseInput('PromotionAction', a));
+        this.validateRequiredConditions(conditions, actions);
         const promotion = new Promotion({
             name: input.name,
             enabled: input.enabled,
@@ -108,8 +113,8 @@ export class PromotionService {
             perCustomerUsageLimit: input.perCustomerUsageLimit,
             startsAt: input.startsAt,
             endsAt: input.endsAt,
-            conditions: input.conditions.map(c => this.configArgService.parseInput('PromotionCondition', c)),
-            actions: input.actions.map(a => this.configArgService.parseInput('PromotionAction', a)),
+            conditions,
+            actions,
             priorityScore: this.calculatePriorityScore(input),
         });
         if (promotion.conditions.length === 0 && !promotion.couponCode) {
@@ -227,5 +232,24 @@ export class PromotionService {
         this.activePromotions = await this.connection.getRepository(Promotion).find({
             where: { enabled: true },
         });
+    }
+
+    private validateRequiredConditions(conditions: ConfigurableOperation[], actions: ConfigurableOperation[]) {
+        const conditionCodes: Record<string, string> = conditions.reduce((codeMap, { code }) => ({ ...codeMap, [code]: code }), {});
+        for (const { code: actionCode } of actions) {
+            const { conditions: conditionConfig } =
+                this.configArgService.getByCode('PromotionAction', actionCode) as { conditions?: ConditionConfig };
+            if (!conditionConfig) {
+                continue;
+            }
+            const missingConditions = Object.keys(conditionConfig)
+                .filter((conditionCode) => conditionConfig[conditionCode].required && !conditionCodes[conditionCode]);
+            if (missingConditions.length) {
+                throw new UserInputError('error.conditions-required-for-action', {
+                    name: actionCode,
+                    value: String(missingConditions),
+                });
+            }
+        }
     }
 }


### PR DESCRIPTION
#732

Had a bit of trouble trying to get the typing right. I started with `PromotionActionConfig['conditions']` being an array of string values. But with the array I couldn't get the typing to interpret the string values as literal, while still handling an empty/missing conditions array correctly.
So I made it more analogous to the ConfigArgs object. The difference being that for now in the ConditionConfig, there's not really any useful data to be passed in the values, it's mostly the keys we use. There's a `required` field now, but perhaps there is not a lot of use to it. My guess is in most cases the value for `required` will be `true`
So perhaps somebody has a better solution?