### PR TITLE
fix(core): Fix OrderAddress type AddressCustomFields error (#1377)

### DIFF
--- a/packages/core/src/api/config/graphql-custom-fields.ts
+++ b/packages/core/src/api/config/graphql-custom-fields.ts
@@ -185,7 +185,10 @@ export function addGraphQLCustomFields(
         }
     }
 
-    if (customFieldConfig.Address?.length) {
+    const publicAddressFields = customFieldConfig.Address?.filter(
+        config => !config.internal && (publicOnly === true ? config.public !== false : true),
+    );
+    if (customFieldConfig.Address?.length && publicAddressFields?.length) {
         // For custom fields on the Address entity, we also extend the OrderAddress
         // type (which is used to store address snapshots on Orders)
         if (schema.getType('OrderAddress')) {


### PR DESCRIPTION
Relates to #1377. This commit adds an additional check for public/internal customFields on the `OrderAddress` schema type before adding `AddressCustomFields` to it.