### PR TITLE
feat(core)!: Improve channel service findAll

### DIFF
--- a/packages/core/src/api/resolvers/admin/channel.resolver.ts
+++ b/packages/core/src/api/resolvers/admin/channel.resolver.ts
@@ -25,8 +25,9 @@ export class ChannelResolver {
 
     @Query()
     @Allow(Permission.ReadSettings, Permission.ReadChannel)
-    channels(@Ctx() ctx: RequestContext): Promise<Channel[]> {
-        return this.channelService.findAll(ctx);
+    async channels(@Ctx() ctx: RequestContext): Promise<Channel[]> {
+        const { items } = await this.channelService.findAll(ctx);
+        return items
     }
 
     @Query()

--- a/packages/core/src/api/resolvers/admin/global-settings.resolver.ts
+++ b/packages/core/src/api/resolvers/admin/global-settings.resolver.ts
@@ -82,7 +82,7 @@ export class GlobalSettingsResolver {
         const { availableLanguages } = args.input;
         if (availableLanguages) {
             const channels = await this.channelService.findAll(ctx);
-            const unavailableDefaults = channels.filter(
+            const unavailableDefaults = channels.items.filter(
                 c => !availableLanguages.includes(c.defaultLanguageCode),
             );
             if (unavailableDefaults.length) {


### PR DESCRIPTION
Our need is to retrieve a list of channels by id

```
const { items } = await this.findAll(ctx, {
   filter: {
     id: { in: input.channelIds },
   },
 })
```

This PR standardize the findAll function of ChannelService, by accepting a list query options and relations, and returning a paginated list.


