### PR TITLE
perf(core): Improve performance of apply-collection-filters job

### DIFF
--- a/packages/core/src/service/services/collection.service.ts
+++ b/packages/core/src/service/services/collection.service.ts
@@ -87,9 +87,7 @@ export class CollectionService implements OnModuleInit {
                 Logger.verbose(`Processing ${job.data.collectionIds.length} Collections`);
                 let completed = 0;
                 for (const collectionId of job.data.collectionIds) {
-                    const collection = await this.connection.getRepository(Collection).findOne(collectionId, {
-                        relations: ['productVariants'],
-                    });
+                    const collection = await this.connection.getRepository(Collection).findOne(collectionId);
                     if (!collection) {
                         Logger.warn(`Could not find Collection with id ${collectionId}, skipping`);
                         continue;
@@ -482,8 +480,10 @@ export class CollectionService implements OnModuleInit {
             const productVariants = await this.connection
                 .getRepository(ctx, ProductVariant)
                 .createQueryBuilder('variant')
+                .select('variant.id', 'id')
                 .innerJoin('variant.collections', 'collection', 'collection.id = :id', { id: collection.id })
-                .getMany();
+                .getRawMany();
+
             return productVariants.map(v => v.id);
         }
     }


### PR DESCRIPTION
Changes in this pull request will improve the performance of apply-collection-filters job.

I noticed that we use only variants ids before we reassign `collection.productVariants` in `CollectionService.applyCollectionFiltersInternal`.

Based on experiments the performance of the query in `CollectionService.getCollectionProductVariantIds` method will be 8x faster.