### PR TITLE
fix(admin-ui): Fix tax rate permissions so product variants do not need access to customer groups

### DIFF
--- a/packages/admin-ui/src/lib/catalog/src/components/variant-price-detail/variant-price-detail.component.ts
+++ b/packages/admin-ui/src/lib/catalog/src/components/variant-price-detail/variant-price-detail.component.ts
@@ -25,7 +25,7 @@ export class VariantPriceDetailComponent implements OnInit, OnChanges {
 
     ngOnInit() {
         const taxRates$ = this.dataService.settings
-            .getTaxRates(999, 0, 'cache-first')
+            .getTaxRatesSimple(999, 0, 'cache-first')
             .mapStream(data => data.taxRates.items);
         const activeChannel$ = this.dataService.settings
             .getActiveChannel('cache-first')

--- a/packages/admin-ui/src/lib/core/src/common/generated-types.ts
+++ b/packages/admin-ui/src/lib/core/src/common/generated-types.ts
@@ -7463,6 +7463,27 @@ export type GetTaxRateListQuery = { taxRates: (
     )> }
   ) };
 
+export type GetTaxRateListSimpleQueryVariables = Exact<{
+  options?: Maybe<TaxRateListOptions>;
+}>;
+
+
+export type GetTaxRateListSimpleQuery = { taxRates: (
+    { __typename?: 'TaxRateList' }
+    & Pick<TaxRateList, 'totalItems'>
+    & { items: Array<(
+      { __typename?: 'TaxRate' }
+      & Pick<TaxRate, 'id' | 'createdAt' | 'updatedAt' | 'name' | 'enabled' | 'value'>
+      & { category: (
+        { __typename?: 'TaxCategory' }
+        & Pick<TaxCategory, 'id' | 'name'>
+      ), zone: (
+        { __typename?: 'Zone' }
+        & Pick<Zone, 'id' | 'name'>
+      ) }
+    )> }
+  ) };
+
 export type GetTaxRateQueryVariables = Exact<{
   id: Scalars['ID'];
 }>;
@@ -9849,6 +9870,15 @@ export namespace GetTaxRateList {
   export type Query = GetTaxRateListQuery;
   export type TaxRates = (NonNullable<GetTaxRateListQuery['taxRates']>);
   export type Items = NonNullable<(NonNullable<(NonNullable<GetTaxRateListQuery['taxRates']>)['items']>)[number]>;
+}
+
+export namespace GetTaxRateListSimple {
+  export type Variables = GetTaxRateListSimpleQueryVariables;
+  export type Query = GetTaxRateListSimpleQuery;
+  export type TaxRates = (NonNullable<GetTaxRateListSimpleQuery['taxRates']>);
+  export type Items = NonNullable<(NonNullable<(NonNullable<GetTaxRateListSimpleQuery['taxRates']>)['items']>)[number]>;
+  export type Category = (NonNullable<NonNullable<(NonNullable<(NonNullable<GetTaxRateListSimpleQuery['taxRates']>)['items']>)[number]>['category']>);
+  export type Zone = (NonNullable<NonNullable<(NonNullable<(NonNullable<GetTaxRateListSimpleQuery['taxRates']>)['items']>)[number]>['zone']>);
 }
 
 export namespace GetTaxRate {

--- a/packages/admin-ui/src/lib/core/src/data/definitions/settings-definitions.ts
+++ b/packages/admin-ui/src/lib/core/src/data/definitions/settings-definitions.ts
@@ -259,6 +259,30 @@ export const GET_TAX_RATE_LIST = gql`
     ${TAX_RATE_FRAGMENT}
 `;
 
+export const GET_TAX_RATE_LIST_SIMPLE = gql`
+    query GetTaxRateListSimple($options: TaxRateListOptions) {
+        taxRates(options: $options) {
+            items {
+                id
+                createdAt
+                updatedAt
+                name
+                enabled
+                value
+                category {
+                    id
+                    name
+                }
+                zone {
+                    id
+                    name
+                }
+            }
+            totalItems
+        }
+    }
+`;
+
 export const GET_TAX_RATE = gql`
     query GetTaxRate($id: ID!) {
         taxRate(id: $id) {

--- a/packages/admin-ui/src/lib/core/src/data/providers/settings-data.service.ts
+++ b/packages/admin-ui/src/lib/core/src/data/providers/settings-data.service.ts
@@ -40,6 +40,7 @@ import {
     GetTaxCategory,
     GetTaxRate,
     GetTaxRateList,
+    GetTaxRateListSimple,
     GetZone,
     GetZones,
     JobListOptions,
@@ -93,6 +94,7 @@ import {
     GET_TAX_CATEGORY,
     GET_TAX_RATE,
     GET_TAX_RATE_LIST,
+    GET_TAX_RATE_LIST_SIMPLE,
     GET_ZONES,
     REMOVE_MEMBERS_FROM_ZONE,
     UPDATE_CHANNEL,
@@ -233,6 +235,19 @@ export class SettingsDataService {
     getTaxRates(take: number = 10, skip: number = 0, fetchPolicy?: FetchPolicy) {
         return this.baseDataService.query<GetTaxRateList.Query, GetTaxRateList.Variables>(
             GET_TAX_RATE_LIST,
+            {
+                options: {
+                    take,
+                    skip,
+                },
+            },
+            fetchPolicy,
+        );
+    }
+
+    getTaxRatesSimple(take: number = 10, skip: number = 0, fetchPolicy?: FetchPolicy) {
+        return this.baseDataService.query<GetTaxRateListSimple.Query, GetTaxRateListSimple.Variables>(
+            GET_TAX_RATE_LIST_SIMPLE,
             {
                 options: {
                     take,


### PR DESCRIPTION
As per discussion on Slack:

> `TaxRateEntityResolver.customerGroup()` kicks in to resolve the `TaxRate.customerGroup` field and requires either `ReadCustomer` or `ReadCustomerGroup` permissions. I found it curious that a field resolver needs additional permissions on top of what its parent query (`TaxRateResolver.taxRates()`) does.
Is my assumption to just rely on `ReadProduct` for a full read-only view of products associated to a channel correct or are these added permissions really necessary?

> I think the real issue here is that there is actually no need to even access the `TaxRate.customerGroup` field when listing ProductVariants. I just re-used an existing graphql fragment which is used in the main TaxRate list view. So the solution would be to alter the query to omit that field for the ProductVariants view.

I've leveraged the same convention found in other places, e.g. `GetProductSimple` and `GetProductVariantListSimple`, and created a new query for tax rates that returns less fields - in this case, `customerGroup` - and uses the `Simple` suffix. I couldn't find other examples in the codebases so please let me know if I should take a different approach.