### PR TITLE
fix(email-plugin): Docs missing parameter route on devMode example

### DIFF
--- a/packages/email-plugin/src/plugin.ts
+++ b/packages/email-plugin/src/plugin.ts
@@ -118,6 +118,7 @@ import {
  * ```ts
  * EmailPlugin.init({
  *   devMode: true,
+ *   route: 'mailbox',
  *   handlers: defaultEmailHandlers,
  *   templatePath: path.join(__dirname, 'vendure/email/templates'),
  *   outputPath: path.join(__dirname, 'test-emails'),


### PR DESCRIPTION
When using the EmailPlugin devMode without having specified the route for the mailbox makes the Vendure server crash: added option to description to clarify usage.