### PR TITLE
Add email plugin transport options for AWS SES

### DIFF
--- a/packages/email-plugin/src/nodemailer-email-sender.ts
+++ b/packages/email-plugin/src/nodemailer-email-sender.ts
@@ -11,7 +11,13 @@ import { format } from 'util';
 
 import { loggerCtx } from './constants';
 import { EmailSender } from './email-sender';
-import { EmailDetails, EmailTransportOptions, SendmailTransportOptions, SMTPTransportOptions } from './types';
+import {
+    EmailDetails,
+    EmailTransportOptions,
+    SendmailTransportOptions,
+    SESTransportOptions,
+    SMTPTransportOptions,
+} from './types'
 
 export type StreamTransportInfo = {
     envelope: {
@@ -32,6 +38,7 @@ export type StreamTransportInfo = {
 export class NodemailerEmailSender implements EmailSender {
     private _smtpTransport: Mail | undefined;
     private _sendMailTransport: Mail | undefined;
+    private _sesTransport: Mail |undefined
 
     async send(email: EmailDetails, options: EmailTransportOptions) {
         switch (options.type) {
@@ -53,6 +60,9 @@ export class NodemailerEmailSender implements EmailSender {
             case 'sendmail':
                 await this.sendMail(email, this.getSendMailTransport(options));
                 break;
+            case 'ses':
+                await this.sendMail(email, this.getSesTransport(options));
+                break;
             case 'smtp':
                 await this.sendMail(email, this.getSmtpTransport(options));
                 break;
@@ -70,6 +80,13 @@ export class NodemailerEmailSender implements EmailSender {
             this._smtpTransport = createTransport(options);
         }
         return this._smtpTransport;
+    }
+
+    private getSesTransport(options: SESTransportOptions) {
+        if (!this._sesTransport) {
+            this._sesTransport = createTransport(options);
+        }
+        return this._sesTransport;
     }
 
     private getSendMailTransport(options: SendmailTransportOptions) {

--- a/packages/email-plugin/src/types.ts
+++ b/packages/email-plugin/src/types.ts
@@ -7,6 +7,7 @@ import SMTPTransport from 'nodemailer/lib/smtp-transport';
 import { EmailGenerator } from './email-generator';
 import { EmailSender } from './email-sender';
 import { EmailEventHandler } from './event-handler';
+import SESTransport from 'nodemailer/lib/ses-transport'
 
 /**
  * @description
@@ -112,6 +113,7 @@ export type EmailTransportOptions =
     | SendmailTransportOptions
     | FileTransportOptions
     | NoopTransportOptions
+    | SESTransportOptions
     | TestingTransportOptions;
 
 /**
@@ -131,6 +133,47 @@ export interface SMTPTransportOptions extends SMTPTransport.Options {
      * @default false
      */
     logging?: boolean;
+}
+
+/**
+ * @description
+ * The SES transport options of [Nodemailer](https://nodemailer.com/transports/ses//)
+ *
+ * See [Nodemailers's SES docs](https://nodemailer.com/transports/ses/) for more details
+ *
+ * @example
+ * ```TypeScript
+ *  import { SES, SendRawEmailCommand } from '\@aws-sdk/client-ses'
+ *
+ *  const ses = new SES({
+ *     apiVersion: '2010-12-01',
+ *     region: 'eu-central-1',
+ *     credentials: {
+ *         accessKeyId: process.env.SES_ACCESS_KEY || '',
+ *         secretAccessKey: process.env.SES_SECRET_KEY || '',
+ *     },
+ *  })
+ *
+ *  const config: VendureConfig = {
+ *   // Add an instance of the plugin to the plugins array
+ *   plugins: [
+ *     EmailPlugin.init({
+ *       handlers: defaultEmailHandlers,
+ *       templatePath: path.join(__dirname, 'static/email/templates'),
+ *       transport: {
+ *         type: 'ses',
+ *         SES: { ses, aws: { SendRawEmailCommand } },
+ *         sendingRate: 10, // optional messages per second sending rate
+ *       },
+ *     }),
+ *   ],
+ * };
+ *  ```
+ * @docsCategory EmailPlugin
+ * @docsPage Transport Options
+ */
+export interface SESTransportOptions extends SESTransport.Options {
+    type: 'ses';
 }
 
 /**


### PR DESCRIPTION
Has the advantage of having a sending rate to prevent hitting limits at AWS SES and is officially supported by nodemailer
https://nodemailer.com/transports/ses/

Would be great, if this could be included. Would save us eventual future headaches with send limits of AWS.