### PR TITLE
Fix(admin-ui): cmd+u shortcut on macOS

### DIFF
--- a/packages/admin-ui/src/lib/core/src/app.component.ts
+++ b/packages/admin-ui/src/lib/core/src/app.component.ts
@@ -74,7 +74,7 @@ export class AppComponent implements OnInit {
 
     @HostListener('window:keydown', ['$event'])
     handleGlobalHotkeys(event: KeyboardEvent) {
-        if (event.ctrlKey === true && event.key === 'u') {
+        if ((event.ctrlKey === true || event.metaKey === true) && event.key === 'u') {
             event.preventDefault();
             if (isDevMode()) {
                 this.dataService.client


### PR DESCRIPTION
Related issue: #1290 

This fix will allow users to use `ctrl+u` and `cmd+u` on macs.

Documentation: https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/metaKey