### PR TITLE
feat(core): Option to enable permanent anonymous access to orderByCode

### DIFF
--- a/packages/core/src/config/config.module.ts
+++ b/packages/core/src/config/config.module.ts
@@ -77,6 +77,7 @@ export class ConfigModule implements OnApplicationBootstrap, OnApplicationShutdo
             orderItemPriceCalculationStrategy,
             process,
             orderCodeStrategy,
+            orderByCodeAccessStrategy,
             stockAllocationStrategy,
         } = this.configService.orderOptions;
         const { customFulfillmentProcess } = this.configService.shippingOptions;
@@ -94,6 +95,7 @@ export class ConfigModule implements OnApplicationBootstrap, OnApplicationShutdo
             mergeStrategy,
             checkoutMergeStrategy,
             orderCodeStrategy,
+            orderByCodeAccessStrategy,
             entityIdStrategy,
             productVariantPriceCalculationStrategy,
             orderItemPriceCalculationStrategy,

--- a/packages/core/src/config/default-config.ts
+++ b/packages/core/src/config/default-config.ts
@@ -121,7 +121,7 @@ export const defaultConfig: RuntimeVendureConfig = {
         process: [],
         stockAllocationStrategy: new DefaultStockAllocationStrategy(),
         orderCodeStrategy: new DefaultOrderCodeStrategy(),
-        orderByCodeAccessStrategy: new DefaultOrderByCodeAccessStrategy(),
+        orderByCodeAccessStrategy: new DefaultOrderByCodeAccessStrategy('2h'),
         changedPriceHandlingStrategy: new DefaultChangedPriceHandlingStrategy(),
         orderPlacedStrategy: new DefaultOrderPlacedStrategy(),
     },

--- a/packages/core/src/config/default-config.ts
+++ b/packages/core/src/config/default-config.ts
@@ -22,6 +22,7 @@ import { DefaultOrderItemPriceCalculationStrategy } from './order/default-order-
 import { DefaultOrderPlacedStrategy } from './order/default-order-placed-strategy';
 import { DefaultStockAllocationStrategy } from './order/default-stock-allocation-strategy';
 import { MergeOrdersStrategy } from './order/merge-orders-strategy';
+import { DefaultOrderByCodeAccessStrategy } from './order/order-by-code-access-strategy';
 import { DefaultOrderCodeStrategy } from './order/order-code-strategy';
 import { UseGuestStrategy } from './order/use-guest-strategy';
 import { defaultPromotionActions, defaultPromotionConditions } from './promotion';
@@ -120,6 +121,7 @@ export const defaultConfig: RuntimeVendureConfig = {
         process: [],
         stockAllocationStrategy: new DefaultStockAllocationStrategy(),
         orderCodeStrategy: new DefaultOrderCodeStrategy(),
+        orderByCodeAccessStrategy: new DefaultOrderByCodeAccessStrategy(),
         changedPriceHandlingStrategy: new DefaultChangedPriceHandlingStrategy(),
         orderPlacedStrategy: new DefaultOrderPlacedStrategy(),
     },

--- a/packages/core/src/config/order/order-by-code-access-strategy.ts
+++ b/packages/core/src/config/order/order-by-code-access-strategy.ts
@@ -47,14 +47,20 @@ export interface OrderByCodeAccessStrategy extends InjectableStrategy {
  * @docsPage OrderByCodeAccessStrategy
  */
 export class DefaultOrderByCodeAccessStrategy implements OrderByCodeAccessStrategy {
-    canAccessOrder(ctx: RequestContext, order: Order, anonymousAccessDuration: string = '2h'): boolean {
+    private anonymousAccessDuration;
+
+    constructor(anonymousAccessDuration: string) {
+        this.anonymousAccessDuration = anonymousAccessDuration;
+    }
+
+    canAccessOrder(ctx: RequestContext, order: Order): boolean {
         // Order owned by active user
         const activeUserMatches = order?.customer?.user?.id === ctx.activeUserId;
 
         // For guest Customers, allow access to the Order for the following
         // time period
         const anonymousAccessPermitted = () => {
-            const anonymousAccessLimit = ms(anonymousAccessDuration);
+            const anonymousAccessLimit = ms(this.anonymousAccessDuration);
             const orderPlaced = order.orderPlacedAt ? +order.orderPlacedAt : 0;
             const now = Date.now();
             return now - orderPlaced < anonymousAccessLimit;

--- a/packages/core/src/config/order/order-by-code-access-strategy.ts
+++ b/packages/core/src/config/order/order-by-code-access-strategy.ts
@@ -1,0 +1,67 @@
+import ms from 'ms';
+
+import { RequestContext } from '../../api/common/request-context';
+import { InjectableStrategy } from '../../common/types/injectable-strategy';
+import { Order } from '../../entity/order/order.entity';
+
+/**
+ * @description
+ * The OrderByCodeAccessStrategy determins how access to a placed Order via the
+ * orderByCode query is granted.
+ * With a custom strategy anonymous access could be made permanent or tied to specific
+ * conditions like IP range or a specific Order status.
+ *
+ * @example
+ * This example grants access to the requested Order to everyone – unless it's Monday.
+ * ```TypeScript
+ * export class NotMondayOrderByCodeAccessStrategy implements OrderByCodeAccessStrategy {
+ *     canAccessOrder(ctx: RequestContext, order: Order): boolean {
+ *         const MONDAY = 1;
+ *         const today = (new Date()).getDay();
+ *
+ *         return today !== MONDAY;
+ *     }
+ * }
+ * ```
+ *
+ * @docsCategory orders
+ * @docsPage OrderByCodeAccessStrategy
+ */
+export interface OrderByCodeAccessStrategy extends InjectableStrategy {
+    /**
+     * @description
+     * Gives or denies permission to access the requested Order
+     */
+    canAccessOrder(ctx: RequestContext, order: Order): boolean | Promise<boolean>;
+}
+
+/**
+ * @description
+ * The default OrderByCodeAccessStrategy used by Vendure. It permitts permanent access to
+ * the Customer owning the Order and anyone within 2 hours after placing the Order.
+ *
+ * @docsCategory orders
+ * @docsPage OrderByCodeAccessStrategy
+ */
+export class DefaultOrderByCodeAccessStrategy implements OrderByCodeAccessStrategy {
+    canAccessOrder(ctx: RequestContext, order: Order): boolean {
+        // Order owned by active user
+        const activeUserMatches = !!(
+            order &&
+            order.customer &&
+            order.customer.user &&
+            order.customer.user.id === ctx.activeUserId
+        );
+
+        // For guest Customers, allow access to the Order for the following
+        // time period
+        const anonymousAccessPermitted = () => {
+            const anonymousAccessLimit = ms('2h');
+            const orderPlaced = order.orderPlacedAt ? +order.orderPlacedAt : 0;
+            const now = Date.now();
+            return now - orderPlaced < anonymousAccessLimit;
+        };
+
+        return (ctx.activeUserId && activeUserMatches) || (!ctx.activeUserId && anonymousAccessPermitted());
+    }
+}

--- a/packages/core/src/config/vendure-config.ts
+++ b/packages/core/src/config/vendure-config.ts
@@ -23,6 +23,7 @@ import { JobQueueStrategy } from './job-queue/job-queue-strategy';
 import { VendureLogger } from './logger/vendure-logger';
 import { ChangedPriceHandlingStrategy } from './order/changed-price-handling-strategy';
 import { CustomOrderProcess } from './order/custom-order-process';
+import { OrderByCodeAccessStrategy } from './order/order-by-code-access-strategy';
 import { OrderCodeStrategy } from './order/order-code-strategy';
 import { OrderItemPriceCalculationStrategy } from './order/order-item-price-calculation-strategy';
 import { OrderMergeStrategy } from './order/order-merge-strategy';
@@ -471,6 +472,16 @@ export interface OrderOptions {
      * @default DefaultOrderCodeStrategy
      */
     orderCodeStrategy?: OrderCodeStrategy;
+    /**
+     * @description
+     * Defines the strategy used to check if and how an Order may be retrieved via the orderByCode query.
+     *
+     * The default strategy permitts permanent access to the Customer owning the Order and anyone
+     * within 2 hours after placing the Order.
+     *
+     * @default DefaultOrderByCodeAccessStrategy
+     */
+    orderByCodeAccessStrategy?: OrderByCodeAccessStrategy;
     /**
      * @description
      * Defines how we handle the situation where an OrderItem exists in an Order, and


### PR DESCRIPTION
Implements #922 

This commit adds an option to disable the default 2h time window for guests to retrieve their orders through the `orderByCode` query.

Security considerations: The DefaultOrderCodeStrategy [generates the Code](https://github.com/vendure-ecommerce/vendure/blob/master/packages/core/src/common/generate-public-id.ts#L19) from 33 different characters and is 16 characters long – which makes 33^16 different possible codes (~2*10^24). Collisions are highly unlikely, especially if a request limiter is being used.

This commit is non-breaking. Additionally one db query is saved.