### PR TITLE
Add currency code in generated Email confirmation

### DIFF
--- a/packages/email-plugin/src/mock-events.ts
+++ b/packages/email-plugin/src/mock-events.ts
@@ -20,6 +20,7 @@ export const mockOrderStateTransitionEvent = new OrderStateTransitionEvent(
     {} as any,
     new Order({
         id: '6',
+        currencyCode: 'USD',
         createdAt: '2018-10-31T11:18:29.261Z',
         updatedAt: '2018-10-31T15:24:17.000Z',
         orderPlacedAt: '2018-10-31T13:54:17.000Z',


### PR DESCRIPTION
Add the missing `currencyCode` property in the mocked Order entity.