### PR TITLE
docs(core): Updates UuidIdStrategy jsdoc to resolve vendure-config/entityIdStrategy deprecation

### DIFF
--- a/packages/core/src/config/entity-id-strategy/uuid-id-strategy.ts
+++ b/packages/core/src/config/entity-id-strategy/uuid-id-strategy.ts
@@ -4,15 +4,18 @@ import { EntityIdStrategy } from './entity-id-strategy';
  * @description
  * An id strategy which uses string uuids as primary keys
  * for all entities. This strategy can be configured with the
- * `entityIdStrategy` property of the {@link VendureConfig}.
+ * `entityIdStrategy` property of the `entityOptions` property
+ * of {@link VendureConfig}.
  *
  * @example
  * ```TypeScript
  * import { UuidIdStrategy, VendureConfig } from '\@vendure/core';
  *
  * export const config: VendureConfig = {
- *   entityIdStrategy: new UuidIdStrategy(),
- *   // ...
+ *   entityOptions: {
+ *     entityIdStrategy: new UuidIdStrategy(),
+ *     // ...
+ *   }
  * }
  * ```
  *


### PR DESCRIPTION
### Purpose

Updates the jsdoc of uuid-id-strategy to configure via `vendure-config/entityOptions/entityIdStrategy` instead of the deprecated `vendure-config/entityIdStrategy` property.