### PR TITLE
feat(core): Declare setDefaultContext in VendureLogger

### DIFF
--- a/packages/core/src/bootstrap.ts
+++ b/packages/core/src/bootstrap.ts
@@ -98,9 +98,7 @@ export async function bootstrap(userConfig: Partial<VendureConfig>): Promise<INe
 export async function bootstrapWorker(userConfig: Partial<VendureConfig>): Promise<VendureWorker> {
     const vendureConfig = await preBootstrapConfig(userConfig);
     const config = disableSynchronize(vendureConfig);
-    if (config.logger instanceof DefaultLogger) {
-        config.logger.setDefaultContext('Vendure Worker');
-    }
+    config.logger.setDefaultContext?.('Vendure Worker');
     Logger.useLogger(config.logger);
     Logger.info(`Bootstrapping Vendure Worker (pid: ${process.pid})...`);
 

--- a/packages/core/src/config/logger/vendure-logger.ts
+++ b/packages/core/src/config/logger/vendure-logger.ts
@@ -50,6 +50,7 @@ export interface VendureLogger {
     info(message: string, context?: string): void;
     verbose(message: string, context?: string): void;
     debug(message: string, context?: string): void;
+    setDefaultContext?(defaultContext: string): void;
 }
 
 const noopLogger: VendureLogger = {

--- a/packages/dev-server/dev-config.ts
+++ b/packages/dev-server/dev-config.ts
@@ -67,7 +67,7 @@ export const devConfig: VendureConfig = {
         }),
         DefaultSearchPlugin.init({ bufferUpdates: true, indexStockStatus: false }),
         BullMQJobQueuePlugin.init({}),
-        // DefaultJobQueuePlugin.init(),
+        // DefaultJobQueuePlugin.init({}),
         // JobQueueTestPlugin.init({ queueCount: 10 }),
         // ElasticsearchPlugin.init({
         //     host: 'http://localhost',


### PR DESCRIPTION
### Context:

Our application uses a custom [Winston](https://github.com/winstonjs/winston) logger implementing `VendureLogger`, which behind the scenes sends logs to New Relic but whose output is similar to `DefaultLogger`. At first, we had quite a few log entries with an "[undefined]" prefix because, in different places, messages are logged without a `context` parameter. `DefaultLogger` handles this scenario by internally defining a "VendureServer" default context, which is overridden by the worker process to use "VendureWorker" instead. However, this logic is not flexible and only applies to instances of `DefaultLogger`.

### Proposed solution:

The idea is to define `setDefaultContext` as an optional method of `VendureLogger` - therefore not resulting in breaking changes - and update `bootstrapWorker` to call the function only if defined in the logger object. This way, custom implementations of `VendureLogger` can also benefit of such functionality if they deem so.

Another tiny update was on a commented out line of code from `dev-server/dev-config.ts`: `DefaultJobQueuePlugin.init` expects an object as an argument.