### PR TITLE
Added additional sort order to orderService.findOne query

### DIFF
--- a/packages/core/src/service/services/order.service.ts
+++ b/packages/core/src/service/services/order.service.ts
@@ -251,7 +251,9 @@ export class OrderService {
             .where('order.id = :orderId', { orderId })
             .andWhere('channel.id = :channelId', { channelId: ctx.channelId });
         if (effectiveRelations.includes('lines') && effectiveRelations.includes('lines.items')) {
-            qb.addOrderBy('order__lines.createdAt', 'ASC').addOrderBy('order__lines__items.createdAt', 'ASC');
+            qb.addOrderBy('order__lines.createdAt', 'ASC')
+                .addOrderBy('order__lines__items.createdAt', 'ASC')
+                .addOrderBy('order__lines.productVariantId', 'ASC');
         }
 
         // tslint:disable-next-line:no-non-null-assertion


### PR DESCRIPTION
Added additional sort order to orderService.findOne query to avoid changing sort order of orderLines if they are created at the exact same time. 

resolves #1903 