### PR TITLE
fix(core): Support usage GQL interface on relational custom field

### DIFF
--- a/packages/core/src/api/resolvers/admin/global-settings.resolver.ts
+++ b/packages/core/src/api/resolvers/admin/global-settings.resolver.ts
@@ -11,6 +11,7 @@ import {
     GraphQLOutputType,
     GraphQLResolveInfo,
     isEnumType,
+    isInterfaceType,
     isListType,
     isNonNullType,
     isObjectType,
@@ -118,7 +119,7 @@ export class GlobalSettingsResolver {
     private getScalarFieldsOfType(info: GraphQLResolveInfo, typeName: string): string[] {
         const type = info.schema.getType(typeName);
 
-        if (type && isObjectType(type)) {
+        if (type && (isObjectType(type) || isInterfaceType(type))) {
             return Object.values(type.getFields())
                 .filter(field => {
                     const namedType = this.getNamedType(field.type);


### PR DESCRIPTION
Currently, if you use GraphQL interface on relational custom field, admin-ui will not be able to query all fields, that is presented in this interface. This pull request fixes global config generation.