### PR TITLE
feat(core): Deprecation of getRepository without context argument

### DIFF
--- a/packages/core/src/common/error/errors.ts
+++ b/packages/core/src/common/error/errors.ts
@@ -93,7 +93,9 @@ export class ChannelNotFoundError extends I18nError {
  * @docsPage Error Types
  */
 export class EntityNotFoundError extends I18nError {
-    constructor(entityName: keyof typeof coreEntitiesMap, id: ID) {
+    constructor(entityName: keyof typeof coreEntitiesMap, id: ID)
+    constructor(entityName: string, id: ID)
+    constructor(entityName: keyof typeof coreEntitiesMap | string, id: ID) {
         super('error.entity-with-id-not-found', { entityName, id }, 'ENTITY_NOT_FOUND', LogLevel.Warn);
     }
 }

--- a/packages/core/src/connection/transactional-connection.ts
+++ b/packages/core/src/connection/transactional-connection.ts
@@ -7,7 +7,6 @@ import {
     EntitySchema,
     FindOneOptions,
     FindOptionsUtils,
-    getRepository,
     ObjectType,
     Repository,
 } from 'typeorm';
@@ -55,6 +54,8 @@ export class TransactionalConnection {
      * Returns a TypeORM repository. Note that when no RequestContext is supplied, the repository will not
      * be aware of any existing transaction. Therefore calling this method without supplying a RequestContext
      * is discouraged without a deliberate reason.
+     * 
+     * @deprecated since 1.6.3: Use {@link TransactionalConnection.getOuterRepository getOuterRepository()} function instead.
      */
     getRepository<Entity>(target: ObjectType<Entity> | EntitySchema<Entity> | string): Repository<Entity>;
     /**
@@ -78,12 +79,26 @@ export class TransactionalConnection {
                 return transactionManager.getRepository(maybeTarget!);
             } else {
                 // tslint:disable-next-line:no-non-null-assertion
-                return getRepository(maybeTarget!);
+                return this.getOuterRepository(maybeTarget!);
             }
         } else {
             // tslint:disable-next-line:no-non-null-assertion
-            return getRepository(ctxOrTarget ?? maybeTarget!);
+            return this.getOuterRepository(ctxOrTarget ?? maybeTarget!);
         }
+    }
+
+    /**
+     * @description
+     * Returns a TypeORM repository, which is not aware of any existing transaction. 
+     * Therefore calling this method is discouraged without a deliberate reason.
+     * It's recommended to use {@link TransactionalConnection.getRepository getRepository(ctx, Entity)} instead.
+     * 
+     * @since 1.6.3
+     */
+    getOuterRepository<Entity>(
+        target: ObjectType<Entity> | EntitySchema<Entity> | string
+    ): Repository<Entity> {
+        return this.rawConnection.getRepository(target);
     }
 
     /**

--- a/packages/core/src/connection/transactional-connection.ts
+++ b/packages/core/src/connection/transactional-connection.ts
@@ -55,7 +55,7 @@ export class TransactionalConnection {
      * be aware of any existing transaction. Therefore calling this method without supplying a RequestContext
      * is discouraged without a deliberate reason.
      * 
-     * @deprecated since 1.6.3: Use {@link TransactionalConnection.getOuterRepository getOuterRepository()} function instead.
+     * @deprecated since 1.7.0: Use {@link TransactionalConnection.rawConnection rawConnection.getRepository()} function instead.
      */
     getRepository<Entity>(target: ObjectType<Entity> | EntitySchema<Entity> | string): Repository<Entity>;
     /**
@@ -79,26 +79,12 @@ export class TransactionalConnection {
                 return transactionManager.getRepository(maybeTarget!);
             } else {
                 // tslint:disable-next-line:no-non-null-assertion
-                return this.getOuterRepository(maybeTarget!);
+                return this.rawConnection.getRepository(maybeTarget!);
             }
         } else {
             // tslint:disable-next-line:no-non-null-assertion
-            return this.getOuterRepository(ctxOrTarget ?? maybeTarget!);
+            return this.rawConnection.getRepository(ctxOrTarget ?? maybeTarget!);
         }
-    }
-
-    /**
-     * @description
-     * Returns a TypeORM repository, which is not aware of any existing transaction. 
-     * Therefore calling this method is discouraged without a deliberate reason.
-     * It's recommended to use {@link TransactionalConnection.getRepository getRepository(ctx, Entity)} instead.
-     * 
-     * @since 1.6.3
-     */
-    getOuterRepository<Entity>(
-        target: ObjectType<Entity> | EntitySchema<Entity> | string
-    ): Repository<Entity> {
-        return this.rawConnection.getRepository(target);
     }
 
     /**


### PR DESCRIPTION
**Motivation**
Having getRepository() with optional RequestContext argument is not safe:
```
withTransaction(ctx, ctx => {
  await getRepository(ctx, User).create(...)
  await getRepository(Administrator).create(...) <--- A serious mistake here, this query will be out of transaction.
});
```
Therefore current way to get repository from connection is error prone: it's simple to forget to pass context. 

**Solution**
Deprecate getRepository(Entity) function without RequestContext argument. Introduce `getOuterRepository()` function to enforce explicitly usage.
```
withTransaction(ctx, ctx => {
  await getRepository(ctx, User).create(...)
  await getRepository(Administrator).create(...) <--- A deprecation warning thrown by IDE. Developer should pay an attention
  // If this is intended behavior, developer should use
  // await getOuterRepository(Administrator).create(...) <--- No warning here
});
```

**Bonus**
Allow to construct new EntityNotFoundError with custom entity.

**Further steps**
Completely remove signature of getRepository without RequestContext argument in v2.0. 