### PR TITLE
fix(server): Changed datatype for data in job_record to longtext

### DIFF
--- a/packages/core/src/plugin/default-job-queue-plugin/job-record.entity.ts
+++ b/packages/core/src/plugin/default-job-queue-plugin/job-record.entity.ts
@@ -13,7 +13,7 @@ export class JobRecord extends VendureEntity {
     @Column()
     queueName: string;
 
-    @Column('simple-json', { nullable: true })
+    @Column('longtext', { nullable: true })
     data: any;
 
     @Column('varchar')


### PR DESCRIPTION
This is to close #1298 

Changed `simple-json` to `longtext` to take more characters in job data