### PR TITLE
Fix(UI devkit) update scaffolding to use correct eslib

### DIFF
--- a/packages/ui-devkit/package.json
+++ b/packages/ui-devkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vendure/ui-devkit",
-  "version": "1.8.3",
+  "version": "1.8.4",
   "description": "A library for authoring Vendure Admin UI extensions",
   "keywords": [
     "vendure",

--- a/packages/ui-devkit/package.json
+++ b/packages/ui-devkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vendure/ui-devkit",
-  "version": "1.8.4",
+  "version": "1.8.5",
   "description": "A library for authoring Vendure Admin UI extensions",
   "keywords": [
     "vendure",

--- a/packages/ui-devkit/package.json
+++ b/packages/ui-devkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vendure/ui-devkit",
-  "version": "1.8.5",
+  "version": "1.8.3",
   "description": "A library for authoring Vendure Admin UI extensions",
   "keywords": [
     "vendure",

--- a/packages/ui-devkit/scaffold/tsconfig.json
+++ b/packages/ui-devkit/scaffold/tsconfig.json
@@ -18,7 +18,7 @@
     "allowSyntheticDefaultImports": true,
     "typeRoots": [],
     "lib": [
-      "es2017",
+      "es2019",
       "dom",
       "esnext.asynciterable"
     ]


### PR DESCRIPTION
Fixes #1859 by updating the scaffolding to match the use of `es2019` in the Admin UI's `tsconfig.json`.  This can be be validated by creating a simple plugin with UI extensions, which will use `compileUiExtensions` from the `ui-devkit` and will have some value for `outputPath`.  When that `outputPath` does not contain the `admin-ui` files (i.e, the first time you run it or if you delete the directory that has already been placed there), then it will be copied from the `ui-devkit`'s scaffolding folder.  Before this change, the scaffolding would be copied with `es2017`, which would lead to the error described in #1859.  After this change, the scaffolding will be copied with `es2019`, which would allow for successful compilation.