### PR TITLE
feat(elasticsearch-plugin): Independently access to customMappings

### DIFF
--- a/packages/elasticsearch-plugin/e2e/elasticsearch-plugin.e2e-spec.ts
+++ b/packages/elasticsearch-plugin/e2e/elasticsearch-plugin.e2e-spec.ts
@@ -1355,9 +1355,18 @@ describe('Elasticsearch plugin', () => {
             search(input: { take: 1, groupByProduct: false, sort: { name: ASC } }) {
                 items {
                   productVariantName
+                  customProductVariantMappings {
+                    inStock
+                  }
+                  customProductMappings {
+                    answer
+                  }
                   customMappings {
                     ...on CustomProductVariantMappings {
                       inStock
+                    }
+                    ...on CustomProductMappings {
+                        answer
                     }
                   }
                 }
@@ -1367,6 +1376,12 @@ describe('Elasticsearch plugin', () => {
 
             expect(search.items[0]).toEqual({
                 productVariantName: 'Bonsai Tree',
+                customProductVariantMappings: {
+                    inStock: false,
+                },
+                customProductMappings: {
+                    answer: 42,
+                },
                 customMappings: {
                     inStock: false,
                 },

--- a/packages/elasticsearch-plugin/src/api/api-extensions.ts
+++ b/packages/elasticsearch-plugin/src/api/api-extensions.ts
@@ -127,18 +127,22 @@ function generateCustomMappingTypes(options: ElasticsearchOptions): DocumentNode
 
                 extend type SearchResult {
                     customMappings: CustomMappings!
+                    customProductMappings: CustomProductMappings!
+                    customProductVariantMappings: CustomProductVariantMappings!
                 }
             `;
         } else if (productMappings.length) {
             sdl += `
                 extend type SearchResult {
                     customMappings: CustomProductMappings!
+                    customProductMappings: CustomProductMappings!
                 }
             `;
         } else if (variantMappings.length) {
             sdl += `
                 extend type SearchResult {
                     customMappings: CustomProductVariantMappings!
+                    customProductVariantMappings: CustomProductVariantMappings!
                 }
             `;
         }

--- a/packages/elasticsearch-plugin/src/api/api-extensions.ts
+++ b/packages/elasticsearch-plugin/src/api/api-extensions.ts
@@ -126,7 +126,7 @@ function generateCustomMappingTypes(options: ElasticsearchOptions): DocumentNode
                 union CustomMappings = CustomProductMappings | CustomProductVariantMappings
 
                 extend type SearchResult {
-                    customMappings: CustomMappings!
+                    customMappings: CustomMappings! @deprecated(reason: "Use customProductMappings or customProductVariantMappings")
                     customProductMappings: CustomProductMappings!
                     customProductVariantMappings: CustomProductVariantMappings!
                 }
@@ -134,14 +134,14 @@ function generateCustomMappingTypes(options: ElasticsearchOptions): DocumentNode
         } else if (productMappings.length) {
             sdl += `
                 extend type SearchResult {
-                    customMappings: CustomProductMappings!
+                    customMappings: CustomProductMappings! @deprecated(reason: "Use customProductMappings or customProductVariantMappings")
                     customProductMappings: CustomProductMappings!
                 }
             `;
         } else if (variantMappings.length) {
             sdl += `
                 extend type SearchResult {
-                    customMappings: CustomProductVariantMappings!
+                    customMappings: CustomProductVariantMappings! @deprecated(reason: "Use customProductMappings or customProductVariantMappings")
                     customProductVariantMappings: CustomProductVariantMappings!
                 }
             `;

--- a/packages/elasticsearch-plugin/src/elasticsearch.service.ts
+++ b/packages/elasticsearch-plugin/src/elasticsearch.service.ts
@@ -505,6 +505,7 @@ export class ElasticsearchService implements OnModuleInit, OnModuleDestroy {
         ElasticsearchService.addCustomMappings(
             result,
             source,
+            this.options.customProductMappings,
             this.options.customProductVariantMappings,
             false,
         );
@@ -547,7 +548,13 @@ export class ElasticsearchService implements OnModuleInit, OnModuleDestroy {
             inStock: source.productInStock,
             score: hit._score || 0,
         };
-        ElasticsearchService.addCustomMappings(result, source, this.options.customProductMappings, true);
+        ElasticsearchService.addCustomMappings(
+            result,
+            source,
+            this.options.customProductMappings,
+            this.options.customProductVariantMappings,
+            true,
+        );
         ElasticsearchService.addScriptMappings(
             result,
             fields,
@@ -581,18 +588,31 @@ export class ElasticsearchService implements OnModuleInit, OnModuleDestroy {
     private static addCustomMappings(
         result: any,
         source: any,
-        mappings: { [fieldName: string]: CustomMapping<any> },
+        productMappings: { [fieldName: string]: CustomMapping<any> },
+        variantMappings: { [fieldName: string]: CustomMapping<any> },
         groupByProduct: boolean,
     ): any {
-        const customMappings = Object.keys(mappings);
-        if (customMappings.length) {
+        const productCustomMappings = Object.keys(productMappings);
+        if (productCustomMappings.length) {
             const customMappingsResult: any = {};
-            for (const name of customMappings) {
-                customMappingsResult[name] = (source as any)[
-                    groupByProduct ? `product-${name}` : `variant-${name}`
-                ];
+            for (const name of productCustomMappings) {
+                customMappingsResult[name] = (source as any)[`product-${name}`];
             }
-            (result as any).customMappings = customMappingsResult;
+            (result as any).customProductMappings = customMappingsResult;
+            if (groupByProduct) {
+                (result as any).customMappings = customMappingsResult;
+            }
+        }
+        const variantCustomMappings = Object.keys(variantMappings);
+        if (variantCustomMappings.length) {
+            const customMappingsResult: any = {};
+            for (const name of variantCustomMappings) {
+                customMappingsResult[name] = (source as any)[`variant-${name}`];
+            }
+            (result as any).customProductVariantMappings = customMappingsResult;
+            if (!groupByProduct) {
+                (result as any).customMappings = customMappingsResult;
+            }
         }
         return result;
     }

--- a/packages/elasticsearch-plugin/src/options.ts
+++ b/packages/elasticsearch-plugin/src/options.ts
@@ -165,7 +165,7 @@ export interface ElasticsearchOptions {
      * @description
      * Custom mappings may be defined which will add the defined data to the
      * Elasticsearch index and expose that data via the SearchResult GraphQL type,
-     * adding a new `customMappings` field, customProductMappings, customProductVariantMappings.
+     * adding a new `customMappings`, `customProductMappings` & `customProductVariantMappings` fields.
      *
      * The `graphQlType` property may be one of `String`, `Int`, `Float`, `Boolean`, `ID` or list
      * versions thereof (`[String!]` etc) and can be appended with a `!` to indicate non-nullable fields.
@@ -175,8 +175,8 @@ export interface ElasticsearchOptions {
      * parsed to the elasticsearch index.
      *
      * This config option defines custom mappings which are accessible when the "groupByProduct"
-     * input options is set to `true`. Anyway, customProductVariantMappings can be accessed by using
-     * customProductVariantMappings field.
+     * input options is set to `true`. In addition, custom variant mappings can be accessed by using
+     * the `customProductVariantMappings` field, which is always available.
      *
      * @example
      * ```TypeScript
@@ -227,8 +227,8 @@ export interface ElasticsearchOptions {
     /**
      * @description
      * This config option defines custom mappings which are accessible when the "groupByProduct"
-     * input options is set to `false`. Anyway, customProductMappings can be accessed by using
-     * customProductMappings field.
+     * input options is set to `false`. In addition, custom product mappings can be accessed by using
+     * the `customProductMappings` field, which is always available.
      *
      * @example
      * ```SDL

--- a/packages/elasticsearch-plugin/src/options.ts
+++ b/packages/elasticsearch-plugin/src/options.ts
@@ -165,7 +165,7 @@ export interface ElasticsearchOptions {
      * @description
      * Custom mappings may be defined which will add the defined data to the
      * Elasticsearch index and expose that data via the SearchResult GraphQL type,
-     * adding a new `customMappings` field.
+     * adding a new `customMappings` field, customProductMappings, customProductVariantMappings.
      *
      * The `graphQlType` property may be one of `String`, `Int`, `Float`, `Boolean`, `ID` or list
      * versions thereof (`[String!]` etc) and can be appended with a `!` to indicate non-nullable fields.
@@ -175,7 +175,8 @@ export interface ElasticsearchOptions {
      * parsed to the elasticsearch index.
      *
      * This config option defines custom mappings which are accessible when the "groupByProduct"
-     * input options is set to `true`.
+     * input options is set to `true`. Anyway, customProductVariantMappings can be accessed by using
+     * customProductVariantMappings field.
      *
      * @example
      * ```TypeScript
@@ -205,6 +206,10 @@ export interface ElasticsearchOptions {
      *         items {
      *             productId
      *             productName
+     *             customProductMappings {
+     *                 variantCount
+     *                 reviewRating
+     *             }
      *             customMappings {
      *                 ...on CustomProductMappings {
      *                     variantCount
@@ -222,7 +227,8 @@ export interface ElasticsearchOptions {
     /**
      * @description
      * This config option defines custom mappings which are accessible when the "groupByProduct"
-     * input options is set to `false`.
+     * input options is set to `false`. Anyway, customProductMappings can be accessed by using
+     * customProductMappings field.
      *
      * @example
      * ```SDL
@@ -232,6 +238,9 @@ export interface ElasticsearchOptions {
      *         items {
      *             productId
      *             productName
+     *             customProductVariantMappings {
+     *                 weight
+     *             }
      *             customMappings {
      *                 ...on CustomProductVariantMappings {
      *                     weight


### PR DESCRIPTION
### Description
Access to customProductVariantMappings and customProductMappings independently from groupByProduct by adding two new fields - customProductVariantMappings and customProductMappings.

This PR don't break current GQL scheme, just expand it.

### Use case
We always use `groupByProduct=true`, because our product can have a lot of variants and we don't want to spam our listings of rather similar items. 
Current logic of elasticsearch plugin select the best productVariant attributes after applying filters (through facets values). But this logic is not applied to customMapping - i can't select customProductVariantMappings when i have `groupByProduct=true`. Real case - we have customProductVariantMapping `allAssets` with all image of variant. I want to apply filter `color=blue` and get grouped by product result with blue images.