### PR TITLE
feat: Allow to override email language

### DIFF
--- a/packages/email-plugin/src/event-handler.ts
+++ b/packages/email-plugin/src/event-handler.ts
@@ -130,6 +130,7 @@ import {
  */
 export class EmailEventHandler<T extends string = string, Event extends EventWithContext = EventWithContext> {
     private setRecipientFn: (event: Event) => string;
+    private setLanguageCodeFn: (event: Event) => LanguageCode | undefined;
     private setTemplateVarsFn: SetTemplateVarsFn<Event>;
     private setAttachmentsFn?: SetAttachmentsFn<Event>;
     private setOptionalAddressFieldsFn?: SetOptionalAddressFieldsFn<Event>;
@@ -175,6 +176,19 @@ export class EmailEventHandler<T extends string = string, Event extends EventWit
      */
     setRecipient(setRecipientFn: (event: Event) => string): EmailEventHandler<T, Event> {
         this.setRecipientFn = setRecipientFn;
+        return this;
+    }
+
+    /**
+     * @description
+     * A function which allows to override the language of the email. If not defined, the language from the context will be used.
+     *
+     * @since 1.8.0
+     */
+    setLanguageCode(
+        setLanguageCodeFn: (event: Event) => LanguageCode | undefined,
+    ): EmailEventHandler<T, Event> {
+        this.setLanguageCodeFn = setLanguageCodeFn;
         return this;
     }
 
@@ -343,7 +357,8 @@ export class EmailEventHandler<T extends string = string, Event extends EventWit
             );
         }
         const { ctx } = event;
-        const configuration = this.getBestConfiguration(ctx.channel.code, ctx.languageCode);
+        const languageCode = this.setLanguageCodeFn?.(event) || ctx.languageCode;
+        const configuration = this.getBestConfiguration(ctx.channel.code, languageCode);
         const subject = configuration ? configuration.subject : this.defaultSubject;
         if (subject == null) {
             throw new Error(

--- a/packages/email-plugin/src/plugin.spec.ts
+++ b/packages/email-plugin/src/plugin.spec.ts
@@ -369,6 +369,28 @@ describe('EmailPlugin', () => {
             expect(onSend.mock.calls[1][0].subject).toBe('Servus, Test!');
             expect(onSend.mock.calls[1][0].body).toContain('German body.');
         });
+
+        it('set LanguageCode', async () => {
+            const handler = new EmailEventListener('test')
+                .on(MockEvent)
+                .setFrom('"test from" <noreply@test.com>')
+                .setSubject('Hello, {{ name }}!')
+                .setRecipient(() => 'test@test.com')
+                .setLanguageCode(() => LanguageCode.de)
+                .setTemplateVars(() => ({ name: 'Test' }))
+                .addTemplate({
+                    channelCode: 'default',
+                    languageCode: LanguageCode.de,
+                    templateFile: 'body.de.hbs',
+                    subject: 'Servus, {{ name }}!',
+                });
+
+            const ctxEn = RequestContext.deserialize({ ...ctx, _languageCode: LanguageCode.en } as any);
+            eventBus.publish(new MockEvent(ctxEn, true));
+            await pause();
+            expect(onSend.mock.calls[1][0].subject).toBe('Servus, Test!');
+            expect(onSend.mock.calls[1][0].body).toContain('German body.');
+        });
     });
 
     describe('loadData', () => {


### PR DESCRIPTION
As discussed on Slack earlier, this feature allows to set the languageCode of an email manually instead of taking it from the context.