### PR TITLE
fix(core): Filter Promotions on Channel before applying to Order

### DIFF
--- a/packages/core/src/service/services/order.service.ts
+++ b/packages/core/src/service/services/order.service.ts
@@ -1345,9 +1345,9 @@ export class OrderService {
                 item.listPriceIncludesTax = priceResult.priceIncludesTax;
             }
         }
-        const promotions = await this.connection.getRepository(ctx, Promotion).find({
-            where: { enabled: true, deletedAt: null },
-            order: { priorityScore: 'ASC' },
+        const { items: promotions } = await this.promotionService.findAll(ctx, {
+            filter: { enabled: { eq: true } },
+            sort: { priorityScore: 'ASC' },
         });
         const updatedItems = await this.orderCalculator.applyPriceAdjustments(
             ctx,


### PR DESCRIPTION
When an Order is placed on a certain Channel, Promotions from other Channels are applied as well. Using the PromotionService, the filtering per Channel is automatically applied.