### PR TITLE
feat(core): Pass order as an additional argument to strategies

### DIFF
--- a/packages/core/src/config/order/changed-price-handling-strategy.ts
+++ b/packages/core/src/config/order/changed-price-handling-strategy.ts
@@ -2,6 +2,7 @@ import { RequestContext } from '../../api/common/request-context';
 import { PriceCalculationResult } from '../../common/types/common-types';
 import { InjectableStrategy } from '../../common/types/injectable-strategy';
 import { OrderItem } from '../../entity/order-item/order-item.entity';
+import { Order } from '../../entity/order/order.entity';
 
 /**
  * @description
@@ -25,5 +26,6 @@ export interface ChangedPriceHandlingStrategy extends InjectableStrategy {
         ctx: RequestContext,
         current: PriceCalculationResult,
         existingItems: OrderItem[],
+        order: Order,
     ): PriceCalculationResult | Promise<PriceCalculationResult>;
 }

--- a/packages/core/src/config/order/order-item-price-calculation-strategy.ts
+++ b/packages/core/src/config/order/order-item-price-calculation-strategy.ts
@@ -1,6 +1,7 @@
 import { RequestContext } from '../../api/common/request-context';
 import { PriceCalculationResult } from '../../common/types/common-types';
 import { InjectableStrategy } from '../../common/types/injectable-strategy';
+import { Order } from '../../entity/order/order.entity';
 import { ProductVariant } from '../../entity/product-variant/product-variant.entity';
 
 /**
@@ -53,5 +54,6 @@ export interface OrderItemPriceCalculationStrategy extends InjectableStrategy {
         ctx: RequestContext,
         productVariant: ProductVariant,
         orderLineCustomFields: { [key: string]: any },
+        order: Order,
     ): PriceCalculationResult | Promise<PriceCalculationResult>;
 }

--- a/packages/core/src/service/services/order-testing.service.ts
+++ b/packages/core/src/service/services/order-testing.service.ts
@@ -135,6 +135,7 @@ export class OrderTestingService {
                 ctx,
                 productVariant,
                 orderLine.customFields || {},
+                mockOrder
             );
             const taxRate = productVariant.taxRateApplied;
             const unitPrice = priceIncludesTax ? taxRate.netPriceOf(price) : price;

--- a/packages/core/src/service/services/order.service.ts
+++ b/packages/core/src/service/services/order.service.ts
@@ -1706,6 +1706,7 @@ export class OrderService {
                     ctx,
                     variant,
                     updatedOrderLine.customFields || {},
+                    order
                 );
                 const initialListPrice =
                     updatedOrderLine.items.find(i => i.initialListPrice != null)?.initialListPrice ??
@@ -1715,6 +1716,7 @@ export class OrderService {
                         ctx,
                         priceResult,
                         updatedOrderLine.items,
+                        order,
                     );
                 }
                 for (const item of updatedOrderLine.items) {


### PR DESCRIPTION
**Motivation**
Say you want to sell first two order items of the same order line for free. To be able to do this, you need an order instance to get an access to other order lines.

**Solution**
Just pass order as an argument to strategies. It's available at every call of strategies methods.

**Alternatives**
Not sure, whether it would work, but it's theoretically possible to get active order from context, but it's just an extra operation, which could be eliminated by passing order from the outside.