### PR TITLE
fix(admin-ui): Display refund metadata

### DIFF
--- a/packages/admin-ui/src/lib/order/src/components/order-payment-card/order-payment-card.component.ts
+++ b/packages/admin-ui/src/lib/order/src/components/order-payment-card/order-payment-card.component.ts
@@ -16,7 +16,7 @@ export class OrderPaymentCardComponent {
     @Output() settleRefund = new EventEmitter<OrderDetail.Refunds>();
 
     refundHasMetadata(refund?: OrderDetail.Refunds): boolean {
-        return !!refund && Object.keys(refund).length < 0;
+        return !!refund && Object.keys(refund.metadata).length > 0;
     }
 
     nextOtherStates(): string[] {


### PR DESCRIPTION
Display refund's metadata on admin-ui order details. Solves #874 