### PR TITLE
fix(core): Job update doesn't emit if progress didn't changed

### DIFF
--- a/packages/core/src/job-queue/subscribable-job.ts
+++ b/packages/core/src/job-queue/subscribable-job.ts
@@ -81,7 +81,7 @@ export class SubscribableJob<T extends JobData<T> = any> extends Job<T> {
                     return strategy.findOne(id);
                 }),
                 filter(notNullOrUndefined),
-                distinctUntilChanged((a, b) => a?.progress === b?.progress || a?.state === b?.state),
+                distinctUntilChanged((a, b) => a?.progress === b?.progress && a?.state === b?.state),
                 takeWhile(
                     job =>
                         job?.state !== JobState.FAILED &&


### PR DESCRIPTION
**The problem**
Currently, getting polling updates through `job.updates()` is not always possible, because of a mistake in operator `distinctUntilChanged`. Current logic is to ignore updates if `progress` OR `state` is equal to previous value. So if your job do not update progress, you will not receive any update through polling. Also this bug spawns a memory leak, because `takeUntil` operator placed after `distinctUntilChanged`

**The solution**
Change operator to ignore updates if `progress` AND `state` are equal to previous values.