### PR TITLE
Fixed batch size error on Postgresql

### DIFF
--- a/packages/core/src/plugin/default-search-plugin/indexer/indexer.controller.ts
+++ b/packages/core/src/plugin/default-search-plugin/indexer/indexer.controller.ts
@@ -401,7 +401,7 @@ export class IndexerController {
             }
         }
 
-        await this.queue.push(() => this.connection.getRepository(SearchIndexItem).save(items));
+        await this.queue.push(() => this.connection.getRepository(SearchIndexItem).save(items, { chunk: 2500 }));
     }
 
     /**


### PR DESCRIPTION
When indexing many items with multiple channels and languages, the postgresql will throw an error because of parameter limit to exceed. 
Setting Chunk size will fix the problem. 