### PR TITLE
fix(default-search-plugin): Language fallback

### DIFF
--- a/packages/core/e2e/default-search-plugin.e2e-spec.ts
+++ b/packages/core/e2e/default-search-plugin.e2e-spec.ts
@@ -1541,7 +1541,7 @@ describe('Default search plugin', () => {
                     SEARCH_PRODUCTS,
                     {
                         input: {
-                            take: 1,
+                            take: 100,
                         },
                     },
                     {
@@ -1592,25 +1592,34 @@ describe('Default search plugin', () => {
                 await awaitRunningJobs(adminClient);
             });
 
+            it('fallbacks to default language', async () => {
+                const { search } = await searchInLanguage(LanguageCode.af)
+                // No records for AF language, but we expect > 0
+                // because of fallback to default language (EN)
+                expect(search.totalItems).toBeGreaterThan(0);
+            })
+
             it('indexes product-level languages', async () => {
                 const {search: search1} = await searchInLanguage(LanguageCode.de);
 
-                expect(search1.items[0].productName).toBe('laptop name de');
-                expect(search1.items[0].slug).toBe('laptop-slug-de');
-                expect(search1.items[0].description).toBe('laptop description de');
+                expect(search1.items.map(i => i.productName)).toContain('laptop name de');
+                expect(search1.items.map(i => i.productName)).not.toContain('laptop name zh')
+                expect(search1.items.map(i => i.slug)).toContain('laptop-slug-de');
+                expect(search1.items.map(i => i.description)).toContain('laptop description de');
 
                 const {search: search2} = await searchInLanguage(LanguageCode.zh);
 
-                expect(search2.items[0].productName).toBe('laptop name zh');
-                expect(search2.items[0].slug).toBe('laptop-slug-zh');
-                expect(search2.items[0].description).toBe('laptop description zh');
+                expect(search2.items.map(i => i.productName)).toContain('laptop name zh');
+                expect(search2.items.map(i => i.productName)).not.toContain('laptop name de');
+                expect(search2.items.map(i => i.slug)).toContain('laptop-slug-zh');
+                expect(search2.items.map(i => i.description)).toContain('laptop description zh');
             });
 
             it('indexes product variant-level languages', async () => {
                 const {search: search1} = await searchInLanguage(LanguageCode.fr);
 
-                expect(search1.items[0].productName).toBe('Laptop');
-                expect(search1.items[0].productVariantName).toBe('laptop variant fr');
+                expect(search1.items.map(i => i.productName)).toContain('Laptop');
+                expect(search1.items.map(i => i.productVariantName)).toContain('laptop variant fr');
             });
         });
     });

--- a/packages/core/src/plugin/default-search-plugin/search-strategy/mysql-search-strategy.ts
+++ b/packages/core/src/plugin/default-search-plugin/search-strategy/mysql-search-strategy.ts
@@ -41,7 +41,7 @@ export class MysqlSearchStrategy implements SearchStrategy {
         const facetValuesQb = this.connection
             .getRepository(ctx, SearchIndexItem)
             .createQueryBuilder('si')
-            .select(['MIN(si.productId)', 'MIN(productVariantId)'])
+            .select(['MIN(si.productId)', 'MIN(si.productVariantId)'])
             .addSelect('GROUP_CONCAT(si.facetValueIds)', 'facetValues');
 
         this.applyTermAndFilters(ctx, facetValuesQb, { ...input, groupByProduct: true });

--- a/packages/core/src/plugin/default-search-plugin/search-strategy/mysql-search-strategy.ts
+++ b/packages/core/src/plugin/default-search-plugin/search-strategy/mysql-search-strategy.ts
@@ -170,7 +170,7 @@ export class MysqlSearchStrategy implements SearchStrategy {
                             .orWhere('MATCH (si_inner.description) AGAINST (:term IN BOOLEAN MODE)');
                     }),
                 )
-                .andWhere('si.channelId = :channelId')
+                .andWhere('si_inner.channelId = :channelId')
                 .setParameters({ term: `${term}*`, like_term: `%${term}%`, channelId: ctx.channelId });
 
             qb.innerJoin(`(${termScoreQuery.getQuery()})`, 'term_result', 'inner_productId = si.productId')

--- a/packages/core/src/plugin/default-search-plugin/search-strategy/mysql-search-strategy.ts
+++ b/packages/core/src/plugin/default-search-plugin/search-strategy/mysql-search-strategy.ts
@@ -154,20 +154,20 @@ export class MysqlSearchStrategy implements SearchStrategy {
                 .createQueryBuilder('si_inner')
                 .select('si_inner.productId', 'inner_productId')
                 .addSelect('si_inner.productVariantId', 'inner_productVariantId')
-                .addSelect(`IF (si.sku LIKE :like_term, 10, 0)`, 'sku_score')
+                .addSelect(`IF (si_inner.sku LIKE :like_term, 10, 0)`, 'sku_score')
                 .addSelect(
                     `(SELECT sku_score) +
-                     MATCH (si.productName) AGAINST (:term IN BOOLEAN MODE) * 2 +
-                     MATCH (si.productVariantName) AGAINST (:term IN BOOLEAN MODE) * 1.5 +
-                     MATCH (si.description) AGAINST (:term IN BOOLEAN MODE) * 1`,
+                     MATCH (si_inner.productName) AGAINST (:term IN BOOLEAN MODE) * 2 +
+                     MATCH (si_inner.productVariantName) AGAINST (:term IN BOOLEAN MODE) * 1.5 +
+                     MATCH (si_inner.description) AGAINST (:term IN BOOLEAN MODE) * 1`,
                     'score',
                 )
                 .where(
                     new Brackets(qb1 => {
-                        qb1.where('si.sku LIKE :like_term')
-                            .orWhere('MATCH (si.productName) AGAINST (:term IN BOOLEAN MODE)')
-                            .orWhere('MATCH (si.productVariantName) AGAINST (:term IN BOOLEAN MODE)')
-                            .orWhere('MATCH (si.description) AGAINST (:term IN BOOLEAN MODE)');
+                        qb1.where('si_inner.sku LIKE :like_term')
+                            .orWhere('MATCH (si_inner.productName) AGAINST (:term IN BOOLEAN MODE)')
+                            .orWhere('MATCH (si_inner.productVariantName) AGAINST (:term IN BOOLEAN MODE)')
+                            .orWhere('MATCH (si_inner.description) AGAINST (:term IN BOOLEAN MODE)');
                     }),
                 )
                 .andWhere('si.channelId = :channelId')
@@ -238,7 +238,7 @@ export class MysqlSearchStrategy implements SearchStrategy {
         if (collectionSlug) {
             qb.andWhere(`FIND_IN_SET (:collectionSlug, si.collectionSlugs)`, { collectionSlug });
         }
-        
+
         applyLanguageConstraints(qb, ctx.languageCode, ctx.channel.defaultLanguageCode);
         qb.andWhere('si.channelId = :channelId', { channelId: ctx.channelId });
         if (input.groupByProduct === true) {

--- a/packages/core/src/plugin/default-search-plugin/search-strategy/postgres-search-strategy.ts
+++ b/packages/core/src/plugin/default-search-plugin/search-strategy/postgres-search-strategy.ts
@@ -13,6 +13,7 @@ import { DefaultSearchPluginInitOptions, SearchInput } from '../types';
 import { SearchStrategy } from './search-strategy';
 import { getFieldsToSelect } from './search-strategy-common';
 import {
+    applyLanguageConstraints,
     createCollectionIdCountMap,
     createFacetIdCountMap,
     createPlaceholderFromId,
@@ -89,10 +90,10 @@ export class PostgresSearchStrategy implements SearchStrategy {
             .createQueryBuilder('si')
             .select(this.createPostgresSelect(!!input.groupByProduct));
         if (input.groupByProduct) {
-            qb.addSelect('MIN(price)', 'minPrice')
-                .addSelect('MAX(price)', 'maxPrice')
-                .addSelect('MIN("priceWithTax")', 'minPriceWithTax')
-                .addSelect('MAX("priceWithTax")', 'maxPriceWithTax');
+            qb.addSelect('MIN(si.price)', 'minPrice')
+                .addSelect('MAX(si.price)', 'maxPrice')
+                .addSelect('MIN(si.priceWithTax)', 'minPriceWithTax')
+                .addSelect('MAX(si.priceWithTax)', 'maxPriceWithTax');
         }
         this.applyTermAndFilters(ctx, qb, input);
 
@@ -243,7 +244,8 @@ export class PostgresSearchStrategy implements SearchStrategy {
                 collectionSlug,
             });
         }
-        qb.andWhere('si.languageCode = :languageCode', { languageCode: ctx.languageCode });
+        
+        applyLanguageConstraints(qb, ctx.languageCode, ctx.channel.defaultLanguageCode);
         qb.andWhere('si.channelId = :channelId', { channelId: ctx.channelId });
         if (input.groupByProduct === true) {
             qb.groupBy('si.productId');

--- a/packages/core/src/plugin/default-search-plugin/search-strategy/search-strategy-common.ts
+++ b/packages/core/src/plugin/default-search-plugin/search-strategy/search-strategy-common.ts
@@ -22,6 +22,14 @@ export const fieldsToSelect = [
     'productVariantPreviewFocalPoint',
 ];
 
+export const identifierFields = [
+    'channelId',
+    'productVariantId',
+    'productId',
+    'productAssetId',
+    'productVariantAssetId',
+]
+
 export function getFieldsToSelect(includeStockStatus: boolean = false) {
     return includeStockStatus ? [...fieldsToSelect, 'inStock', 'productInStock'] : fieldsToSelect;
 }

--- a/packages/core/src/plugin/default-search-plugin/search-strategy/search-strategy-utils.ts
+++ b/packages/core/src/plugin/default-search-plugin/search-strategy/search-strategy-utils.ts
@@ -1,6 +1,7 @@
 import {
     Coordinate,
     CurrencyCode,
+    LanguageCode,
     PriceRange,
     SearchResult,
     SearchResultAsset,
@@ -8,6 +9,9 @@ import {
 } from '@vendure/common/lib/generated-types';
 import { ID } from '@vendure/common/lib/shared-types';
 import { unique } from '@vendure/common/lib/unique';
+import { QueryBuilder, SelectQueryBuilder } from 'typeorm';
+import { SearchIndexItem } from '../entities/search-index-item.entity';
+import { identifierFields } from './search-strategy-common';
 
 /**
  * Maps a raw database result to a SearchResult.
@@ -109,4 +113,41 @@ function parseFocalPoint(focalPoint: any): Coordinate | undefined {
 
 export function createPlaceholderFromId(id: ID): string {
     return '_' + id.toString().replace(/-/g, '_');
+}
+
+/**
+ * Applies language constraints for {@link SearchIndexItem} query.
+ * 
+ * @param qb QueryBuilder instance
+ * @param languageCode Preferred language code
+ * @param defaultLanguageCode Default language code that is used if {@link SearchIndexItem} is not available in preferred language
+ */
+export function applyLanguageConstraints(
+    qb: SelectQueryBuilder<SearchIndexItem>,
+    languageCode: LanguageCode,
+    defaultLanguageCode: LanguageCode,
+) {
+    if (languageCode == defaultLanguageCode) {
+        qb.andWhere('si.languageCode = :languageCode', { languageCode: languageCode });
+    } else {
+        qb.andWhere('si.languageCode IN (:...languageCodes)', {
+            languageCodes: [languageCode, defaultLanguageCode],
+        });
+
+        const joinFieldConditions = identifierFields
+            .map(field => `si.${field} = sil.${field}`)
+            .join(' AND ');
+
+        qb.leftJoin(SearchIndexItem, 'sil', `
+            ${joinFieldConditions}
+            AND si.languageCode != sil.languageCode
+            AND sil.languageCode = :languageCode
+        `, {
+            languageCode: languageCode,
+        });
+
+        qb.andWhere('sil.languageCode IS NULL');
+    }
+
+    return qb;
 }


### PR DESCRIPTION
**Motivation**
Say you have a product with EN translation. You use default search plugin, and two languages are available: EN, AZ.
Searching product with EN languageCode gives you a product, but when you search AZ, results are empty. 
My expectations around this, to be product available in AZ search, but it should be in default translation, which is determined by channel's `defaultLanguageCode `, so in EN.

**Solution**
Use `LEFT JOIN` clause on the same table, to join identical records but with default language code, if preferred language code and default one are different. 
Example generated query:
```sql
SELECT
  "si"."languageCode" AS "si_languageCode",
  "si"."enabled" AS "si_enabled",
  "si"."productName" AS "si_productName",
  "si"."productVariantName" AS "si_productVariantName",
  "si"."description" AS "si_description",
  "si"."slug" AS "si_slug",
  "si"."sku" AS "si_sku",
  "si"."price" AS "si_price",
  "si"."priceWithTax" AS "si_priceWithTax",
  "si"."facetIds" AS "si_facetIds",
  "si"."facetValueIds" AS "si_facetValueIds",
  "si"."collectionIds" AS "si_collectionIds",
  "si"."collectionSlugs" AS "si_collectionSlugs",
  "si"."channelIds" AS "si_channelIds",
  "si"."productPreview" AS "si_productPreview",
  "si"."productPreviewFocalPoint" AS "si_productPreviewFocalPoint",
  "si"."productVariantPreview" AS "si_productVariantPreview",
  "si"."productVariantPreviewFocalPoint" AS "si_productVariantPreviewFocalPoint",
  "si"."inStock" AS "si_inStock",
  "si"."productInStock" AS "si_productInStock",
  "si"."productVariantId" AS "si_productVariantId",
  "si"."channelId" AS "si_channelId",
  "si"."productId" AS "si_productId",
  "si"."productAssetId" AS "si_productAssetId",
  "si"."productVariantAssetId" AS "si_productVariantAssetId"
FROM
  "search_index_item" "si"
  LEFT JOIN "search_index_item" "sil" ON "si"."productVariantId" = "sil"."productVariantId"
  AND "si"."channelId" = "sil"."channelId"
  AND "si"."productId" = "sil"."productId"
  AND "si"."productAssetId" = "sil"."productAssetId"
  AND "si"."productVariantAssetId" = "sil"."productVariantAssetId"
  AND "si"."languageCode" != "sil"."languageCode"
  AND "sil"."languageCode" = 'az'
WHERE
  1 = 1
  AND "si"."languageCode" IN ('az, 'en')
  AND "sil"."languageCode" IS NULL
  AND "si"."channelId" = 2
ORDER BY
  "si"."productVariantId" ASC
```
**Implementation Notes**
Because of join, we should use prefix `si.` everywhere, this was already has been done, except a few places. 

**Additional Context**
Slack thread: https://vendure-ecommerce.slack.com/archives/CKYMF0ZTJ/p1658917239434719