### PR TITLE
fix(core): 'productVariantId' in group statement is ambiguous

### DIFF
--- a/packages/core/src/plugin/default-search-plugin/search-strategy/mysql-search-strategy.ts
+++ b/packages/core/src/plugin/default-search-plugin/search-strategy/mysql-search-strategy.ts
@@ -46,7 +46,7 @@ export class MysqlSearchStrategy implements SearchStrategy {
 
         this.applyTermAndFilters(ctx, facetValuesQb, { ...input, groupByProduct: true });
         if (!input.groupByProduct) {
-            facetValuesQb.groupBy('productVariantId');
+            facetValuesQb.groupBy('si.productVariantId');
         }
         if (enabledOnly) {
             facetValuesQb.andWhere('si.enabled = :enabled', { enabled: true });


### PR DESCRIPTION
When you uncheck `Group by product`  in Products view we have this MySQL Error (with red notification in admin interface):

`ERROR 1052 (23000): Column 'productVariantId' in group statement is ambiguous`

This is the generated SQL Query:
```sql
SELECT MIN(`si`.`productId`), MIN(`si`.`productVariantId`), GROUP_CONCAT(`si`.`facetValueIds`) AS `facetValues`, 1 as score, BIT_OR(`si`.`enabled`) AS `productEnabled` FROM `search_index_item` `si` LEFT JOIN `search_index_item` `sil` ON              `si`.`channelId` = `sil`.`channelId` AND `si`.`productVariantId` = `sil`.`productVariantId` AND `si`.`productId` = `sil`.`productId` AND `si`.`productAssetId` = `sil`.`productAssetId` AND `si`.`productVariantAssetId` = `sil`.`productVariantAssetId`             AND `si`.`languageCode` != `sil`.`languageCode`             AND `sil`.`languageCode` = 'en'          WHERE `si`.`languageCode` IN ('en', 'fr') AND `sil`.`languageCode` IS NULL AND `si`.`channelId` = '5c4c2665-118a-483e-85d8-083980424196' GROUP BY productVariantId;
```