### PR TITLE
fix(core): Order promotions passing state correctly

### DIFF
--- a/packages/core/src/config/promotion/promotion-action.ts
+++ b/packages/core/src/config/promotion/promotion-action.ts
@@ -309,7 +309,7 @@ export class PromotionOrderAction<
 
     /** @internal */
     execute(ctx: RequestContext, order: Order, args: ConfigArg[], state: PromotionState) {
-        const actionState = this.conditions ? pick(state, Object.keys(this.conditions)) : {};
+        const actionState = this.conditions ? pick(state, this.conditions.map(c => c.code)) : {};
         return this.executeFn(ctx, order, this.argsArrayToHash(args), actionState as ConditionState<U>);
     }
 }
@@ -340,7 +340,7 @@ export class PromotionShippingAction<
         args: ConfigArg[],
         state: PromotionState,
     ) {
-        const actionState = this.conditions ? pick(state, Object.keys(this.conditions)) : {};
+        const actionState = this.conditions ? pick(state, this.conditions.map(c => c.code)) : {};
         return this.executeFn(
             ctx,
             shippingLine,


### PR DESCRIPTION
fixes #1322 

Looking at the code the cause is somewhat obvious, the action's state matcher uses `Object.keys` for a conditions' array which messes up `pick()` function. This code reverts to using `map()` with code.