### PR TITLE
fix(core): Copy context on transaction start. Do not allow to run queries after transaction aborts.

### DIFF
--- a/packages/core/src/api/decorators/request-context.decorator.ts
+++ b/packages/core/src/api/decorators/request-context.decorator.ts
@@ -1,6 +1,6 @@
 import { ContextType, createParamDecorator, ExecutionContext } from '@nestjs/common';
 
-import { REQUEST_CONTEXT_KEY } from '../../common/constants';
+import { REQUEST_CONTEXT_KEY, REQUEST_CONTEXT_MAP_KEY } from '../../common/constants';
 
 /**
  * @description
@@ -19,11 +19,20 @@ import { REQUEST_CONTEXT_KEY } from '../../common/constants';
  * @docsPage Ctx Decorator
  */
 export const Ctx = createParamDecorator((data, ctx: ExecutionContext) => {
+    const getContext = (req: any) => {
+        const map: Map<Function, any> | undefined = req[REQUEST_CONTEXT_MAP_KEY];
+
+        // If a map contains associated transactional context with this handler
+        // we have to use it. It means that this handler was wrapped with @Transaction decorator.
+        // Otherwise use default context.
+        return map?.get(ctx.getHandler()) || req[REQUEST_CONTEXT_KEY];
+    }
+
     if (ctx.getType<ContextType | 'graphql'>() === 'graphql') {
         // GraphQL request
-        return ctx.getArgByIndex(2).req[REQUEST_CONTEXT_KEY];
+        return getContext(ctx.getArgByIndex(2).req);
     } else {
         // REST request
-        return ctx.switchToHttp().getRequest()[REQUEST_CONTEXT_KEY];
+        return getContext(ctx.switchToHttp().getRequest());
     }
 });

--- a/packages/core/src/api/middleware/transaction-interceptor.ts
+++ b/packages/core/src/api/middleware/transaction-interceptor.ts
@@ -1,8 +1,9 @@
 import { CallHandler, ExecutionContext, Injectable, NestInterceptor } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
 import { Observable, of } from 'rxjs';
+import { RequestContext } from '..';
 
-import { REQUEST_CONTEXT_KEY } from '../../common/constants';
+import { REQUEST_CONTEXT_KEY, REQUEST_CONTEXT_MAP_KEY } from '../../common/constants';
 import { TransactionWrapper } from '../../connection/transaction-wrapper';
 import { TransactionalConnection } from '../../connection/transactional-connection';
 import { parseContext } from '../common/parse-context';
@@ -20,24 +21,45 @@ export class TransactionInterceptor implements NestInterceptor {
         private transactionWrapper: TransactionWrapper,
         private reflector: Reflector,
     ) {}
+
     intercept(context: ExecutionContext, next: CallHandler): Observable<any> {
         const { isGraphQL, req } = parseContext(context);
-        const ctx = (req as any)[REQUEST_CONTEXT_KEY];
+        const ctx: RequestContext | undefined = (req as any)[REQUEST_CONTEXT_KEY];
+
         if (ctx) {
             const transactionMode = this.reflector.get<TransactionMode>(
                 TRANSACTION_MODE_METADATA_KEY,
                 context.getHandler(),
             );
+            
             return of(
                 this.transactionWrapper.executeInTransaction(
-                    ctx.copy(),
-                    () => next.handle(),
+                    ctx,
+                    (ctx) => {
+                        this.registerTransactionalContext(ctx, context.getHandler(), req);
+
+                        return next.handle()
+                    },
                     transactionMode,
                     this.connection.rawConnection,
-                ),
+                )
             );
         } else {
             return next.handle();
         }
+    }
+
+    /**
+     * Registers transactional request context associated with execution handler function
+     * 
+     * @param ctx transactional request context
+     * @param handler handler function from ExecutionContext
+     * @param req Request object
+     */
+    registerTransactionalContext(ctx: RequestContext, handler: Function, req: any) {
+        const map: Map<Function, RequestContext> = req[REQUEST_CONTEXT_MAP_KEY] || new Map();
+        map.set(handler, ctx);
+
+        req[REQUEST_CONTEXT_MAP_KEY] = map;
     }
 }

--- a/packages/core/src/api/middleware/transaction-interceptor.ts
+++ b/packages/core/src/api/middleware/transaction-interceptor.ts
@@ -30,7 +30,7 @@ export class TransactionInterceptor implements NestInterceptor {
             );
             return of(
                 this.transactionWrapper.executeInTransaction(
-                    ctx,
+                    ctx.copy(),
                     () => next.handle(),
                     transactionMode,
                     this.connection.rawConnection,

--- a/packages/core/src/common/constants.ts
+++ b/packages/core/src/common/constants.ts
@@ -9,6 +9,7 @@ import { CrudPermissionDefinition, PermissionDefinition, PermissionMetadata } fr
 export const DEFAULT_LANGUAGE_CODE = LanguageCode.en;
 export const TRANSACTION_MANAGER_KEY = Symbol('TRANSACTION_MANAGER');
 export const REQUEST_CONTEXT_KEY = 'vendureRequestContext';
+export const REQUEST_CONTEXT_MAP_KEY = 'vendureRequestContextMap';
 export const DEFAULT_PERMISSIONS: PermissionDefinition[] = [
     new PermissionDefinition({
         name: 'Authenticated',

--- a/packages/core/src/connection/transactional-connection.ts
+++ b/packages/core/src/connection/transactional-connection.ts
@@ -73,8 +73,9 @@ export class TransactionalConnection {
     ): Repository<Entity> {
         if (ctxOrTarget instanceof RequestContext) {
             const transactionManager = this.getTransactionManager(ctxOrTarget);
-            if (transactionManager && maybeTarget && !transactionManager.queryRunner?.isReleased) {
-                return transactionManager.getRepository(maybeTarget);
+            if (transactionManager) {
+                // tslint:disable-next-line:no-non-null-assertion
+                return transactionManager.getRepository(maybeTarget!);
             } else {
                 // tslint:disable-next-line:no-non-null-assertion
                 return getRepository(maybeTarget!);
@@ -131,7 +132,7 @@ export class TransactionalConnection {
         let ctx: RequestContext;
         let work: (ctx: RequestContext) => Promise<T>;
         if (ctxOrWork instanceof RequestContext) {
-            ctx = ctxOrWork;
+            ctx = ctxOrWork.copy();
             // tslint:disable-next-line:no-non-null-assertion
             work = maybeWork!;
         } else {

--- a/packages/core/src/connection/transactional-connection.ts
+++ b/packages/core/src/connection/transactional-connection.ts
@@ -136,14 +136,14 @@ export class TransactionalConnection {
         let ctx: RequestContext;
         let work: (ctx: RequestContext) => Promise<T>;
         if (ctxOrWork instanceof RequestContext) {
-            ctx = ctxOrWork.copy();
+            ctx = ctxOrWork;
             // tslint:disable-next-line:no-non-null-assertion
             work = maybeWork!;
         } else {
             ctx = RequestContext.empty();
             work = ctxOrWork;
         }
-        return this.transactionWrapper.executeInTransaction(ctx, () => work(ctx), 'auto', this.rawConnection);
+        return this.transactionWrapper.executeInTransaction(ctx, work, 'auto', this.rawConnection);
     }
 
     /**

--- a/packages/core/src/connection/transactional-connection.ts
+++ b/packages/core/src/connection/transactional-connection.ts
@@ -102,15 +102,19 @@ export class TransactionalConnection {
      * of Vendure internal services.
      *
      * If there is already a {@link RequestContext} object available, you should pass it in as the first
-     * argument in order to add a new transaction to it. If not, omit the first argument and an empty
+     * argument in order to create transactional context as the copy. If not, omit the first argument and an empty
      * RequestContext object will be created, which is then used to propagate the transaction to
      * all inner method calls.
      *
      * @example
      * ```TypeScript
-     * private async transferCredit(fromId: ID, toId: ID, amount: number) {
-     *   await this.connection.withTransaction(ctx => {
+     * private async transferCredit(outerCtx: RequestContext, fromId: ID, toId: ID, amount: number) {
+     *   await this.connection.withTransaction(outerCtx, ctx => {
      *     await this.giftCardService.updateCustomerCredit(fromId, -amount);
+     * 
+     *     // Note you must not use outerCtx here, instead use ctx. Otherwise this query
+     *     // will be executed outside of transaction
+     *     await this.connection.getRepository(ctx, GiftCard).update(fromId, { transferred: true })
      *
      *     // If some intermediate logic here throws an Error,
      *     // then all DB transactions will be rolled back and neither Customer's


### PR DESCRIPTION
**The problem**
Current architecture of transaction and context guarantees that if one of operation inside of transaction block fails, whole transaction aborts. To bound queries to transaction we use getRepository(ctx, Entity) function, where ctx is the context which bound to transaction:
```
executeInTransaction(ctx, ctx => {
  await getRepository(ctx, Entity).update(...) // op1
  await getRepository(ctx, Entity2).delete(...) // op2
  ... lots of another ops
})
```
If op2 fails, then op1 and other ops in the transaction block aborts, that is what developer actually expects.

Say you have this code:
```
executeInTransaction(ctx, ctx => {
  op1 = getRepository(ctx, Entity).update(...)
  op2 = getRepository(ctx, Entity2).delete(...)
  await Promise.all([op1, op2, op3, opN...])
})
```
This way developer expects the same behavior as in previous example, but instead, if op2 fails, other operations may execute some queries outside of transaction as the result. This happens because of two things:
1. _Promise.all()_ does not abort promises that are already in process of execution
2. getRepository(ctx, Entity) contains check on _isReleased_ property of query runner: https://github.com/vendure-ecommerce/vendure/blob/b70cee883662281b5653ceaa12617c4d0b08a37a/packages/core/src/connection/transactional-connection.ts#L76.
So imagine that op1, op2 and op3 runs in parallel, if op2 fails, op3 may still execute _getRepository(ctx, Entity)_ at some point and you get repository with fresh QueryRunner instance, that is able to execute sql queries. 

**The solution**
1. Do not check _isReleased_ property, to ensure _getRepository(ctx, Entity)_ will get repository that is bound to released query runner. So released query runner will throw an exception in case of any query execute.
2. Copy RequestContext and pass copied instance to _executeInTransaction()_ function, to make sure that original context will be able to run queries outside of transaction.

**Note**
Since transaction binds to copied context, developer must execute queries using copied context, otherwise queries will run outside of transaction.