### PR TITLE
feat(payments-plugin): Add Stripe integration

### DIFF
--- a/docs/content/getting-started.md
+++ b/docs/content/getting-started.md
@@ -16,7 +16,7 @@ weight: 0
  
 ## Installation with @vendure/create
 
-The recommended way to get started with Vendure is by using the [@vendure/create](https://github.com/vendure-ecommerce/vendure/tree/master/packages/create) tool. This is a command-line tool which will scaffold and configure your new Vendure project and install all dependiencies.
+The recommended way to get started with Vendure is by using the [@vendure/create](https://github.com/vendure-ecommerce/vendure/tree/master/packages/create) tool. This is a command-line tool which will scaffold and configure your new Vendure project and install all dependencies.
 
 {{% tab "npx" %}}
 ```sh

--- a/packages/payments-plugin/package.json
+++ b/packages/payments-plugin/package.json
@@ -22,7 +22,8 @@
     },
     "peerDependencies": {
         "@mollie/api-client": "3.x",
-        "braintree": "3.x"
+        "braintree": "3.x",
+        "stripe": "8.x"
     },
     "devDependencies": {
         "@mollie/api-client": "^3.5.1",
@@ -33,6 +34,7 @@
         "braintree": "^3.0.0",
         "nock": "^13.1.4",
         "rimraf": "^3.0.2",
+        "stripe": "^8.197.0",
         "typescript": "4.3.5"
     }
 }

--- a/packages/payments-plugin/src/braintree/README.md
+++ b/packages/payments-plugin/src/braintree/README.md
@@ -1,6 +1,5 @@
-# Braintree  payment plugin
+# Braintree payment plugin
 
 This plugin enables payments to be processed by [Braintree](https://www.braintreepayments.com/).
 
 For documentation, see https://www.vendure.io/docs/typescript-api/payments-plugin/braintree-plugin
-

--- a/packages/payments-plugin/src/braintree/types.ts
+++ b/packages/payments-plugin/src/braintree/types.ts
@@ -1,11 +1,12 @@
 import { ConfigArgValues } from '@vendure/core/dist/common/configurable-operation';
+import '@vendure/core/dist/entity/custom-entity-fields';
 import { Environment } from 'braintree';
 
 import { braintreePaymentMethodHandler } from './braintree.handler';
 
 export type PaymentMethodArgsHash = ConfigArgValues<typeof braintreePaymentMethodHandler['args']>;
 
-declare module '@vendure/core' {
+declare module '@vendure/core/dist/entity/custom-entity-fields' {
     interface CustomCustomerFields {
         braintreeCustomerId?: string;
     }

--- a/packages/payments-plugin/src/braintree/types.ts
+++ b/packages/payments-plugin/src/braintree/types.ts
@@ -6,6 +6,8 @@ import { braintreePaymentMethodHandler } from './braintree.handler';
 
 export type PaymentMethodArgsHash = ConfigArgValues<typeof braintreePaymentMethodHandler['args']>;
 
+// Note: deep import is necessary here because CustomCustomerFields is also extended in the Stripe
+// plugin. Reference: https://github.com/microsoft/TypeScript/issues/46617
 declare module '@vendure/core/dist/entity/custom-entity-fields' {
     interface CustomCustomerFields {
         braintreeCustomerId?: string;

--- a/packages/payments-plugin/src/mollie/mollie.controller.ts
+++ b/packages/payments-plugin/src/mollie/mollie.controller.ts
@@ -33,7 +33,7 @@ export class MollieController {
         const paymentMethod = await this.paymentMethodService.findOne(ctx, paymentMethodId);
         if (!paymentMethod) {
             // Fail silently, as we don't want to expose if a paymentMethodId exists or not
-            return Logger.error(`No paymentMethod found with id ${paymentMethod}`, loggerCtx);
+            return Logger.error(`No paymentMethod found with id ${paymentMethodId}`, loggerCtx);
         }
         const apiKey = paymentMethod.handler.args.find(a => a.name === 'apiKey')?.value;
         if (!apiKey) {

--- a/packages/payments-plugin/src/stripe/README.md
+++ b/packages/payments-plugin/src/stripe/README.md
@@ -1,1 +1,5 @@
-# Vendure Stripe integration
+# Stripe payment plugin
+
+Plugin to enable payments through [Stripe](https://stripe.com/docs).
+
+For documentation, see https://www.vendure.io/docs/typescript-api/payments-plugin/stripe-plugin

--- a/packages/payments-plugin/src/stripe/constants.ts
+++ b/packages/payments-plugin/src/stripe/constants.ts
@@ -1,0 +1,2 @@
+export const loggerCtx = 'StripePlugin';
+export const STRIPE_PLUGIN_OPTIONS = Symbol('STRIPE_PLUGIN_OPTIONS');

--- a/packages/payments-plugin/src/stripe/index.ts
+++ b/packages/payments-plugin/src/stripe/index.ts
@@ -1,0 +1,2 @@
+export * from './stripe.plugin';
+export * from './';

--- a/packages/payments-plugin/src/stripe/raw-body.middleware.ts
+++ b/packages/payments-plugin/src/stripe/raw-body.middleware.ts
@@ -1,0 +1,18 @@
+import { json } from 'body-parser';
+import { ServerResponse } from 'http';
+
+import { IncomingMessageWithRawBody } from './types';
+
+/**
+ * Middleware which adds the raw request body to the incoming message object. This is needed by
+ * Stripe to properly verify webhook events.
+ */
+export const rawBodyMiddleware = json({
+    verify(req: IncomingMessageWithRawBody, _: ServerResponse, buf: Buffer) {
+        if (Buffer.isBuffer(buf)) {
+            req.rawBody = Buffer.from(buf);
+        }
+
+        return true;
+    },
+});

--- a/packages/payments-plugin/src/stripe/stripe.controller.ts
+++ b/packages/payments-plugin/src/stripe/stripe.controller.ts
@@ -1,4 +1,4 @@
-import { BadRequestException, Controller, Headers, HttpStatus, Post, Req, Res } from '@nestjs/common';
+import { Controller, Headers, HttpStatus, Post, Req, Res } from '@nestjs/common';
 import {
     ChannelService,
     InternalServerError,

--- a/packages/payments-plugin/src/stripe/stripe.controller.ts
+++ b/packages/payments-plugin/src/stripe/stripe.controller.ts
@@ -1,0 +1,125 @@
+import { BadRequestException, Controller, Headers, Post, Req } from '@nestjs/common';
+import {
+    ChannelService,
+    InternalServerError,
+    LanguageCode,
+    Logger,
+    Order,
+    OrderService,
+    OrderStateTransitionError,
+    PaymentMethod,
+    RequestContext,
+    TransactionalConnection,
+} from '@vendure/core';
+import Stripe from 'stripe';
+
+import { loggerCtx } from './constants';
+import { stripePaymentMethodHandler } from './stripe.handler';
+import { StripeService } from './stripe.service';
+import { IncomingMessageWithRawBody } from './types';
+
+@Controller('payments')
+export class StripeController {
+    constructor(
+        private connection: TransactionalConnection,
+        private channelService: ChannelService,
+        private orderService: OrderService,
+        private stripeService: StripeService,
+    ) {}
+
+    @Post('stripe')
+    async webhook(
+        @Headers('stripe-signature') signature: string | undefined,
+        @Req() request: IncomingMessageWithRawBody,
+    ): Promise<void> {
+        if (!signature) {
+            throw new BadRequestException('Missing stripe-signature header');
+        }
+
+        let event = null;
+        try {
+            event = this.stripeService.constructEventFromPayload(request.rawBody, signature);
+        } catch (e: any) {
+            Logger.error(`Error verifying Stripe webhook signature ${signature}: ${e.message}`);
+            throw new BadRequestException('Error verifying Stripe webhook signature');
+        }
+
+        const paymentIntent = event.data.object as Stripe.PaymentIntent;
+        if (!paymentIntent) {
+            throw new BadRequestException('No payment intent in the webhook payload');
+        }
+
+        const { metadata: { channelToken, orderCode, orderId } = {} } = paymentIntent;
+
+        if (event.type === 'payment_intent.payment_failed') {
+            const message = paymentIntent.last_payment_error && paymentIntent.last_payment_error.message;
+            Logger.warn(`Payment for order ${orderCode} failed: ${message}`, loggerCtx);
+            return;
+        }
+
+        if (event.type !== 'payment_intent.succeeded') {
+            // This should never happen as the webhook is configured to receive
+            // payment_intent.succeeded and payment_intent.payment_failed events only
+            Logger.info(`Received ${event.type} status update for order ${orderCode}`, loggerCtx);
+            return;
+        }
+
+        const ctx = await this.createContext(channelToken);
+
+        const transitionToStateResult = await this.orderService.transitionToState(
+            ctx,
+            orderId,
+            'ArrangingPayment',
+        );
+
+        if (transitionToStateResult instanceof OrderStateTransitionError) {
+            Logger.error(
+                `Error transitioning order ${orderCode} to ArrangingPayment state: ${transitionToStateResult.message}`,
+                loggerCtx,
+            );
+            return;
+        }
+
+        const paymentMethod = await this.getPaymentMethod(ctx);
+
+        const addPaymentToOrderResult = await this.orderService.addPaymentToOrder(ctx, orderId, {
+            method: paymentMethod.code,
+            metadata: {
+                paymentIntentId: paymentIntent.id,
+            },
+        });
+
+        if (!(addPaymentToOrderResult instanceof Order)) {
+            Logger.error(`Error adding payment to order ${orderCode}: ${addPaymentToOrderResult.message}`);
+            return;
+        }
+
+        Logger.info(`Stripe payment intent id ${paymentIntent.id} added to order ${orderCode}`, loggerCtx);
+    }
+
+    private async createContext(channelToken: string): Promise<RequestContext> {
+        const channel = await this.channelService.getChannelFromToken(channelToken);
+
+        return new RequestContext({
+            apiType: 'admin',
+            isAuthorized: true,
+            authorizedAsOwnerOnly: false,
+            channel,
+            languageCode: LanguageCode.en,
+        });
+    }
+
+    private async getPaymentMethod(ctx: RequestContext): Promise<PaymentMethod> {
+        const method = await this.connection.getRepository(ctx, PaymentMethod).findOne({
+            where: {
+                code: stripePaymentMethodHandler.code,
+            },
+        });
+
+        if (!method) {
+            throw new InternalServerError(`[${loggerCtx}] Could not find Stripe PaymentMethod`);
+        }
+
+        return method;
+    }
+}

--- a/packages/payments-plugin/src/stripe/stripe.handler.ts
+++ b/packages/payments-plugin/src/stripe/stripe.handler.ts
@@ -1,0 +1,28 @@
+import { CreatePaymentResult, LanguageCode, PaymentMethodHandler, SettlePaymentResult } from '@vendure/core';
+
+/**
+ * The handler for Stripe payments.
+ */
+export const stripePaymentMethodHandler = new PaymentMethodHandler({
+    code: 'stripe',
+
+    description: [{ languageCode: LanguageCode.en, value: 'Stripe payments' }],
+
+    args: {},
+
+    async createPayment(_, __, amount, ___, metadata): Promise<CreatePaymentResult> {
+        // Payment is already settled in Stripe by the time the webhook in stripe.controller.ts
+        // adds the payment to the order
+        return {
+            amount,
+            state: 'Settled' as const,
+            transactionId: metadata.paymentIntentId,
+        };
+    },
+
+    settlePayment(): SettlePaymentResult {
+        return {
+            success: true,
+        };
+    },
+});

--- a/packages/payments-plugin/src/stripe/stripe.plugin.ts
+++ b/packages/payments-plugin/src/stripe/stripe.plugin.ts
@@ -1,0 +1,134 @@
+import { LanguageCode, PluginCommonModule, Type, VendurePlugin } from '@vendure/core';
+import { gql } from 'graphql-tag';
+
+import { STRIPE_PLUGIN_OPTIONS } from './constants';
+import { rawBodyMiddleware } from './raw-body.middleware';
+import { StripeController } from './stripe.controller';
+import { stripePaymentMethodHandler } from './stripe.handler';
+import { StripeResolver } from './stripe.resolver';
+import { StripeService } from './stripe.service';
+import { StripePluginOptions } from './types';
+
+/**
+ * @description
+ * Plugin to enable payments through [Stripe](https://stripe.com/docs) via the Payment Intents API.
+ *
+ * ## Requirements
+ *
+ * 1. You will need to create a Stripe account and get your secret key in the dashboard.
+ * 2. Create a webhook endpoint in the Stripe dashboard which listens to the `payment_intent.succeeded` and
+ * `payment_intent.payment_failed` events. The URL should be `https://my-shop.com/payments/stripe`, where
+ * `my-shop.com` is the host of your storefront application.
+ * 3. Get the signing secret for the newly created webhook.
+ * 4. Install the Payments plugin and the Stripe Node library:
+ *
+ *     `yarn add \@vendure/payments-plugin stripe`
+ *
+ *     or
+ *
+ *     `npm install \@vendure/payments-plugin stripe`
+ *
+ * ## Setup
+ *
+ * 1. Add the plugin to your VendureConfig `plugins` array:
+ *     ```TypeScript
+ *     import { StripePlugin } from '\@vendure/payments-plugin/package/stripe';
+ *
+ *     // ...
+ *
+ *     plugins: [
+ *       StripePlugin.init({
+ *         apiKey: process.env.YOUR_STRIPE_SECRET_KEY,
+ *         webhookSigningSecret: process.env.YOUR_STRIPE_WEBHOOK_SIGNING_SECRET,
+ *         // This prevents different customers from using the same PaymentIntent
+ *         storeCustomersInStripe: true,
+ *       }),
+ *     ]
+ *     ````
+ * 2. Create a new PaymentMethod in the Admin UI, and select "Stripe payments" as the handler.
+ *
+ * ## Storefront usage
+ *
+ * The plugin is designed to work with the [Custom payment flow](https://stripe.com/docs/payments/accept-a-payment?platform=web&ui=elements).
+ * In this flow, Stripe provides libraries which handle the payment UI and confirmation for you. You can install it in your storefront project
+ * with:
+ *
+ * ```shell
+ * yarn add \@stripe/stripe-js
+ * # or
+ * npm install \@stripe/stripe-js
+ * ```
+ *
+ * If you are using React, you should also consider installing `@stripe/react-stripe-js`, which is a wrapper around Stripe Elements.
+ *
+ * The high-level workflow is:
+ * 1. Create a "payment intent" on the server by executing the `createStripePaymentIntent` mutation which is exposed by this plugin.
+ * 2. Use the returned client secret to instantiate the Stripe Payment Element.
+ * 3. Once the form is submitted and Stripe processes the payment, the webhook takes care of updating the order without additional action
+ * in the storefront.
+ *
+ * ## Local development
+ *
+ * Use something like [localtunnel](https://github.com/localtunnel/localtunnel) to test on localhost.
+ *
+ * ```bash
+ * npx localtunnel --port 3000 --subdomain my-shop-local-dev
+ * > your url is: https://my-shop-local-dev.loca.lt
+ * ```
+ *
+ * @docsCategory payments-plugin
+ * @docsPage StripePlugin
+ */
+@VendurePlugin({
+    imports: [PluginCommonModule],
+    controllers: [StripeController],
+    providers: [
+        {
+            provide: STRIPE_PLUGIN_OPTIONS,
+            useFactory: (): StripePluginOptions => StripePlugin.options,
+        },
+        StripeService,
+    ],
+    configuration: config => {
+        config.paymentOptions.paymentMethodHandlers.push(stripePaymentMethodHandler);
+
+        config.apiOptions.middleware.push({
+            route: '/payments/stripe',
+            handler: rawBodyMiddleware,
+            beforeListen: true,
+        });
+
+        if (StripePlugin.options.storeCustomersInStripe) {
+            config.customFields.Customer.push({
+                name: 'stripeCustomerId',
+                type: 'string',
+                label: [{ languageCode: LanguageCode.en, value: 'Stripe Customer ID' }],
+                nullable: true,
+                public: false,
+                readonly: true,
+            });
+        }
+
+        return config;
+    },
+    shopApiExtensions: {
+        schema: gql`
+            extend type Mutation {
+                createStripePaymentIntent: String
+            }
+        `,
+        resolvers: [StripeResolver],
+    },
+})
+export class StripePlugin {
+    static options: StripePluginOptions;
+
+    /**
+     * @description
+     * Initialize the Stripe payment plugin
+     */
+    static init(options: StripePluginOptions): Type<StripePlugin> {
+        this.options = options;
+        return StripePlugin;
+    }
+}

--- a/packages/payments-plugin/src/stripe/stripe.resolver.ts
+++ b/packages/payments-plugin/src/stripe/stripe.resolver.ts
@@ -1,0 +1,20 @@
+import { Mutation, Resolver } from '@nestjs/graphql';
+import { ActiveOrderService, Allow, Ctx, Permission, RequestContext } from '@vendure/core';
+
+import { StripeService } from './stripe.service';
+
+@Resolver()
+export class StripeResolver {
+    constructor(private stripeService: StripeService, private activeOrderService: ActiveOrderService) {}
+
+    @Mutation()
+    @Allow(Permission.Owner)
+    async createStripePaymentIntent(@Ctx() ctx: RequestContext): Promise<string | undefined> {
+        if (ctx.authorizedAsOwnerOnly) {
+            const sessionOrder = await this.activeOrderService.getOrderFromContext(ctx);
+            if (sessionOrder) {
+                return this.stripeService.createPaymentIntent(ctx, sessionOrder);
+            }
+        }
+    }
+}

--- a/packages/payments-plugin/src/stripe/stripe.service.ts
+++ b/packages/payments-plugin/src/stripe/stripe.service.ts
@@ -87,9 +87,8 @@ export class StripeService {
 
         const { customer } = order;
 
-        // TODO: fix typings
-        if ((customer.customFields as any).stripeCustomerId) {
-            return (customer.customFields as any).stripeCustomerId;
+        if (customer.customFields.stripeCustomerId) {
+            return customer.customFields.stripeCustomerId;
         }
 
         let stripeCustomerId;
@@ -108,8 +107,7 @@ export class StripeService {
             Logger.info(`Created Stripe Customer record for customerId ${customer.id}`, loggerCtx);
         }
 
-        // TODO: fix typings
-        (customer.customFields as any).stripeCustomerId = stripeCustomerId;
+        customer.customFields.stripeCustomerId = stripeCustomerId;
         await this.connection.getRepository(ctx, Customer).save(customer, { reload: false });
 
         return stripeCustomerId;

--- a/packages/payments-plugin/src/stripe/stripe.service.ts
+++ b/packages/payments-plugin/src/stripe/stripe.service.ts
@@ -1,0 +1,102 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { Customer, Logger, Order, RequestContext, TransactionalConnection } from '@vendure/core';
+import Stripe from 'stripe';
+
+import { loggerCtx, STRIPE_PLUGIN_OPTIONS } from './constants';
+import { StripePluginOptions } from './types';
+
+@Injectable()
+export class StripeService {
+    private stripe: Stripe;
+
+    constructor(
+        private connection: TransactionalConnection,
+        @Inject(STRIPE_PLUGIN_OPTIONS) private options: StripePluginOptions,
+    ) {
+        this.stripe = new Stripe(this.options.apiKey, {
+            apiVersion: '2020-08-27',
+        });
+    }
+
+    async createPaymentIntent(ctx: RequestContext, activeOrder: Order): Promise<string | undefined> {
+        let customerId: string | undefined;
+
+        if (this.options.storeCustomersInStripe && ctx.activeUserId) {
+            customerId = await this.getStripeCustomerId(ctx, activeOrder);
+        }
+
+        const { client_secret } = await this.stripe.paymentIntents.create({
+            amount: activeOrder.total,
+            currency: activeOrder.currencyCode.toLowerCase(),
+            customer: customerId,
+            automatic_payment_methods: {
+                enabled: true,
+            },
+            metadata: {
+                channelToken: ctx.channel.token,
+                orderId: activeOrder.id,
+                orderCode: activeOrder.code,
+            },
+        });
+
+        if (!client_secret) {
+            // This should never happen
+            Logger.warn(
+                `Payment intent creation for order ${activeOrder.code} did not return client secret`,
+                loggerCtx,
+            );
+        }
+
+        return client_secret ?? undefined;
+    }
+
+    constructEventFromPayload(payload: Buffer, signature: string): Stripe.Event {
+        return this.stripe.webhooks.constructEvent(payload, signature, this.options.webhookSigningSecret);
+    }
+
+    /**
+     * Returns the stripeCustomerId if the Customer has one. If that's not the case, queries Stripe to check
+     * if the customer is already registered, in which case it saves the id as stripeCustomerId and returns it.
+     * Otherwise, creates a new Customer record in Stripe and returns the generated id.
+     */
+    private async getStripeCustomerId(ctx: RequestContext, activeOrder: Order): Promise<string | undefined> {
+        // Load relation with customer not available in the response from activeOrderService.getOrderFromContext()
+        const order = await this.connection.getRepository(Order).findOne(activeOrder.id, {
+            relations: ['customer'],
+        });
+
+        if (!order || !order.customer) {
+            // This should never happen
+            return undefined;
+        }
+
+        const { customer } = order;
+
+        // TODO: fix typings
+        if ((customer.customFields as any).stripeCustomerId) {
+            return (customer.customFields as any).stripeCustomerId;
+        }
+
+        let stripeCustomerId;
+
+        const stripeCustomers = await this.stripe.customers.list({ email: customer.emailAddress });
+        if (stripeCustomers.data.length > 0) {
+            stripeCustomerId = stripeCustomers.data[0].id;
+        } else {
+            const newStripeCustomer = await this.stripe.customers.create({
+                email: customer.emailAddress,
+                name: `${customer.firstName} ${customer.lastName}`,
+            });
+
+            stripeCustomerId = newStripeCustomer.id;
+
+            Logger.info(`Created Stripe Customer record for customerId ${customer.id}`, loggerCtx);
+        }
+
+        // TODO: fix typings
+        (customer.customFields as any).stripeCustomerId = stripeCustomerId;
+        await this.connection.getRepository(ctx, Customer).save(customer, { reload: false });
+
+        return stripeCustomerId;
+    }
+}

--- a/packages/payments-plugin/src/stripe/types.ts
+++ b/packages/payments-plugin/src/stripe/types.ts
@@ -1,0 +1,42 @@
+import { CustomCustomerFields } from '@vendure/core';
+import { IncomingMessage } from 'http';
+
+declare module '@vendure/core' {
+    interface CustomCustomerFields {
+        stripeCustomerId?: string;
+    }
+}
+
+/**
+ * @description
+ * Configuration options for the Stripe payments plugin.
+ *
+ * @docsCategory payments-plugin
+ * @docsPage StripePlugin
+ */
+export interface StripePluginOptions {
+    /**
+     * @description
+     * Secret key of your Stripe account.
+     */
+    apiKey: string;
+    /**
+     * @description
+     * Signing secret of your configured Stripe webhook.
+     */
+    webhookSigningSecret: string;
+    /**
+     * @description
+     * If set to `true`, a [Customer](https://stripe.com/docs/api/customers) object will be created in Stripe - if
+     * it doesn't already exist - for authenticated users, which prevents payment methods attached to other Customers
+     * to be used with the same PaymentIntent. This is done by adding a custom field to the Customer entity to store
+     * the Stripe customer ID, so switching this on will require a database migration / synchronization.
+     *
+     * @default false
+     */
+    storeCustomersInStripe?: boolean;
+}
+
+export interface IncomingMessageWithRawBody extends IncomingMessage {
+    rawBody: Buffer;
+}

--- a/packages/payments-plugin/src/stripe/types.ts
+++ b/packages/payments-plugin/src/stripe/types.ts
@@ -1,7 +1,7 @@
-import { CustomCustomerFields } from '@vendure/core';
+import '@vendure/core/dist/entity/custom-entity-fields';
 import { IncomingMessage } from 'http';
 
-declare module '@vendure/core' {
+declare module '@vendure/core/dist/entity/custom-entity-fields' {
     interface CustomCustomerFields {
         stripeCustomerId?: string;
     }

--- a/packages/payments-plugin/src/stripe/types.ts
+++ b/packages/payments-plugin/src/stripe/types.ts
@@ -1,6 +1,8 @@
 import '@vendure/core/dist/entity/custom-entity-fields';
 import { IncomingMessage } from 'http';
 
+// Note: deep import is necessary here because CustomCustomerFields is also extended in the Braintree
+// plugin. Reference: https://github.com/microsoft/TypeScript/issues/46617
 declare module '@vendure/core/dist/entity/custom-entity-fields' {
     interface CustomCustomerFields {
         stripeCustomerId?: string;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4220,6 +4220,11 @@
   resolved "https://registry.npmjs.org/@types/node/-/node-16.7.1.tgz#c6b9198178da504dfca1fd0be9b2e1002f1586f0"
   integrity sha512-ncRdc45SoYJ2H4eWU9ReDfp3vtFqDYhjOsKlFFUDEn8V1Bgr2RjYal8YT5byfadWIRluhPFU6JiDOl0H6Sl87A==
 
+"@types/node@>=8.1.0":
+  version "17.0.14"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.14.tgz#33b9b94f789a8fedd30a68efdbca4dbb06b61f20"
+  integrity sha512-SbjLmERksKOGzWzPNuW7fJM7fk3YXVTFiZWB/Hs99gwhk+/dnrQRPBQjPW9aO+fi1tAffi9PrwFvsmOKmDTyng==
+
 "@types/node@^10.1.0":
   version "10.17.60"
   resolved "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz#35f3d6213daed95da7f0f73e75bcc6980e90597b"
@@ -15785,6 +15790,13 @@ qs@6.7.0:
   resolved "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz#41dc1a015e3d581f1621776be31afb2876a9b1bc"
   integrity sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==
 
+qs@^6.6.0:
+  version "6.10.3"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.10.3.tgz#d6cde1b2ffca87b5aa57889816c5f81535e22e8e"
+  integrity sha512-wr7M2E0OFRfIfJZjKGieI8lBKb7fRCH4Fv5KNPEs7gJ8jadvotdsS08PzOKR7opXhZ/Xkjtt3WF9g38drmyRqQ==
+  dependencies:
+    side-channel "^1.0.4"
+
 qs@^6.9.4:
   version "6.10.1"
   resolved "https://registry.npmjs.org/qs/-/qs-6.10.1.tgz#4931482fa8d647a5aab799c5271d2133b981fb6a"
@@ -17583,6 +17595,14 @@ strip-json-comments@~2.0.1:
   version "2.0.1"
   resolved "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
   integrity sha1-PFMZQukIwml8DsNEhYwobHygpgo=
+
+stripe@^8.197.0:
+  version "8.202.0"
+  resolved "https://registry.yarnpkg.com/stripe/-/stripe-8.202.0.tgz#884760713a690983d5a3128ea3cbeb677ee2645f"
+  integrity sha512-3YGHVnUatEn/At5+aRy+REdB2IyVa96/zls2xvQrKFTgaJzRu1MsJcK0GKg0p2B0y0VqlZo9gmdDEqphSHHvtA==
+  dependencies:
+    "@types/node" ">=8.1.0"
+    qs "^6.6.0"
 
 strong-log-transformer@^2.1.0:
   version "2.1.0"


### PR DESCRIPTION
Complements #1087.

The goal of this PR is to add Stripe integration to `@vendure/payments-plugin` using the [Custom payment flow ](https://stripe.com/docs/payments/accept-a-payment?platform=web&ui=elements) and [Payment Intents API](https://stripe.com/docs/payments/payment-intents).  A rough, high-level sequence diagram of a successful payment for an order can be seen below, which aids in explaining the key components in more detail:

<img width="962" alt="stripe_plugin" src="https://user-images.githubusercontent.com/8788208/153352234-bcfb3d82-d769-4261-ae0a-24f342dd117d.png">

* `stripe.plugin.ts`
Actual plugin class.

* `stripe.resolver.ts`
Contains the resolver for the `createStripePaymentIntent` Shop API mutation, which requires an active order in the current session.

* `stripe.service.ts`
Provides methods to interact with Stripe via the `stripe` Node library, most importantly, the creation of a payment intent for the active order. It also supports creating/linking the Customer to Stripe via the `storeCustomersInStripe` plugin option.

* `stripe.controller.ts`
Contains the webhook endpoint which listens for payment intent status updates from Stripe - success or failure - and ultimately calls `OrderService.addPaymentToOrder`.

* `stripe.handler.ts`
Actual payment method handler for Stripe. `createPayment` always returns a `Settled` payment because the webhook is only called when the payment is already settled in Stripe (in case of success). That is, `OrderService.addPaymentToOrder` should always succeed.

* `raw-body.middleware.ts`
Middleware for the webhook route which adds the raw request body to the incoming message object, which is the [format Stripe requires](https://stripe.com/docs/webhooks/signatures#verify-official-libraries). Credit to [Gab from the Slack channel](https://vendure-ecommerce.slack.com/archives/CKYMF0ZTJ/p1625483446188600?thread_ts=1625483114.188400&cid=CKYMF0ZTJ).

I have also updated/fixed a few very minor typos and cosmetic documentation issues.

**Decisions / Caveats**

* As discussed on Slack, API key and Webhook signing secret must be passed in as plugin options as opposed to payment method handler args since both are needed in `stripe.controller.ts` before we have access to any Vendure-specific data (such as channel token).
* I chose to expose the payment intent creation as a Shop API endpoint as opposed to have it as part of the payment method handler's `createPayment` because, as the name implies, it's just an _intent_. Stripe requires a created intent in order to display the payment form, that is, the call to `stripe.createPaymentIntent` must take place as soon as the customer lands on the payment page. I didn't want to "lock" the customer by transitioning the order to `ArrangingPayment` and calling `addPaymentToOrder` at that point because they might change their mind and go back to their shopping cart to add more items. Therefore, this solution updates the order at the very last minute once we get confirmation from Stripe in the webhook. As a consequence, the `ArrangingPayment` state is pretty much ignored and only transitioned to given the order state machine requires so.
* As discussed on Slack, typings for the new Customer custom field `stripeCustomerId` is not working for some reason. I used `any` and added a `TODO` where appropriate.