### PR TITLE
Fix(admin-ui): Fix error if no array of assets is provided

### DIFF
--- a/packages/admin-ui/src/lib/catalog/src/components/product-assets/product-assets.component.ts
+++ b/packages/admin-ui/src/lib/catalog/src/components/product-assets/product-assets.component.ts
@@ -42,7 +42,7 @@ export interface AssetChange {
 export class ProductAssetsComponent {
     @Input('assets') set assetsSetter(val: Asset[]) {
         // create a new non-readonly array of assets
-        this.assets = val.slice();
+        this.assets = (val || []).slice();
     }
 
     @Input() featuredAsset: Asset | undefined;


### PR DESCRIPTION
If no assets array is set via the `assets` input of the ProductAssetsComponent this error is thrown:
```
ERROR TypeError: Cannot read properties of undefined (reading 'slice')
    at ProductAssetsComponent.set assetsSetter [as assetsSetter] (vendure-admin-ui-catalog.js:7092)
    at setInputsForProperty (core.js:10960)
    at elementPropertyInternal (core.js:10004)
    at Module.ɵɵproperty (core.js:14787)
    at RecipeDetailComponent_Template (recipe-detail.component.html:61)
    at executeTemplate (core.js:9599)
    at refreshView (core.js:9465)
    at refreshComponent (core.js:10636)
    at refreshChildComponents (core.js:9261)
    at refreshView (core.js:9515)
```

This pull request fixes this by using an empty array as a fallback.

I can change it to this alternative and more robust implementation if you like this solution better:
```ts
this.assets = Array.isArray(val) ? val.slice() : [];
```