### PR TITLE
fix(admin-ui): Lib es2019 so ts understands array.flat

### DIFF
--- a/packages/admin-ui/tsconfig.json
+++ b/packages/admin-ui/tsconfig.json
@@ -21,7 +21,7 @@
       "./typings"
     ],
     "lib": [
-      "es2017",
+      "es2019",
       "dom",
       "esnext.asynciterable"
     ],

--- a/packages/admin-ui/tsconfig.lib.json
+++ b/packages/admin-ui/tsconfig.lib.json
@@ -8,6 +8,7 @@
     "inlineSources": true,
     "types": [],
     "lib": [
+      "es2019",
       "dom",
       "es2018"
     ]


### PR DESCRIPTION
Prevents build error `Property 'flat' does not exist on type 'string[][]'`

```shell
✔ Bundling to UMD
- Writing package metadata
✔ Writing package metadata
✔ Built @vendure/admin-ui/core
- Compiling with Angular in legacy View Engine compilation mode.
✖ Compiling with Angular in legacy View Engine compilation mode.
src/lib/catalog/src/components/product-variants-editor/product-variants-editor.component.ts:492:98 - error TS2550: Property 'flat' does not exist on type 'string[][]'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2019' or later.

492                 const allUsedOptionIds = p.variants.map(v => v.options.map(option => option.id)).flat();
                                                                                                     ~~~~
src/lib/catalog/src/components/product-variants-editor/product-variants-editor.component.ts:495:22 - error TS2550: Property 'flat' does not exist on type 'string[][]'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2019' or later.

495                     .flat();
```