### PR TITLE
refactor(core): use existing function to update product variant price

### DIFF
--- a/packages/core/src/service/services/product-variant.service.ts
+++ b/packages/core/src/service/services/product-variant.service.ts
@@ -493,18 +493,7 @@ export class ProductVariantService {
         });
         await this.customFieldRelationService.updateRelations(ctx, ProductVariant, input, updatedVariant);
         if (input.price != null) {
-            const variantPriceRepository = this.connection.getRepository(ctx, ProductVariantPrice);
-            const variantPrice = await variantPriceRepository.findOne({
-                where: {
-                    variant: input.id,
-                    channelId: ctx.channelId,
-                },
-            });
-            if (!variantPrice) {
-                throw new InternalServerError(`error.could-not-find-product-variant-price`);
-            }
-            variantPrice.price = input.price;
-            await variantPriceRepository.save(variantPrice);
+            await this.createOrUpdateProductVariantPrice(ctx, input.id, input.price, ctx.channelId);
         }
         return updatedVariant.id;
     }


### PR DESCRIPTION
**Motivation**
I'm using an overriden version of `createOrUpdateProductVariantPrice` in my project, but since this is not correctly used on update, custom behavior does not apply.

**Solution**
Just use existing function on update