### PR TITLE
fix(admin-ui): fix Safari dropdown auto-select (#1036)

### DIFF
--- a/packages/admin-ui/src/lib/settings/src/components/channel-detail/channel-detail.component.html
+++ b/packages/admin-ui/src/lib/settings/src/components/channel-detail/channel-detail.component.html
@@ -73,6 +73,7 @@
             formControlName="defaultTaxZoneId"
             [vdrDisabled]="!(updatePermission | hasPermission)"
         >
+            <option selected value style="display: none"></option>
             <option *ngFor="let zone of zones$ | async" [value]="zone.id">{{ zone.name }}</option>
         </select>
     </vdr-form-field>
@@ -95,6 +96,7 @@
             formControlName="defaultShippingZoneId"
             [vdrDisabled]="!(updatePermission | hasPermission)"
         >
+            <option selected value style="display: none"></option>            
             <option *ngFor="let zone of zones$ | async" [value]="zone.id">{{ zone.name }}</option>
         </select>
     </vdr-form-field>


### PR DESCRIPTION
fix(admin-ui): fix Safari dropdown auto-select

Relates to #1036 . This commit adds an extra empty option tag to default shipping and taxing zones, in order for Safari to select these and not the first real option.