### PR TITLE
feat(core): Pass payment method to handler and eligibility checker

### DIFF
--- a/packages/admin-ui/src/lib/core/src/public_api.ts
+++ b/packages/admin-ui/src/lib/core/src/public_api.ts
@@ -178,7 +178,6 @@ export * from './shared/directives/if-multichannel.directive';
 export * from './shared/directives/if-permissions.directive';
 export * from './shared/dynamic-form-inputs/boolean-form-input/boolean-form-input.component';
 export * from './shared/dynamic-form-inputs/code-editor-form-input/json-editor-form-input.component';
-export * from './shared/dynamic-form-inputs/combination-mode-form-input/combination-mode-form-input.component';
 export * from './shared/dynamic-form-inputs/currency-form-input/currency-form-input.component';
 export * from './shared/dynamic-form-inputs/customer-group-form-input/customer-group-form-input.component';
 export * from './shared/dynamic-form-inputs/date-form-input/date-form-input.component';

--- a/packages/admin-ui/src/lib/core/src/public_api.ts
+++ b/packages/admin-ui/src/lib/core/src/public_api.ts
@@ -178,6 +178,7 @@ export * from './shared/directives/if-multichannel.directive';
 export * from './shared/directives/if-permissions.directive';
 export * from './shared/dynamic-form-inputs/boolean-form-input/boolean-form-input.component';
 export * from './shared/dynamic-form-inputs/code-editor-form-input/json-editor-form-input.component';
+export * from './shared/dynamic-form-inputs/combination-mode-form-input/combination-mode-form-input.component';
 export * from './shared/dynamic-form-inputs/currency-form-input/currency-form-input.component';
 export * from './shared/dynamic-form-inputs/customer-group-form-input/customer-group-form-input.component';
 export * from './shared/dynamic-form-inputs/date-form-input/date-form-input.component';

--- a/packages/core/src/config/payment/dummy-payment-method-handler.ts
+++ b/packages/core/src/config/payment/dummy-payment-method-handler.ts
@@ -51,7 +51,7 @@ export const dummyPaymentHandler = new PaymentMethodHandler({
             defaultValue: false,
         },
     },
-    createPayment: async (ctx, order, amount, args, metadata) => {
+    createPayment: async (ctx, order, amount, args, metadata, method) => {
         if (metadata.shouldDecline) {
             return {
                 amount,
@@ -78,7 +78,7 @@ export const dummyPaymentHandler = new PaymentMethodHandler({
             };
         }
     },
-    settlePayment: async (ctx, order, payment, args) => {
+    settlePayment: async (ctx, order, payment, args, method) => {
         if (payment.metadata.shouldErrorOnSettle) {
             return {
                 success: false,

--- a/packages/core/src/config/payment/example-payment-method-handler.ts
+++ b/packages/core/src/config/payment/example-payment-method-handler.ts
@@ -29,7 +29,7 @@ export const examplePaymentHandler = new PaymentMethodHandler({
         automaticCapture: { type: 'boolean', required: false },
         apiKey: { type: 'string', required: false },
     },
-    createPayment: async (ctx, order, amount, args, metadata): Promise<CreatePaymentResult> => {
+    createPayment: async (ctx, order, amount, args, metadata, method): Promise<CreatePaymentResult> => {
         try {
             const result = await gripeSDK.charges.create({
                 apiKey: args.apiKey,
@@ -52,7 +52,7 @@ export const examplePaymentHandler = new PaymentMethodHandler({
             };
         }
     },
-    settlePayment: async (ctx, order, payment, args) => {
+    settlePayment: async (ctx, order, payment, args, method) => {
         const result = await gripeSDK.charges.capture(payment.transactionId);
         return {
             success: result,

--- a/packages/core/src/config/payment/payment-method-eligibility-checker.ts
+++ b/packages/core/src/config/payment/payment-method-eligibility-checker.ts
@@ -7,7 +7,7 @@ import {
     ConfigurableOperationDef,
     ConfigurableOperationDefOptions,
 } from '../../common/configurable-operation';
-import { Order } from '../../entity/order/order.entity';
+import { PaymentMethod, Order } from '../../entity';
 
 /**
  * @description
@@ -60,8 +60,8 @@ export class PaymentMethodEligibilityChecker<
      *
      * @internal
      */
-    async check(ctx: RequestContext, order: Order, args: ConfigArg[]): Promise<boolean | string> {
-        return this.checkFn(ctx, order, this.argsArrayToHash(args));
+    async check(ctx: RequestContext, order: Order, args: ConfigArg[], method: PaymentMethod): Promise<boolean | string> {
+        return this.checkFn(ctx, order, this.argsArrayToHash(args), method);
     }
 }
 
@@ -79,4 +79,5 @@ export type CheckPaymentMethodEligibilityCheckerFn<T extends ConfigArgs> = (
     ctx: RequestContext,
     order: Order,
     args: ConfigArgValues<T>,
+    method: PaymentMethod
 ) => boolean | string | Promise<boolean | string>;

--- a/packages/core/src/service/services/payment-method.service.ts
+++ b/packages/core/src/service/services/payment-method.service.ts
@@ -177,7 +177,7 @@ export class PaymentMethodService {
                     'PaymentMethodEligibilityChecker',
                     method.checker.code,
                 );
-                const eligible = await checker.check(ctx, order, method.checker.args);
+                const eligible = await checker.check(ctx, order, method.checker.args, method);
                 if (eligible === false || typeof eligible === 'string') {
                     isEligible = false;
                     eligibilityMessage = typeof eligible === 'string' ? eligible : undefined;

--- a/packages/core/src/service/services/payment.service.ts
+++ b/packages/core/src/service/services/payment.service.ts
@@ -117,7 +117,7 @@ export class PaymentService {
             method,
         );
         if (paymentMethod.checker && checker) {
-            const eligible = await checker.check(ctx, order, paymentMethod.checker.args);
+            const eligible = await checker.check(ctx, order, paymentMethod.checker.args, paymentMethod);
             if (eligible === false || typeof eligible === 'string') {
                 return new IneligiblePaymentMethodError(typeof eligible === 'string' ? eligible : undefined);
             }
@@ -128,6 +128,7 @@ export class PaymentService {
             amount,
             paymentMethod.handler.args,
             metadata || {},
+            paymentMethod,
         );
         const initialState = 'Created';
         const payment = await this.connection
@@ -162,6 +163,7 @@ export class PaymentService {
             payment.order,
             payment,
             paymentMethod.handler.args,
+            paymentMethod,
         );
         const fromState = payment.state;
         let toState: PaymentState;
@@ -288,6 +290,7 @@ export class PaymentService {
                 order,
                 paymentToRefund,
                 paymentMethod.handler.args,
+                paymentMethod,
             );
             if (createRefundResult) {
                 refund.transactionId = createRefundResult.transactionId || '';


### PR DESCRIPTION
Currently there is not way to get payment method for which handler and eligibility checker called. This PR adds such ability.