### PR TITLE
fix(elasticsearch-plugin): Elasticsearch Cloud auth is not set during re-indexing

### DIFF
--- a/packages/elasticsearch-plugin/src/elasticsearch.service.ts
+++ b/packages/elasticsearch-plugin/src/elasticsearch.service.ts
@@ -19,7 +19,7 @@ import equal from 'fast-deep-equal/es6';
 import { buildElasticBody } from './build-elastic-body';
 import { ELASTIC_SEARCH_OPTIONS, loggerCtx, PRODUCT_INDEX_NAME, VARIANT_INDEX_NAME } from './constants';
 import { ElasticsearchIndexService } from './elasticsearch-index.service';
-import { createIndices } from './indexing-utils';
+import { createIndices, getClient } from './indexing-utils';
 import { ElasticsearchOptions } from './options';
 import {
     CustomMapping,
@@ -48,14 +48,7 @@ export class ElasticsearchService implements OnModuleInit, OnModuleDestroy {
     }
 
     onModuleInit(): any {
-        const { host, port } = this.options;
-        const node = this.options.clientOptions?.node ?? `${host}:${port}`;
-        this.client = new Client({
-            node,
-            // `any` cast is there due to a strange error "Property '[Symbol.iterator]' is missing in type... URLSearchParams"
-            // which looks like possibly a TS/definitions bug.
-            ...(this.options.clientOptions as any),
-        });
+        this.client = getClient(this.options);
     }
 
     onModuleDestroy(): any {
@@ -465,9 +458,10 @@ export class ElasticsearchService implements OnModuleInit, OnModuleDestroy {
         return result;
     }
 
-    private getSearchResultAssets(
-        source: ProductIndexItem | VariantIndexItem,
-    ): { productAsset: SearchResultAsset | undefined; productVariantAsset: SearchResultAsset | undefined } {
+    private getSearchResultAssets(source: ProductIndexItem | VariantIndexItem): {
+        productAsset: SearchResultAsset | undefined;
+        productVariantAsset: SearchResultAsset | undefined;
+    } {
         const productAsset: SearchResultAsset | undefined = source.productAssetId
             ? {
                   id: source.productAssetId.toString(),

--- a/packages/elasticsearch-plugin/src/indexer.controller.ts
+++ b/packages/elasticsearch-plugin/src/indexer.controller.ts
@@ -23,7 +23,7 @@ import {
 import { Observable } from 'rxjs';
 
 import { ELASTIC_SEARCH_OPTIONS, loggerCtx, PRODUCT_INDEX_NAME, VARIANT_INDEX_NAME } from './constants';
-import { createIndices, getIndexNameByAlias } from './indexing-utils';
+import { createIndices, getClient, getIndexNameByAlias } from './indexing-utils';
 import { ElasticsearchOptions } from './options';
 import {
     BulkOperation,
@@ -87,10 +87,7 @@ export class ElasticsearchIndexerController implements OnModuleInit, OnModuleDes
     ) {}
 
     onModuleInit(): any {
-        const { host, port } = this.options;
-        this.client = new Client({
-            node: `${host}:${port}`,
-        });
+        this.client = getClient(this.options);
     }
 
     onModuleDestroy(): any {
@@ -919,9 +916,9 @@ export class ElasticsearchIndexerController implements OnModuleInit, OnModuleDes
         translatable: T,
         languageCode: LanguageCode,
     ): Translation<T> {
-        return ((translatable.translations.find(t => t.languageCode === languageCode) ||
+        return (translatable.translations.find(t => t.languageCode === languageCode) ||
             translatable.translations.find(t => t.languageCode === this.configService.defaultLanguageCode) ||
-            translatable.translations[0]) as unknown) as Translation<T>;
+            translatable.translations[0]) as unknown as Translation<T>;
     }
 
     private getFacetIds(variants: ProductVariant[]): string[] {

--- a/packages/elasticsearch-plugin/src/indexing-utils.ts
+++ b/packages/elasticsearch-plugin/src/indexing-utils.ts
@@ -1,7 +1,8 @@
 import { Client } from '@elastic/elasticsearch';
-import { ID, Logger } from '@vendure/core';
+import { DeepRequired, ID, Logger } from '@vendure/core';
 
 import { loggerCtx, PRODUCT_INDEX_NAME, VARIANT_INDEX_NAME } from './constants';
+import { ElasticsearchOptions } from './options';
 import { ProductIndexItem, VariantIndexItem } from './types';
 
 export async function createIndices(
@@ -161,6 +162,19 @@ export async function deleteByChannel(client: Client, prefix: string, channelId:
     } catch (e) {
         Logger.error(e, loggerCtx);
     }
+}
+
+export function getClient(
+    options: Required<ElasticsearchOptions> | DeepRequired<ElasticsearchOptions>,
+): Client {
+    const { host, port } = options;
+    const node = options.clientOptions?.node ?? `${host}:${port}`;
+    return new Client({
+        node,
+        // `any` cast is there due to a strange error "Property '[Symbol.iterator]' is missing in type... URLSearchParams"
+        // which looks like possibly a TS/definitions bug.
+        ...(options.clientOptions as any),
+    });
 }
 
 export async function getIndexNameByAlias(client: Client, aliasName: string) {


### PR DESCRIPTION
Fixes #1106
Make sure elasticsearch-js client is instantiated with the clientOptions