### PR TITLE
fix(core): Transition from AddingItems to custom state with an empty order lines

### DIFF
--- a/packages/core/src/service/helpers/order-state-machine/order-state-machine.ts
+++ b/packages/core/src/service/helpers/order-state-machine/order-state-machine.ts
@@ -108,7 +108,7 @@ export class OrderStateMachine {
                 return `message.cannot-transition-from-arranging-additional-payment`;
             }
         }
-        if (fromState === 'AddingItems' && toState !== 'Cancelled') {
+        if (fromState === 'AddingItems' && toState !== 'Cancelled' && data.order.lines.length > 0) {
             const variantIds = unique(data.order.lines.map(l => l.productVariant.id));
             const qb = this.connection
                 .getRepository(data.ctx, ProductVariant)


### PR DESCRIPTION
Fixes this: https://github.com/vendure-ecommerce/vendure/issues/1735
Slack thread: https://vendure-ecommerce.slack.com/archives/CKYMF0ZTJ/p1661264397433399

In case of spreading an empty array into query builder, typeorm leaves an empty brackets in clause: `IN ()`, which is interpreted by database as a syntax error. To accomplish that, an additional check added.