### PR TITLE
fix(core): Manage transactions outside of order modify function

### DIFF
--- a/packages/core/src/service/services/order.service.ts
+++ b/packages/core/src/service/services/order.service.ts
@@ -878,23 +878,26 @@ export class OrderService {
      * * Shipping or billing address changes
      *
      * Setting the `dryRun` input property to `true` will apply all changes, including updating the price of the
-     * Order, but will not actually persist any of those changes to the database.
+     * Order, except history entry and additional payment actions. 
+     * 
+     * __Using dryRun option, you must wrap function call in transaction manually.__
+     * 
      */
     async modifyOrder(
         ctx: RequestContext,
         input: ModifyOrderInput,
     ): Promise<ErrorResultUnion<ModifyOrderResult, Order>> {
-        await this.connection.startTransaction(ctx);
         const order = await this.getOrderOrThrow(ctx, input.orderId);
         const result = await this.orderModifier.modifyOrder(ctx, input, order);
-        if (input.dryRun) {
-            await this.connection.rollBackTransaction(ctx);
-            return isGraphQlErrorResult(result) ? result : result.order;
-        }
+
         if (isGraphQlErrorResult(result)) {
-            await this.connection.rollBackTransaction(ctx);
             return result;
         }
+
+        if (input.dryRun) {
+            return result.order;
+        }
+
         await this.historyService.createHistoryEntryForOrder({
             ctx,
             orderId: input.orderId,
@@ -903,7 +906,6 @@ export class OrderService {
                 modificationId: result.modification.id,
             },
         });
-        await this.connection.commitOpenTransaction(ctx);
         return this.getOrderOrThrow(ctx, input.orderId);
     }
 


### PR DESCRIPTION
**The problem**
Currently, it is impossible to have a  orderService.modifyOrder() call along with other logic in the same transaction, because internally modifyOrder() manages transaction itself. Slack thread: https://vendure-ecommerce.slack.com/archives/CKYMF0ZTJ/p1650625231400079

**The solution**
Move transaction logic outside of this function to resolver.

**Alternative solution**
Use nested transaction (save points). This is more elegant solution, but it requires typeorm update to 0.2.45 version (0.2.41 current), and introduces changes in core module. This is long-term issue which will be resolved later.