### PR TITLE
fix(core): Export translator.service from core

### DIFF
--- a/packages/core/src/service/index.ts
+++ b/packages/core/src/service/index.ts
@@ -16,6 +16,7 @@ export * from './helpers/product-price-applicator/product-price-applicator';
 export * from './helpers/refund-state-machine/refund-state';
 export * from './helpers/request-context/request-context.service';
 export * from './helpers/translatable-saver/translatable-saver';
+export * from './helpers/translator/translator.service';
 export * from './helpers/utils/patch-entity';
 export * from './helpers/utils/translate-entity';
 export * from './helpers/verification-token-generator/verification-token-generator';


### PR DESCRIPTION
Added the translator service to the index.ts to be able to use it in the implementation.
Will allow it to be imported in `@vendure/core` instead of `@vendure/core/dist/service/helpers/translator/translator.service`