### PR TITLE
fix(docs): Fix typos in README and collection-filter link comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ If you do not specify the `DB` argument, it will default to "mysql".
 
 1. `cd packages/admin-ui`
 2. `yarn start`
-3. Go to http://localhost:4200 and log in with "superadmin", "superadmin"
+3. Go to http://localhost:3000 and log in with "superadmin", "superadmin"
 
 ### Code generation
 
@@ -97,7 +97,7 @@ Running `yarn codegen` will generate the following files:
 * [`packages/common/src/generated-types.ts`](./packages/common/src/generated-types.ts): Types, Inputs & resolver args relating to the Admin API
 * [`packages/common/src/generated-shop-types.ts`](./packages/common/src/generated-shop-types.ts): Types, Inputs & resolver args relating to the Shop API
 * [`packages/admin-ui/src/lib/core/src/common/generated-types.ts`](./packages/admin-ui/src/lib/core/src/common/generated-types.ts): Types & operations relating to the admin-ui queries & mutations.
-* [`packages/admin-ui/src/lib/core/src/common/introspection-result.ts`](./packages/admin-ui/src/lib/core/src/common/introspection-result.ts): Used by the Apollo Client [`IntrospectionFragmentMatcher`](https://www.apollographql.com/docs/react/data/fragments/#fragments-on-unions-and-interfaces) to correctly handle fragements in the Admin UI.
+* [`packages/admin-ui/src/lib/core/src/common/introspection-result.ts`](./packages/admin-ui/src/lib/core/src/common/introspection-result.ts): Used by the Apollo Client [`IntrospectionFragmentMatcher`](https://www.apollographql.com/docs/react/data/fragments/#fragments-on-unions-and-interfaces) to correctly handle fragments in the Admin UI.
 * Also generates types used in e2e tests in those packages which feature e2e tests (core, elasticsearch-plugin, asset-server-plugin etc).
 
 ### Testing

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ If you do not specify the `DB` argument, it will default to "mysql".
 
 1. `cd packages/admin-ui`
 2. `yarn start`
-3. Go to http://localhost:3000 and log in with "superadmin", "superadmin"
+3. Go to http://localhost:4200 and log in with "superadmin", "superadmin"
 
 ### Code generation
 

--- a/packages/core/src/config/catalog/collection-filter.ts
+++ b/packages/core/src/config/catalog/collection-filter.ts
@@ -25,7 +25,7 @@ export interface CollectionFilterConfig<T extends ConfigArgs> extends Configurab
  * [`QueryBuilder`](https://typeorm.io/#/select-query-builder) object to which clauses may be added.
  *
  * Creating a CollectionFilter is considered an advanced Vendure topic. For more insight into how
- * they work, study the [default collection filters](https://github.com/vendure-ecommerce/vendure/blob/master/packages/core/src/config/collection/default-collection-filters.ts)
+ * they work, study the [default collection filters](https://github.com/vendure-ecommerce/vendure/blob/master/packages/core/src/config/catalog/default-collection-filters.ts)
  *
  * @docsCategory configuration
  */


### PR DESCRIPTION
Just fixing a couple doc issues I came across:

`README.md`:
* The default port number for the dev server is 3000 and not 4200 as defined in [shared-constants.ts](https://github.com/vendure-ecommerce/vendure/blob/5f5f767e145938959a0f17d3abe1a25091c6779b/packages/common/src/shared-constants.ts#L5)
* `fragments` as opposed to `fragements`

`collection-filter.ts`
* Link to `default-collection-filters.ts` currently returns a 404. Updating the path to the correct one