### PR TITLE
Auth changes to fix external and native interoperability issues

### DIFF
--- a/packages/core/src/config/auth/native-authentication-strategy.ts
+++ b/packages/core/src/config/auth/native-authentication-strategy.ts
@@ -62,7 +62,7 @@ export class NativeAuthenticationStrategy implements AuthenticationStrategy<Nati
     private getUserFromIdentifier(ctx: RequestContext, identifier: string): Promise<User | undefined> {
         return this.connection.getRepository(ctx, User).findOne({
             where: { identifier, deletedAt: null },
-            relations: ['roles', 'roles.channels'],
+            relations: ['roles', 'roles.channels', 'authenticationMethods'],
         });
     }
 
@@ -76,7 +76,10 @@ export class NativeAuthenticationStrategy implements AuthenticationStrategy<Nati
         if (!user) {
             return false;
         }
-        const nativeAuthMethod = user.getNativeAuthenticationMethod();
+        const nativeAuthMethod = user.getNativeAuthenticationMethod(false);
+        if (!nativeAuthMethod) {
+            return false;
+        }
         const pw =
             (
                 await this.connection

--- a/packages/core/src/entity/user/user.entity.ts
+++ b/packages/core/src/entity/user/user.entity.ts
@@ -48,14 +48,17 @@ export class User extends VendureEntity implements HasCustomFields, SoftDeletabl
     @Column(type => CustomUserFields)
     customFields: CustomUserFields;
 
-    getNativeAuthenticationMethod(): NativeAuthenticationMethod {
+    getNativeAuthenticationMethod(): NativeAuthenticationMethod;
+    getNativeAuthenticationMethod(strict? : boolean): NativeAuthenticationMethod | undefined;
+
+    getNativeAuthenticationMethod(strict? : boolean): NativeAuthenticationMethod | undefined {
         if (!this.authenticationMethods) {
             throw new InternalServerError('error.user-authentication-methods-not-loaded');
         }
         const match = this.authenticationMethods.find(
             (m): m is NativeAuthenticationMethod => m instanceof NativeAuthenticationMethod,
         );
-        if (!match) {
+        if (!match && (strict === undefined || strict)) {
             throw new InternalServerError('error.native-authentication-methods-not-found');
         }
         return match;

--- a/packages/core/src/service/services/auth.service.ts
+++ b/packages/core/src/service/services/auth.service.ts
@@ -19,6 +19,7 @@ import { ConfigService } from '../../config/config.service';
 import { TransactionalConnection } from '../../connection/transactional-connection';
 import { AuthenticatedSession } from '../../entity/session/authenticated-session.entity';
 import { User } from '../../entity/user/user.entity';
+import { ExternalAuthenticationMethod } from '../../entity/authentication-method/external-authentication-method.entity';
 import { EventBus } from '../../event-bus/event-bus';
 import { AttemptedLoginEvent } from '../../event-bus/events/attempted-login-event';
 import { LoginEvent } from '../../event-bus/events/login-event';
@@ -87,7 +88,8 @@ export class AuthService {
             user.roles = userWithRoles?.roles || [];
         }
 
-        if (this.configService.authOptions.requireVerification && !user.verified) {
+        const extAuths = (user.authenticationMethods ?? []).filter(am => am instanceof ExternalAuthenticationMethod);
+        if (!extAuths.length && this.configService.authOptions.requireVerification && !user.verified) {
             return new NotVerifiedError();
         }
         if (ctx.session && ctx.session.activeOrderId) {


### PR DESCRIPTION
The existing way to load User during auth stage have side effects that clears AuthMethod.userId in database.
This PR shows a possible fix.
Is there some TypeORM config/annotation that could fix this cleanly?
