### PR TITLE
fix(email-plugin): Added filename filter for json files

### DIFF
--- a/packages/email-plugin/src/dev-mailbox.ts
+++ b/packages/email-plugin/src/dev-mailbox.ts
@@ -83,7 +83,7 @@ export class DevMailbox {
     private async getEmailList(outputPath: string) {
         const list = await fs.readdir(outputPath);
         const contents: any[] = [];
-        for (const fileName of list) {
+        for (const fileName of list.filter(name => name.endsWith('.json'))) {
             const json = await fs.readFile(path.join(outputPath, fileName), 'utf-8');
             const content = JSON.parse(json);
             contents.push({


### PR DESCRIPTION
Will fix: https://github.com/vendure-ecommerce/real-world-vendure/issues/14

Only `.json` files shall be taken into account.