### PR TITLE
feat(core): Allow to configure body parser

### DIFF
--- a/packages/core/src/app.module.ts
+++ b/packages/core/src/app.module.ts
@@ -1,7 +1,7 @@
 import { MiddlewareConsumer, Module, NestModule, OnApplicationShutdown } from '@nestjs/common';
-import { Type } from '@vendure/common/lib/shared-types';
 
 import { ApiModule } from './api/api.module';
+import { Middleware, MiddlewareHandler } from './common';
 import { ConfigModule } from './config/config.module';
 import { ConfigService } from './config/config.service';
 import { Logger } from './config/logger/vendure-logger';
@@ -11,9 +11,6 @@ import { I18nService } from './i18n/i18n.service';
 import { PluginModule } from './plugin/plugin.module';
 import { ProcessContextModule } from './process-context/process-context.module';
 import { ServiceModule } from './service/service.module';
-
-// tslint:disable-next-line:ban-types
-type Middleware = Type<any> | Function;
 
 @Module({
     imports: [
@@ -32,12 +29,13 @@ export class AppModule implements NestModule, OnApplicationShutdown {
     configure(consumer: MiddlewareConsumer) {
         const { adminApiPath, shopApiPath, middleware } = this.configService.apiOptions;
         const i18nextHandler = this.i18nService.handle();
-        const defaultMiddleware: Array<{ handler: Middleware; route?: string }> = [
+        const defaultMiddleware: Middleware[] = [
             { handler: i18nextHandler, route: adminApiPath },
             { handler: i18nextHandler, route: shopApiPath },
         ];
         const allMiddleware = defaultMiddleware.concat(middleware);
-        const middlewareByRoute = this.groupMiddlewareByRoute(allMiddleware);
+        const consumableMiddlewares = allMiddleware.filter(mid => !mid.beforeListen);
+        const middlewareByRoute = this.groupMiddlewareByRoute(consumableMiddlewares);
         for (const [route, handlers] of Object.entries(middlewareByRoute)) {
             consumer.apply(...handlers).forRoutes(route);
         }
@@ -52,10 +50,8 @@ export class AppModule implements NestModule, OnApplicationShutdown {
     /**
      * Groups middleware handlers together in an object with the route as the key.
      */
-    private groupMiddlewareByRoute(
-        middlewareArray: Array<{ handler: Middleware; route?: string }>,
-    ): { [route: string]: Middleware[] } {
-        const result = {} as { [route: string]: Middleware[] };
+    private groupMiddlewareByRoute(middlewareArray: Middleware[]): { [route: string]: MiddlewareHandler[] } {
+        const result = {} as { [route: string]: MiddlewareHandler[] };
         for (const middleware of middlewareArray) {
             const route = middleware.route || this.configService.apiOptions.adminApiPath;
             if (!result[route]) {

--- a/packages/core/src/bootstrap.ts
+++ b/packages/core/src/bootstrap.ts
@@ -47,12 +47,11 @@ export async function bootstrap(userConfig: Partial<VendureConfig>): Promise<INe
     // tslint:disable-next-line:whitespace
     const appModule = await import('./app.module');
     setProcessContext('server');
-    const { hostname, port, cors, bodyParser } = config.apiOptions;
+    const { hostname, port, cors } = config.apiOptions;
     DefaultLogger.hideNestBoostrapLogs();
     const app = await NestFactory.create(appModule.AppModule, {
         cors,
         logger: new Logger(),
-        bodyParser,
     });
     DefaultLogger.restoreOriginalLogLevel();
     app.useLogger(new Logger());

--- a/packages/core/src/bootstrap.ts
+++ b/packages/core/src/bootstrap.ts
@@ -47,11 +47,12 @@ export async function bootstrap(userConfig: Partial<VendureConfig>): Promise<INe
     // tslint:disable-next-line:whitespace
     const appModule = await import('./app.module');
     setProcessContext('server');
-    const { hostname, port, cors } = config.apiOptions;
+    const { hostname, port, cors, bodyParser } = config.apiOptions;
     DefaultLogger.hideNestBoostrapLogs();
     const app = await NestFactory.create(appModule.AppModule, {
         cors,
         logger: new Logger(),
+        bodyParser,
     });
     DefaultLogger.restoreOriginalLogLevel();
     app.useLogger(new Logger());

--- a/packages/core/src/common/types/common-types.ts
+++ b/packages/core/src/common/types/common-types.ts
@@ -1,3 +1,5 @@
+import { Type } from '@vendure/common/shared-types';
+
 import { VendureEntity } from '../../entity/base/base.entity';
 import { Channel } from '../../entity/channel/channel.entity';
 import { Tag } from '../../entity/tag/tag.entity';
@@ -144,3 +146,8 @@ export type PriceCalculationResult = {
     price: number;
     priceIncludesTax: boolean;
 };
+
+// tslint:disable-next-line:ban-types
+export type MiddlewareHandler = Type<any> | Function;
+
+export type Middleware = { handler: MiddlewareHandler; route: string; beforeListen?: boolean };

--- a/packages/core/src/common/types/common-types.ts
+++ b/packages/core/src/common/types/common-types.ts
@@ -1,4 +1,4 @@
-import { Type } from '@vendure/common/shared-types';
+import { Type } from '@vendure/common/lib/shared-types';
 
 import { VendureEntity } from '../../entity/base/base.entity';
 import { Channel } from '../../entity/channel/channel.entity';

--- a/packages/core/src/config/default-config.ts
+++ b/packages/core/src/config/default-config.ts
@@ -62,6 +62,7 @@ export const defaultConfig: RuntimeVendureConfig = {
         },
         middleware: [],
         apolloServerPlugins: [],
+        bodyParser: true,
     },
     authOptions: {
         disableAuth: false,

--- a/packages/core/src/config/default-config.ts
+++ b/packages/core/src/config/default-config.ts
@@ -62,7 +62,6 @@ export const defaultConfig: RuntimeVendureConfig = {
         },
         middleware: [],
         apolloServerPlugins: [],
-        bodyParser: true,
     },
     authOptions: {
         disableAuth: false,

--- a/packages/core/src/config/vendure-config.ts
+++ b/packages/core/src/config/vendure-config.ts
@@ -174,6 +174,13 @@ export interface ApiOptions {
      * @default []
      */
     apolloServerPlugins?: PluginDefinition[];
+    /**
+     * @description
+     * Whether to use underlying platform body parser.
+     *
+     * @default true
+     */
+    bodyParser?: true;
 }
 
 /**

--- a/packages/core/src/config/vendure-config.ts
+++ b/packages/core/src/config/vendure-config.ts
@@ -6,6 +6,7 @@ import { RequestHandler } from 'express';
 import { ValidationContext } from 'graphql';
 import { ConnectionOptions } from 'typeorm';
 
+import { Middleware } from '../common';
 import { PermissionDefinition } from '../common/permission-definition';
 
 import { AssetNamingStrategy } from './asset-naming-strategy/asset-naming-strategy';
@@ -162,7 +163,7 @@ export interface ApiOptions {
      * @default []
      */
     // tslint:disable-next-line:ban-types
-    middleware?: Array<{ handler: Type<any> | Function; route: string }>;
+    middleware?: Middleware[];
     /**
      * @description
      * Custom [ApolloServerPlugins](https://www.apollographql.com/docs/apollo-server/integrations/plugins/) which

--- a/packages/core/src/config/vendure-config.ts
+++ b/packages/core/src/config/vendure-config.ts
@@ -174,13 +174,6 @@ export interface ApiOptions {
      * @default []
      */
     apolloServerPlugins?: PluginDefinition[];
-    /**
-     * @description
-     * Whether to use underlying platform body parser.
-     *
-     * @default true
-     */
-    bodyParser?: true;
 }
 
 /**


### PR DESCRIPTION
Implements [#934 ](https://github.com/vendure-ecommerce/vendure/issues/934)

We currently have no way to control the body parser applied to the global middleware.

This commit would let us configure it the same way we already configure  copple of the NestApplicationOptions using Vendure config.