### PR TITLE
fix(payments-plugin): Return 200 on Stripe payment failed event

### DIFF
--- a/packages/payments-plugin/src/stripe/stripe.controller.ts
+++ b/packages/payments-plugin/src/stripe/stripe.controller.ts
@@ -65,6 +65,7 @@ export class StripeController {
         if (event.type === 'payment_intent.payment_failed') {
             const message = paymentIntent.last_payment_error?.message;
             Logger.warn(`Payment for order ${orderCode} failed: ${message}`, loggerCtx);
+            response.status(HttpStatus.OK).send('Ok');
             return;
         }
 


### PR DESCRIPTION
The Stripe webhook handler does not return a 200 status code response for `payment_intent.payment_failed` events as per [official docs](https://stripe.com/docs/webhooks#acknowledge-events-immediately). This PR fixes that behaviour, which was initially [flagged on Slack](https://vendure-ecommerce.slack.com/archives/CKYMF0ZTJ/p1668154455407779).