### PR TITLE
fix(core): validateRequiredFields() fails on required args

### DIFF
--- a/packages/core/src/service/helpers/config-arg/config-arg.service.ts
+++ b/packages/core/src/service/helpers/config-arg/config-arg.service.ts
@@ -92,15 +92,7 @@ export class ConfigArgService {
         for (const [name, argDef] of Object.entries(def.args)) {
             if (argDef.required) {
                 const inputArg = input.arguments.find(a => a.name === name);
-                let val: unknown;
-                if (inputArg) {
-                    try {
-                        val = JSON.parse(inputArg?.value);
-                    } catch (e) {
-                        // ignore
-                    }
-                }
-                if (val == null) {
+                if (!inputArg || inputArg.value === null || inputArg.value === '') {
                     throw new UserInputError('error.configurable-argument-is-required', {
                         name,
                     });


### PR DESCRIPTION
Maybe fixes issue #855 

ConfigArgService.validateRequiredFields() fails to check strings in required args because of a JSON parsing error. Please read the issue.