### PR TITLE
fix(core): Order fixed discount considers channel pricesIncludeTax

### DIFF
--- a/packages/core/src/config/promotion/actions/order-fixed-discount-action.ts
+++ b/packages/core/src/config/promotion/actions/order-fixed-discount-action.ts
@@ -13,7 +13,8 @@ export const orderFixedDiscount = new PromotionOrderAction({
         },
     },
     execute(ctx, order, args) {
-        return -Math.min(args.discount, order.subTotal);
+        const upperBound = ctx.channel.pricesIncludeTax ? order.subTotalWithTax : order.subTotal;
+        return -Math.min(args.discount, upperBound);
     },
     description: [{ languageCode: LanguageCode.en, value: 'Discount order by fixed amount' }],
 });


### PR DESCRIPTION
Reference: https://vendure-ecommerce.slack.com/archives/CKYMF0ZTJ/p1665539143010169

Check the channel `pricesIncludeTax` flag to determine if the upper bounds on a order fixed discount should be tax inclusive. 