### PR TITLE
Fix: add Subscription to parentType

### DIFF
--- a/packages/core/src/api/middleware/auth-guard.ts
+++ b/packages/core/src/api/middleware/auth-guard.ts
@@ -175,6 +175,6 @@ export class AuthGuard implements CanActivate {
             return false;
         }
         const parentType = info?.parentType?.name;
-        return parentType !== 'Query' && parentType !== 'Mutation';
+        return parentType !== 'Query' && parentType !== 'Mutation' && parentType !== 'Subscription';
     }
 }


### PR DESCRIPTION
Add Subscription to parent type resolver action
fix problem when trying to authenticate a graphql subscription