### PR TITLE
fix(core): Add Permission.ReadProduct to Allow decorator of TaxRateResolver.taxRates

### DIFF
--- a/packages/core/src/api/resolvers/admin/tax-rate.resolver.ts
+++ b/packages/core/src/api/resolvers/admin/tax-rate.resolver.ts
@@ -22,8 +22,11 @@ export class TaxRateResolver {
     constructor(private taxRateService: TaxRateService) {}
 
     @Query()
-    @Allow(Permission.ReadSettings, Permission.ReadCatalog, Permission.ReadTaxRate)
-    taxRates(@Ctx() ctx: RequestContext, @Args() args: QueryTaxRatesArgs): Promise<PaginatedList<TaxRate>> {
+    @Allow(Permission.ReadSettings, Permission.ReadCatalog, Permission.ReadProduct, Permission.ReadTaxRate)
+    async taxRates(
+        @Ctx() ctx: RequestContext,
+        @Args() args: QueryTaxRatesArgs,
+    ): Promise<PaginatedList<TaxRate>> {
         return this.taxRateService.findAll(ctx, args.options || undefined);
     }
 


### PR DESCRIPTION
As per discussion on Slack:

> `TaxRateResolver.taxRates()` demands `ReadTaxRates` or `ReadCatalog` permissions for the tax to be displayed. I would expect `ReadProduct` to get the job done too.

> Agreed, the `ReadProduct` should be added to the `Allow` decorator for that field.

`TaxRateResolver.taxRates()` is ultimately called by `VariantPriceDetailComponent`, which is used in the product variant view. A role with "read" permissions to Product should be allowed to access that information in the same vein as `ReadCatalog`.

I have also added a missing `async` to the function definition as it returns a `Promise` like the other queries in the same class.

**NOTE:** I did not update the `taxRate` resolver in a similar fashion because from what I could gather it's only [eventually used](https://github.com/vendure-ecommerce/vendure/blob/ce147dc13e139be6d734016f43f7abeed9fac8d9/packages/admin-ui/src/lib/settings/src/settings.routes.ts#L124) as a `resolve` for the `tax-rates/:id` path in the Admin UI. That is, unrelated to the issue at hand. However, please let me know if it makes sense to change it as well and I can update this pull request.