### PR TITLE
fix(core): Add order-testing service to index.ts

### DIFF
--- a/packages/core/src/service/index.ts
+++ b/packages/core/src/service/index.ts
@@ -31,6 +31,7 @@ export * from './services/fulfillment.service';
 export * from './services/global-settings.service';
 export * from './services/history.service';
 export * from './services/order.service';
+export * from './services/order-testing.service';
 export * from './services/payment-method.service';
 export * from './services/payment.service';
 export * from './services/product-option-group.service';


### PR DESCRIPTION
Added the order-testing service to the index.ts to be able to use it in the implementation.

Fixes #1469 