### PR TITLE
Fix/long nav items

### DIFF
--- a/packages/admin-ui/src/lib/core/src/components/main-nav/main-nav.component.html
+++ b/packages/admin-ui/src/lib/core/src/components/main-nav/main-nav.component.html
@@ -15,7 +15,7 @@
                         ></vdr-status-badge>
                     </ng-container>
                     <input [id]="section.id" type="checkbox" [checked]="section.collapsedByDefault" />
-                    <label [for]="section.id">{{ section.label | translate }}</label>
+                    <label class="nav-group-header" [for]="section.id">{{ section.label | translate }}</label>
                     <ul class="nav-list">
                         <ng-container *ngFor="let item of section.items">
                             <li *ngIf="shouldDisplayLink(item)">

--- a/packages/admin-ui/src/lib/core/src/components/main-nav/main-nav.component.scss
+++ b/packages/admin-ui/src/lib/core/src/components/main-nav/main-nav.component.scss
@@ -16,6 +16,9 @@ nav.sidenav {
     .nav-list {
         margin: 0;
     }
+    .nav-group-header {
+        margin: 0;
+    }
     .nav-link {
         display: inline-flex;
         line-height: 1rem;

--- a/packages/admin-ui/src/lib/core/src/components/main-nav/main-nav.component.scss
+++ b/packages/admin-ui/src/lib/core/src/components/main-nav/main-nav.component.scss
@@ -12,6 +12,15 @@ nav.sidenav {
     border-right-color: var(--clr-sidenav-border-color);
 }
 
+.sidenav .nav-group {
+    .nav-list {
+        margin: 0;
+    }
+    .nav-link {
+        padding-right: 0.6rem;
+    }
+}
+
 .nav-list clr-icon {
     margin-right: 12px;
 }

--- a/packages/admin-ui/src/lib/core/src/components/main-nav/main-nav.component.scss
+++ b/packages/admin-ui/src/lib/core/src/components/main-nav/main-nav.component.scss
@@ -17,11 +17,14 @@ nav.sidenav {
         margin: 0;
     }
     .nav-link {
+        display: inline-flex;
+        line-height: 1rem;
         padding-right: 0.6rem;
     }
 }
 
 .nav-list clr-icon {
+    flex-shrink: 0;
     margin-right: 12px;
 }
 


### PR DESCRIPTION
Related issue: https://github.com/vendure-ecommerce/vendure/issues/1361

Commit 2d260aeaf6b5845f6851ca582f5ff1c42ff5ff50 fixes the overflowing:  
![margin](https://user-images.githubusercontent.com/7893762/150153430-6ba777ee-8acb-45db-a0cb-e2d110435cb5.jpg)

This leads to a left shift of the elements (I can also change that if you want the same look as before):  
![navigation](https://user-images.githubusercontent.com/7893762/150153825-0ddc8d89-8d52-4978-964f-fa43e7e7efb1.jpg) 

Commit 11eadc0ef056bb120fb5182e43bed02eb329fd46 improves the alignment of the navigation elements:  
![navigation-item](https://user-images.githubusercontent.com/7893762/150153612-b897d0eb-879e-4f23-bc2f-2d8988514cc6.jpg)

The second change results in minimally higher navigation elements. I can also try to restore the original look here.
