### PR TITLE
Fix/issue/1893

### DIFF
--- a/packages/core/e2e/default-search-plugin.e2e-spec.ts
+++ b/packages/core/e2e/default-search-plugin.e2e-spec.ts
@@ -936,6 +936,8 @@ describe('Default search plugin', () => {
                 await awaitRunningJobs(adminClient);
                 // add an additional check for the collection filters to update
                 await awaitRunningJobs(adminClient);
+                // add an additional check for the collection filters unitary to update
+                await awaitRunningJobs(adminClient);
                 const result1 = await doAdminSearchQuery({ collectionId: 'T_2', groupByProduct: true });
 
                 expect(result1.search.items.map(i => i.productName)).toEqual([

--- a/packages/core/src/service/services/collection.service.ts
+++ b/packages/core/src/service/services/collection.service.ts
@@ -559,6 +559,15 @@ export class CollectionService implements OnModuleInit {
         return filters;
     }
 
+    private chunkArray = <T>(array: T[], chunkSize: number): T[][] => {
+        const results = []
+        for (let i = 0; i < array.length; i += chunkSize) {
+          results.push(array.slice(i, i + chunkSize))
+        }
+      
+        return results
+      }
+
     /**
      * Applies the CollectionFilters
      *
@@ -583,22 +592,43 @@ export class CollectionService implements OnModuleInit {
             ...(collection.filters || []),
         ]);
         const postIds = collection.productVariants.map(v => v.id);
+        const preIdsSet = new Set(preIds);
+        const postIdsSet = new Set(postIds);
+
+        const toDeleteIds = preIds.filter((id) => !postIdsSet.has(id))
+        const toAddIds = postIds.filter((id) => !preIdsSet.has(id))
+
         try {
+            // First we remove variants that are no longer in the collection
+            const chunkedDeleteIds = this.chunkArray(toDeleteIds, 500)
+            let chunkDeleteVariant = 0
+
+            for (const chunkedDeleteId of chunkedDeleteIds) {
+                chunkDeleteVariant++
+                await this.connection.rawConnection
+                  .createQueryBuilder()
+                  .relation(Collection, 'productVariants')
+                  .of(collection)
+                  .remove(chunkedDeleteId)
+              }
+
+            // Then we add variants have been added
+            const chunkedAddIds = this.chunkArray(toAddIds, 500)
+            let chunkVariant = 0
+
+            for (const chunkedAddId of chunkedAddIds) {
+            chunkVariant++
             await this.connection.rawConnection
-                .getRepository(Collection)
-                // Only update the exact changed properties, to avoid VERY hard-to-debug
-                // non-deterministic race conditions e.g. when the "position" is changed
-                // by moving a Collection and then this save operation clobbers it back
-                // to the old value.
-                .save(pick(collection, ['id', 'productVariants']), {
-                    chunk: Math.ceil(collection.productVariants.length / 500),
-                    reload: false,
-                });
+                .createQueryBuilder()
+                .relation(Collection, 'productVariants')
+                .of(collection)
+                .add(chunkedAddId)
+            }
+
         } catch (e) {
             Logger.error(e);
         }
-        const preIdsSet = new Set(preIds);
-        const postIdsSet = new Set(postIds);
+        
 
         if (applyToChangedVariantsOnly) {
             return [...preIds.filter(id => !postIdsSet.has(id)), ...postIds.filter(id => !preIdsSet.has(id))];

--- a/packages/core/src/service/services/collection.service.ts
+++ b/packages/core/src/service/services/collection.service.ts
@@ -600,6 +600,9 @@ export class CollectionService implements OnModuleInit {
 
         try {
             // First we remove variants that are no longer in the collection
+            Logger.debug(
+                `We need to remove ${toDeleteIds.length} variants from ${collection.id} collection`
+            )
             const chunkedDeleteIds = this.chunkArray(toDeleteIds, 500)
             let chunkDeleteVariant = 0
 
@@ -613,6 +616,9 @@ export class CollectionService implements OnModuleInit {
               }
 
             // Then we add variants have been added
+            Logger.debug(
+                `We need to add ${toAddIds.length} variants from ${collection.id} collection`
+            )
             const chunkedAddIds = this.chunkArray(toAddIds, 500)
             let chunkVariant = 0
 

--- a/packages/core/src/service/services/collection.service.ts
+++ b/packages/core/src/service/services/collection.service.ts
@@ -604,10 +604,8 @@ export class CollectionService implements OnModuleInit {
                 `We need to remove ${toDeleteIds.length} variants from ${collection.id} collection`
             )
             const chunkedDeleteIds = this.chunkArray(toDeleteIds, 500)
-            let chunkDeleteVariant = 0
 
             for (const chunkedDeleteId of chunkedDeleteIds) {
-                chunkDeleteVariant++
                 await this.connection.rawConnection
                   .createQueryBuilder()
                   .relation(Collection, 'productVariants')
@@ -620,10 +618,8 @@ export class CollectionService implements OnModuleInit {
                 `We need to add ${toAddIds.length} variants from ${collection.id} collection`
             )
             const chunkedAddIds = this.chunkArray(toAddIds, 500)
-            let chunkVariant = 0
 
             for (const chunkedAddId of chunkedAddIds) {
-            chunkVariant++
             await this.connection.rawConnection
                 .createQueryBuilder()
                 .relation(Collection, 'productVariants')

--- a/packages/elasticsearch-plugin/e2e/elasticsearch-plugin.e2e-spec.ts
+++ b/packages/elasticsearch-plugin/e2e/elasticsearch-plugin.e2e-spec.ts
@@ -671,6 +671,9 @@ describe('Elasticsearch plugin', () => {
                 await awaitRunningJobs(adminClient);
                 // add an additional check for the collection filters to update
                 await awaitRunningJobs(adminClient);
+                // add an additional check for the collection filters unitary to update
+                await awaitRunningJobs(adminClient);
+
                 const result1 = await doAdminSearchQuery(adminClient, {
                     collectionId: 'T_2',
                     groupByProduct: true,


### PR DESCRIPTION
Fix scaling issue when there is a lot of collections/variant in a collection

- Fix applyCollectionFiltersInternal for big collection
- Make apply-collection-filter pop unitary job to avoid having a Big slow job but tiny quick one