### PR TITLE
fix(docs): Fix minor Admin UI and GraphQL doc typos

### DIFF
--- a/docs/content/plugins/extending-the-admin-ui/_index.md
+++ b/docs/content/plugins/extending-the-admin-ui/_index.md
@@ -19,7 +19,7 @@ A UI extension is an [Angular module](https://angular.io/guide/ngmodules) which 
 
 ## Use Your Favourite Framework
 
-The Vendure Admin UI is build with Angular, and writing UI extensions in Angular is seamless and powerful. But if you are not familiar with Angular, that's no problem! You can write UI extensions using **React**, **Vue**, or **any other** web technology of choice!
+The Vendure Admin UI is built with Angular, and writing UI extensions in Angular is seamless and powerful. But if you are not familiar with Angular, that's no problem! You can write UI extensions using **React**, **Vue**, or **any other** web technology of choice!
 
 * [UI extensions in Angular]({{< relref "using-angular" >}})
 * [UI extensions in other frameworks]({{< relref "using-other-frameworks" >}})

--- a/docs/content/plugins/extending-the-admin-ui/using-other-frameworks/_index.md
+++ b/docs/content/plugins/extending-the-admin-ui/using-other-frameworks/_index.md
@@ -89,7 +89,6 @@ import path from 'path';
 import { VendureConfig } from '@vendure/core';
 import { AdminUiPlugin } from '@vendure/admin-ui-plugin';
 import { compileUiExtensions } from '@vendure/ui-devkit/compiler';
-import { reactUiExtension } from './ui-extension/ui-extension';
 
 export const config: VendureConfig = {
   // ...

--- a/packages/core/src/api/schema/admin-api/collection.api.graphql
+++ b/packages/core/src/api/schema/admin-api/collection.api.graphql
@@ -1,6 +1,6 @@
 type Query {
     collections(options: CollectionListOptions): CollectionList!
-    "Get a Collection either by id or slug. If neither id nor slug is speicified, an error will result."
+    "Get a Collection either by id or slug. If neither id nor slug is specified, an error will result."
     collection(id: ID, slug: String): Collection
     collectionFilters: [ConfigurableOperationDefinition!]!
 }

--- a/packages/core/src/api/schema/shop-api/shop.api.graphql
+++ b/packages/core/src/api/schema/shop-api/shop.api.graphql
@@ -5,7 +5,7 @@ type Query {
     activeCustomer: Customer
     """
     The active Order. Will be `null` until an Order is created via `addItemToOrder`. Once an Order reaches the
-    state of `PaymentApproved` or `PaymentSettled`, then that Order is no longer considered "active" and this
+    state of `PaymentAuthorized` or `PaymentSettled`, then that Order is no longer considered "active" and this
     query will once again return `null`.
     """
     activeOrder: Order
@@ -13,7 +13,7 @@ type Query {
     availableCountries: [Country!]!
     "A list of Collections available to the shop"
     collections(options: CollectionListOptions): CollectionList!
-    "Returns a Collection either by its id or slug. If neither 'id' nor 'slug' is speicified, an error will result."
+    "Returns a Collection either by its id or slug. If neither 'id' nor 'slug' is specified, an error will result."
     collection(id: ID, slug: String): Collection
     "Returns a list of eligible shipping methods based on the current active Order"
     eligibleShippingMethods: [ShippingMethodQuote!]!


### PR DESCRIPTION
Fixing a few very minor doc typos I came across while writing my first plugins:

* `docs/content/plugins/extending-the-admin-ui/_index.md`: "is _built_ with" as opposed to "is _build_ with"
* `docs/content/plugins/extending-the-admin-ui/using-other-frameworks/_index.md`: the `reactUiExtension` import is not used in the code snippet so not needed
* `packages/core/src/api/schema/admin-api/collection.api.graphql`: "specified" as opposed to "speicified"
* `packages/core/src/api/schema/shop-api/shop.api.graphql`: same as above plus `PaymentAuthorized` (as per [order state values](https://github.com/vendure-ecommerce/vendure/blob/ce147dc13e139be6d734016f43f7abeed9fac8d9/packages/core/src/service/helpers/order-state-machine/order-state.ts#L12))  instead of `PaymentApproved`