### PR TITLE
fix(core): Add Permission.ReadProduct to Allow decorator of TaxCategoryResolver.taxCategories

### DIFF
--- a/packages/core/src/api/resolvers/admin/tax-category.resolver.ts
+++ b/packages/core/src/api/resolvers/admin/tax-category.resolver.ts
@@ -20,8 +20,13 @@ export class TaxCategoryResolver {
     constructor(private taxCategoryService: TaxCategoryService) {}
 
     @Query()
-    @Allow(Permission.ReadSettings, Permission.ReadCatalog, Permission.ReadTaxCategory)
-    taxCategories(@Ctx() ctx: RequestContext): Promise<TaxCategory[]> {
+    @Allow(
+        Permission.ReadSettings,
+        Permission.ReadCatalog,
+        Permission.ReadProduct,
+        Permission.ReadTaxCategory,
+    )
+    async taxCategories(@Ctx() ctx: RequestContext): Promise<TaxCategory[]> {
         return this.taxCategoryService.findAll(ctx);
     }
 


### PR DESCRIPTION
This is closely related to #1258 and something I missed when testing read-only permissions.

`TaxCategoryResolver.taxCategories()` is also ultimately called as part of the product view flow; in this case, by `ProductDetailComponent`. It already allows `ReadCatalog` so it makes sense to allow `ReadProduct` as well.