### PR TITLE
feat(admin,shop): enable tags on assets for shop api

### DIFF
--- a/packages/core/src/api/schema/admin-api/asset-admin.type.graphql
+++ b/packages/core/src/api/schema/admin-api/asset-admin.type.graphql
@@ -1,3 +1,0 @@
-type Asset {
-    tags: [Tag!]!
-}

--- a/packages/core/src/api/schema/common/asset.type.graphql
+++ b/packages/core/src/api/schema/common/asset.type.graphql
@@ -11,6 +11,7 @@ type Asset implements Node {
     source: String!
     preview: String!
     focalPoint: Coordinate
+    tags: [Tag!]!
 }
 
 type Coordinate {


### PR DESCRIPTION
Enable to retrieve tags on asset for the shop API

* remove the `admin-api` specificity
* add `tags` on common asset type