### PR TITLE
fix(core): Handle different input types in validateRequiredFields()

### DIFF
--- a/packages/core/e2e/configurable-operation.e2e-spec.ts
+++ b/packages/core/e2e/configurable-operation.e2e-spec.ts
@@ -77,8 +77,8 @@ describe('Configurable operations', () => {
                     checker: {
                         code: testShippingEligibilityChecker.code,
                         arguments: [
-                            { name: 'optional', value: 'null' },
-                            { name: 'required', value: '"foo"' },
+                            { name: 'optional', value: '' },
+                            { name: 'required', value: 'foo' },
                         ],
                     },
                     translations: [],
@@ -88,11 +88,11 @@ describe('Configurable operations', () => {
             expect(updateShippingMethod.checker.args).toEqual([
                 {
                     name: 'optional',
-                    value: 'null',
+                    value: '',
                 },
                 {
                     name: 'required',
-                    value: '"foo"',
+                    value: 'foo',
                 },
             ]);
         });
@@ -109,7 +109,7 @@ describe('Configurable operations', () => {
                                 code: testShippingEligibilityChecker.code,
                                 arguments: [
                                     { name: 'optional', value: 'null' },
-                                    { name: 'required', value: 'null' },
+                                    { name: 'required', value: '' },
                                 ],
                             },
                             translations: [],

--- a/packages/core/src/service/helpers/config-arg/config-arg.service.ts
+++ b/packages/core/src/service/helpers/config-arg/config-arg.service.ts
@@ -92,15 +92,19 @@ export class ConfigArgService {
         for (const [name, argDef] of Object.entries(def.args)) {
             if (argDef.required) {
                 const inputArg = input.arguments.find(a => a.name === name);
-                let val: unknown;
-                if (inputArg) {
-                    try {
-                        val = JSON.parse(inputArg?.value);
-                    } catch (e) {
-                        // ignore
+
+                let valid = false;
+                try {
+                    if (['string', 'ID', 'datetime'].includes(argDef.type)) {
+                        valid = !!inputArg && inputArg.value !== '' && inputArg.value != null;
+                    } else {
+                        valid = !!inputArg && JSON.parse(inputArg.value) != null;
                     }
+                } catch (e) {
+                    // ignore
                 }
-                if (val == null) {
+
+                if (!valid) {
                     throw new UserInputError('error.configurable-argument-is-required', {
                         name,
                     });


### PR DESCRIPTION
Implements non-empty checks for different input types of required config-args. Solves #855 

What's not in this commit: Checks for validity of input for actual configured type.