### PR TITLE
fix(elastic search plugin): search grouped by product works only for first variant sku

### DIFF
--- a/packages/elasticsearch-plugin/e2e/e2e-helpers.ts
+++ b/packages/elasticsearch-plugin/e2e/e2e-helpers.ts
@@ -60,6 +60,36 @@ export async function testMatchSearchTerm(client: SimpleGraphQLClient) {
     ]);
 }
 
+export async function testMatchFirstSku(client: SimpleGraphQLClient) {
+    const result = await client.query<SearchProductsShop.Query, SearchProductsShop.Variables>(
+        SEARCH_PRODUCTS_SHOP,
+        {
+            input: {
+                term: 'L2201308',
+                groupByProduct: true,
+            },
+        },
+    );
+    expect(result.search.items.map(i => i.productName)).toEqual([
+        'Laptop',
+    ]);
+}
+
+export async function testMatchSecondSku(client: SimpleGraphQLClient) {
+    const result = await client.query<SearchProductsShop.Query, SearchProductsShop.Variables>(
+        SEARCH_PRODUCTS_SHOP,
+        {
+            input: {
+                term: 'L2201508',
+                groupByProduct: true,
+            },
+        },
+    );
+    expect(result.search.items.map(i => i.productName)).toEqual([
+        'Laptop',
+    ]);
+}
+
 export async function testMatchFacetIdsAnd(client: SimpleGraphQLClient) {
     const result = await client.query<SearchProductsShop.Query, SearchProductsShop.Variables>(
         SEARCH_PRODUCTS_SHOP,

--- a/packages/elasticsearch-plugin/e2e/elasticsearch-plugin.e2e-spec.ts
+++ b/packages/elasticsearch-plugin/e2e/elasticsearch-plugin.e2e-spec.ts
@@ -77,7 +77,9 @@ import {
     testMatchFacetValueFiltersOrWithAnd,
     testMatchFacetValueFiltersWithFacetIdsAnd,
     testMatchFacetValueFiltersWithFacetIdsOr,
+    testMatchFirstSku,
     testMatchSearchTerm,
+    testMatchSecondSku,
     testNoGrouping,
     testPriceRanges,
     testSinglePrices,
@@ -159,6 +161,10 @@ describe('Elasticsearch plugin', () => {
         it('no grouping', () => testNoGrouping(shopClient));
 
         it('matches search term', () => testMatchSearchTerm(shopClient));
+
+        it('matches search first sku', () => testMatchFirstSku(shopClient));
+
+        it('matches search second sku', () => testMatchSecondSku(shopClient));
 
         it('matches by facetValueId with AND operator', () => testMatchFacetIdsAnd(shopClient));
 

--- a/packages/elasticsearch-plugin/src/indexer.controller.ts
+++ b/packages/elasticsearch-plugin/src/indexer.controller.ts
@@ -830,7 +830,7 @@ export class ElasticsearchIndexerController implements OnModuleInit, OnModuleDes
             ? variants.filter(v => v.featuredAsset)[0].featuredAsset
             : null;
         const productTranslation = this.getTranslation(first.product, languageCode);
-        const variantTranslation = this.getTranslation(first, languageCode);
+        const variantTranslationNames = variants.map(v => this.getTranslation(v, languageCode).name).join(` `);
         const collectionTranslations = variants.reduce(
             (translations, variant) => [
                 ...translations,
@@ -842,7 +842,7 @@ export class ElasticsearchIndexerController implements OnModuleInit, OnModuleDes
         const item: ProductIndexItem = {
             channelId,
             languageCode,
-            sku: first.sku,
+            sku: variants.map(v=>v.sku).join(` `),
             slug: productTranslation.slug,
             productId: first.product.id,
             productName: productTranslation.name,
@@ -850,7 +850,7 @@ export class ElasticsearchIndexerController implements OnModuleInit, OnModuleDes
             productPreview: productAsset ? productAsset.preview : '',
             productPreviewFocalPoint: productAsset ? productAsset.focalPoint || undefined : undefined,
             productVariantId: first.id,
-            productVariantName: variantTranslation.name,
+            productVariantName: variantTranslationNames,
             productVariantAssetId: variantAsset ? variantAsset.id : undefined,
             productVariantPreview: variantAsset ? variantAsset.preview : '',
             productVariantPreviewFocalPoint: productAsset ? productAsset.focalPoint || undefined : undefined,


### PR DESCRIPTION
Close #1017

Fixed for sku and variantName