### PR TITLE
fix(elasticsearch-plugin): Fix permissions for pendingSearchIndexUpdates query

### DIFF
--- a/packages/elasticsearch-plugin/src/api/elasticsearch-resolver.ts
+++ b/packages/elasticsearch-plugin/src/api/elasticsearch-resolver.ts
@@ -70,7 +70,7 @@ export class AdminElasticSearchResolver implements Pick<SearchResolver, 'search'
     }
 
     @Query()
-    @Allow(Permission.UpdateCatalog, Permission.UpdateProduct)
+    @Allow(Permission.ReadCatalog, Permission.ReadProduct)
     async pendingSearchIndexUpdates(...args: any[]): Promise<any> {
         return this.searchJobBufferService.getPendingSearchUpdates();
     }


### PR DESCRIPTION
This [commit](https://github.com/vendure-ecommerce/vendure/commit/152e64b) updated the permissions for the `pendingSearchIndexUpdates` query for `SearchResolver` and `AdminFulltextSearchResolver` but missed `AdminElasticSearchResolver`. This PR aims to fix that problem.