### PR TITLE
feat(core): Added a job queue name prefix as a config option

### DIFF
--- a/packages/core/src/config/default-config.ts
+++ b/packages/core/src/config/default-config.ts
@@ -149,6 +149,7 @@ export const defaultConfig: RuntimeVendureConfig = {
         jobBufferStorageStrategy: new InMemoryJobBufferStorageStrategy(),
         activeQueues: [],
         enableWorkerHealthCheck: false,
+        prefix: '',
     },
     customFields: {
         Address: [],

--- a/packages/core/src/config/vendure-config.ts
+++ b/packages/core/src/config/vendure-config.ts
@@ -771,6 +771,15 @@ export interface JobQueueOptions {
      * @default false
      */
     enableWorkerHealthCheck?: boolean;
+    /**
+     * @description
+     * Prefixes all job queue names with the passed string. This is useful with multiple deployments
+     * in cloud environments using services such as Amazon SQS or Google Cloud Tasks.
+     *
+     * For example, we might have a staging and a production deployment in the same account/project and
+     * each one will need its own task queue. We can achieve this with a prefix.
+     */
+    prefix?: string;
 }
 
 /**

--- a/packages/core/src/job-queue/job-queue.service.ts
+++ b/packages/core/src/job-queue/job-queue.service.ts
@@ -69,6 +69,9 @@ export class JobQueueService implements OnModuleDestroy {
     async createQueue<Data extends JobData<Data>>(
         options: CreateQueueOptions<Data>,
     ): Promise<JobQueue<Data>> {
+        if (this.configService.jobQueueOptions.prefix) {
+            options = { ...options, name: `${this.configService.jobQueueOptions.prefix}${options.name}` };
+        }
         const queue = new JobQueue(options, this.jobQueueStrategy, this.jobBufferService);
         if (this.hasStarted && this.shouldStartQueue(queue.name)) {
             await queue.start();


### PR DESCRIPTION
Adds a `prefix` option to the jobQueue configuration. Solves: https://github.com/vendure-ecommerce/vendure/issues/1350