### PR TITLE
fix(admin-ui): Fix hyphenation of long words

### DIFF
--- a/packages/admin-ui/src/lib/core/src/components/main-nav/main-nav.component.scss
+++ b/packages/admin-ui/src/lib/core/src/components/main-nav/main-nav.component.scss
@@ -18,6 +18,7 @@ nav.sidenav {
     }
     .nav-group-header {
         margin: 0;
+        line-height: 1.2;
     }
     .nav-link {
         display: inline-flex;
@@ -29,6 +30,10 @@ nav.sidenav {
 .nav-list clr-icon {
     flex-shrink: 0;
     margin-right: 12px;
+}
+
+.nav-group {
+    hyphens: auto;
 }
 
 .nav-group,

--- a/packages/admin-ui/src/lib/core/src/providers/i18n/i18n.service.ts
+++ b/packages/admin-ui/src/lib/core/src/providers/i18n/i18n.service.ts
@@ -4,6 +4,7 @@ import { TranslateService } from '@ngx-translate/core';
 
 import { LanguageCode } from '../../common/generated-types';
 
+/** @dynamic */
 @Injectable({
     providedIn: 'root',
 })

--- a/packages/admin-ui/src/lib/core/src/providers/i18n/i18n.service.ts
+++ b/packages/admin-ui/src/lib/core/src/providers/i18n/i18n.service.ts
@@ -1,4 +1,5 @@
-import { Injectable } from '@angular/core';
+import { DOCUMENT } from '@angular/common';
+import { Inject, Injectable } from '@angular/core';
 import { TranslateService } from '@ngx-translate/core';
 
 import { LanguageCode } from '../../common/generated-types';
@@ -13,7 +14,7 @@ export class I18nService {
         return [...this._availableLanguages];
     }
 
-    constructor(private ngxTranslate: TranslateService) {}
+    constructor(private ngxTranslate: TranslateService, @Inject(DOCUMENT) private document: Document) {}
 
     /**
      * Set the default language
@@ -27,6 +28,9 @@ export class I18nService {
      */
     setLanguage(language: LanguageCode): void {
         this.ngxTranslate.use(language);
+        if (this.document?.documentElement) {
+            this.document.documentElement.lang = language;
+        }
     }
 
     /**


### PR DESCRIPTION
@michaelbromley I found another problem related to the navigation elements that I have missed in my last pull request (#1362). Here is an example based on a ridiculously long word (left before the fix, right after the fix):

![hyphenation](https://user-images.githubusercontent.com/7893762/151835356-700e14ba-a2c7-4692-8da1-33d5946eb3cb.jpg)

Mobile:  
<img width="359" alt="Bildschirmfoto 2022-01-31 um 17 41 18@2x" src="https://user-images.githubusercontent.com/7893762/151835406-030c2a07-09ac-4cb3-a9ef-b9a0360b75ef.png">

I had to change the `lang` attribute of the `html` element to match the current language code to make `hyphens` work correctly (https://css-tricks.com/almanac/properties/h/hyphenate/):

> Note that hyphens is language-sensitive. Its ability to find break opportunities depends on the language, defined in the lang attribute of a parent element. Not all languages are supported yet, and support depends on the specific browser.
