### PR TITLE
feat(core): Option to enable permanent anonymous access to orderByCode

### DIFF
--- a/packages/core/src/api/resolvers/shop/shop-order.resolver.ts
+++ b/packages/core/src/api/resolvers/shop/shop-order.resolver.ts
@@ -36,6 +36,7 @@ import {
 } from '../../../common/error/generated-graphql-shop-errors';
 import { Translated } from '../../../common/types/locale-types';
 import { idsAreEqual } from '../../../common/utils';
+import { ConfigService } from '../../../config/config.service';
 import { Country } from '../../../entity';
 import { Order } from '../../../entity/order/order.entity';
 import { ActiveOrderService, CountryService } from '../../../service';
@@ -56,6 +57,7 @@ export class ShopOrderResolver {
         private sessionService: SessionService,
         private countryService: CountryService,
         private activeOrderService: ActiveOrderService,
+        private configService: ConfigService,
     ) {}
 
     @Query()
@@ -103,23 +105,31 @@ export class ShopOrderResolver {
             const order = await this.orderService.findOneByCode(ctx, args.code);
 
             if (order) {
-                // For guest Customers, allow access to the Order for the following
-                // time period
-                const anonymousAccessLimit = ms('2h');
-                const orderPlaced = order.orderPlacedAt ? +order.orderPlacedAt : 0;
+                // Order owned by active user
                 const activeUserMatches = !!(
                     order &&
                     order.customer &&
                     order.customer.user &&
                     order.customer.user.id === ctx.activeUserId
                 );
-                const now = +new Date();
-                const isWithinAnonymousAccessLimit = now - orderPlaced < anonymousAccessLimit;
+
+                // For guest Customers, allow access to the Order for the following
+                // time period or if orderByCodePermanentAccess is enabled in orderOptions
+                const permanentAnonymousAccess = this.configService.orderOptions.orderByCodePermanentAccess;
+                const anonymousAccessPermitted =
+                    permanentAnonymousAccess ||
+                    (() => {
+                        const anonymousAccessLimit = ms('2h');
+                        const orderPlaced = order.orderPlacedAt ? +order.orderPlacedAt : 0;
+                        const now = +new Date();
+                        return now - orderPlaced < anonymousAccessLimit;
+                    })();
+
                 if (
                     (ctx.activeUserId && activeUserMatches) ||
-                    (!ctx.activeUserId && isWithinAnonymousAccessLimit)
+                    (!ctx.activeUserId && anonymousAccessPermitted)
                 ) {
-                    return this.orderService.findOne(ctx, order.id);
+                    return order;
                 }
             }
             // We throw even if the order does not exist, since giving a different response

--- a/packages/core/src/config/default-config.ts
+++ b/packages/core/src/config/default-config.ts
@@ -120,6 +120,7 @@ export const defaultConfig: RuntimeVendureConfig = {
         process: [],
         stockAllocationStrategy: new DefaultStockAllocationStrategy(),
         orderCodeStrategy: new DefaultOrderCodeStrategy(),
+        orderByCodePermanentAccess: false,
         changedPriceHandlingStrategy: new DefaultChangedPriceHandlingStrategy(),
         orderPlacedStrategy: new DefaultOrderPlacedStrategy(),
     },

--- a/packages/core/src/config/vendure-config.ts
+++ b/packages/core/src/config/vendure-config.ts
@@ -473,6 +473,19 @@ export interface OrderOptions {
     orderCodeStrategy?: OrderCodeStrategy;
     /**
      * @description
+     * Orders can be retrieved with their code using the orderByCode query. By default this
+     * is only possible if a User is logged in and owns the Order or by anyone knowing the code
+     * if the Order was created in the last two hours.
+     *
+     * Set this to true to enable permanent anonymous access with a code.
+     * You can use more secure codes with a custom OrderCodeStrategy. Also consider limiting
+     * requests to prevent brute forcing a code.
+     *
+     * @default false
+     */
+    orderByCodePermanentAccess?: boolean;
+    /**
+     * @description
      * Defines how we handle the situation where an OrderItem exists in an Order, and
      * then later on another is added but in the mean time the price of the ProductVariant has changed.
      *


### PR DESCRIPTION
Implements #922 

This commit adds an option to disable the default 2h time window for guests to retrieve their orders through the `orderByCode` query.

Security considerations: The DefaultOrderCodeStrategy [generates the Code](https://github.com/vendure-ecommerce/vendure/blob/master/packages/core/src/common/generate-public-id.ts#L19) from 33 different characters and is 16 characters long – which makes 33^16 different possible codes (~2*10^24). Collisions are highly unlikely, especially if a request limiter is being used.

This commit is non-breaking. Additionally one db query is saved.