### PR TITLE
feat(ui-devkit): Support module path mappings for UI extensions

### DIFF
--- a/packages/ui-devkit/src/compiler/types.ts
+++ b/packages/ui-devkit/src/compiler/types.ts
@@ -136,8 +136,8 @@ export interface AdminUiExtension
      * @example
      * ```ts
      * // packages/common-ui-module/src/ui/ui-shared.module.ts
-     * import { NgModule } from '@angular/core';
-     * import { SharedModule } from '@vendure/admin-ui/core';
+     * import { NgModule } from '\@angular/core';
+     * import { SharedModule } from '\@vendure/admin-ui/core';
      * import { CommonUiComponent } from './components/common-ui/common-ui.component';
      *
      * export { CommonUiComponent };
@@ -154,10 +154,10 @@ export interface AdminUiExtension
      * // packages/common-ui-module/src/index.ts
      * import path from 'path';
      *
-     * import { AdminUiExtension } from '@vendure/ui-devkit/compiler';
+     * import { AdminUiExtension } from '\@vendure/ui-devkit/compiler';
      *
      * export const uiExtensions: AdminUiExtension = {
-     *   pathAlias: '@common-ui-module',     // this is the important part
+     *   pathAlias: '\@common-ui-module',     // this is the important part
      *   extensionPath: path.join(__dirname, 'ui'),
      *   ngModules: [
      *     {
@@ -175,7 +175,7 @@ export interface AdminUiExtension
      *   "compilerOptions": {
      *     "baseUrl": ".",
      *     "paths": {
-     *       "@common-ui-module/*": ["packages/common-ui-module/src/ui/*"]
+     *       "\@common-ui-module/*": ["packages/common-ui-module/src/ui/*"]
      *     }
      *   }
      * }
@@ -183,11 +183,11 @@ export interface AdminUiExtension
      *
      * ```ts
      * // packages/sample-plugin/src/ui/ui-extension.module.ts
-     * import { NgModule } from '@angular/core';
-     * import { SharedModule } from '@vendure/admin-ui/core';
+     * import { NgModule } from '\@angular/core';
+     * import { SharedModule } from '\@vendure/admin-ui/core';
      * // the import below works both in the context of the custom Admin UI app as well as the main project
-     * // '@common-ui-module' is the value of "pathAlias" and 'ui-shared.module' is the file we want to reference inside "extensionPath"
-     * import { CommonSharedUiModule, CommonUiComponent } from '@common-ui-module/ui-shared.module';
+     * // '\@common-ui-module' is the value of "pathAlias" and 'ui-shared.module' is the file we want to reference inside "extensionPath"
+     * import { CommonSharedUiModule, CommonUiComponent } from '\@common-ui-module/ui-shared.module';
      *
      * \@NgModule({
      *   imports: [

--- a/packages/ui-devkit/src/compiler/types.ts
+++ b/packages/ui-devkit/src/compiler/types.ts
@@ -5,8 +5,7 @@ export type Extension =
     | TranslationExtension
     | StaticAssetExtension
     | GlobalStylesExtension
-    | SassVariableOverridesExtension
-    | ModulePathMappingExtension;
+    | SassVariableOverridesExtension;
 
 /**
  * @description
@@ -85,138 +84,6 @@ export interface SassVariableOverridesExtension {
 
 /**
  * @description
- * Defines an extension which specifies module path mapping to allow an {@link AdminUiExtension} import code
- * from another AdminUiExtension.
- *
- * By default, Angular modules declared in an AdminUiExtension do not have access to code outside the directory
- * defined by the `extensionPath` property except for `node_modules`. A scenario in which that can be useful though
- * is on a monorepo codebase where a common NgModule is shared across different plugins, each defined in its own
- * package. An example can be found below - note that the main `tsconfig.json` also maps the target module but using
- * a path relative to the project's root folder. The UI module is not part of the main TypeScript build task as explained
- * in [Extending the Admin UI](https://www.vendure.io/docs/plugins/extending-the-admin-ui/) but having `paths`
- * properly configured helps with usual IDE code editing features such as code completion and quick navigation, as
- * well as linting.
- *
- * @example
- * ```json
- * // tsconfig.json
- * {
- *   "compilerOptions": {
- *     "baseUrl": ".",
- *     "paths": {
- *       "@common-ui-module/ui": ["packages/common-ui-module/src/ui/ui-shared.module.ts"]
- *     }
- *   }
- * }
- * ```
- *
- * ```ts
- * // packages/common-ui-module/src/ui/ui-shared.module.ts
- * import { NgModule } from '@angular/core';
- * import { SharedModule } from '@vendure/admin-ui/core';
- *
- * import { CommonUiComponent } from './components/common-ui/common-ui.component';
- *
- * export { CommonUiComponent };
- *
- * \@NgModule({
- *  imports: [SharedModule],
- *  exports: [CommonUiComponent],
- *  declarations: [CommonUiComponent],
- * })
- * export class CommonSharedUiModule {}
- * ```
- *
- * ```ts
- * // packages/common-ui-module/src/index.ts
- * import path from 'path';
- *
- * import { AdminUiExtension } from '@vendure/ui-devkit/compiler';
- *
- * export const uiExtensions: AdminUiExtension = {
- *   id: 'common-ui',     // this is important
- *   extensionPath: path.join(__dirname, 'ui'),
- *   ngModules: [
- *     {
- *       type: 'shared' as const,
- *       ngModuleFileName: 'ui-shared.module.ts',
- *       ngModuleName: 'CommonSharedUiModule',
- *     },
- *   ],
- * };
- * ```
- *
- * ```ts
- * // packages/sample-plugin/src/ui/ui-extension.module.ts
- * import { NgModule } from '@angular/core';
- * import { SharedModule } from '@vendure/admin-ui/core';
- * import { CommonSharedUiModule, CommonUiComponent } from '@common-ui-module/ui';
- *
- * \@NgModule({
- *   imports: [
- *     SharedModule,
- *     CommonSharedUiModule,
- *     RouterModule.forChild([
- *       {
- *         path: '',
- *         pathMatch: 'full',
- *         component: CommonUiComponent,
- *       },
- *     ]),
- *   ],
- * })
- * export class SampleUiExtensionModule {}
- * ```
- *
- * ```ts
- * // vendure-config.ts
- * import path from 'path';
- * import { AdminUiPlugin } from '@vendure/admin-ui-plugin';
- * import { VendureConfig } from '@vendure/core';
- * import { compileUiExtensions } from '@vendure/ui-devkit/compiler';
- * import { uiExtensions as commonUiExtensions } from '@common-ui-module/ui';
- *
- * export const config: VendureConfig = {
- *   // ...
- *   plugins: [
- *     AdminUiPlugin.init({
- *       app: compileUiExtensions({
- *         outputPath: path.join(__dirname, '../admin-ui'),
- *         extensions: [{
- *           modulePathMapping: {
- *             // 'common-ui' is the id given to the common-ui-module UI extension
- *             // 'ui-shared.module.ts' is the file in 'ui' directory that we want to import from
- *             '@common-module/ui': 'common-ui/ui-shared.module.ts',
- *           },
- *         }],
- *         commonUiExtensions,
- *         // UI extensions for SamplePlugin, which uses CommonSharedUiModule, should also be imported
- *         // and declared here
- *       }),
- *     }),
- *   ],
- * };
- * ```
- *
- * @docsCategory UiDevkit
- * @docsPage AdminUiExtension
- */
-export interface ModulePathMappingExtension {
-    /**
-     * @description
-     * Optional object which defines one or more module name mappings in a similar way to TypeScript's
-     * [path mapping](https://www.typescriptlang.org/docs/handbook/module-resolution.html#path-mapping) with
-     * the following differences:
-     *
-     * * The path value is a single string instead of an array of strings
-     * * Paths are resolved relative to the "extensions" folder of the compiled Admin UI app and reference the id
-     *   property of the target AdminUiExtension
-     */
-    modulePathMapping: Record<string, string>;
-}
-
-/**
- * @description
  * Defines extensions to the Admin UI application by specifying additional
  * Angular [NgModules](https://angular.io/guide/ngmodules) which are compiled
  * into the application.
@@ -235,8 +102,7 @@ export interface AdminUiExtension
     /**
      * @description
      * An optional ID for the extension module. Only used internally for generating
-     * import paths to your module or if {@link ModulePathMappingExtension} is defined.
-     * If not specified, a unique hash will be used as the id.
+     * import paths to your module. If not specified, a unique hash will be used as the id.
      */
     id?: string;
 
@@ -247,11 +113,99 @@ export interface AdminUiExtension
      * scss style sheets etc.
      */
     extensionPath: string;
+
     /**
      * @description
      * One or more Angular modules which extend the default Admin UI.
      */
     ngModules: Array<AdminUiExtensionSharedModule | AdminUiExtensionLazyModule>;
+
+    /**
+     * @description
+     * An optional alias for the module so it can be referenced by other UI extension modules.
+     *
+     * By default, Angular modules declared in an AdminUiExtension do not have access to code outside the directory
+     * defined by the `extensionPath`. A scenario in which that can be useful though is in a monorepo codebase where
+     * a common NgModule is shared across different plugins, each defined in its own package. An example can be found
+     * below - note that the main `tsconfig.json` also maps the target module but using a path relative to the project's
+     * root folder. The UI module is not part of the main TypeScript build task as explained in
+     * [Extending the Admin UI](https://www.vendure.io/docs/plugins/extending-the-admin-ui/) but having `paths`
+     * properly configured helps with usual IDE code editing features such as code completion and quick navigation, as
+     * well as linting.
+     *
+     * @example
+     * ```ts
+     * // packages/common-ui-module/src/ui/ui-shared.module.ts
+     * import { NgModule } from '@angular/core';
+     * import { SharedModule } from '@vendure/admin-ui/core';
+     * import { CommonUiComponent } from './components/common-ui/common-ui.component';
+     *
+     * export { CommonUiComponent };
+     *
+     * \@NgModule({
+     *  imports: [SharedModule],
+     *  exports: [CommonUiComponent],
+     *  declarations: [CommonUiComponent],
+     * })
+     * export class CommonSharedUiModule {}
+     * ```
+     *
+     * ```ts
+     * // packages/common-ui-module/src/index.ts
+     * import path from 'path';
+     *
+     * import { AdminUiExtension } from '@vendure/ui-devkit/compiler';
+     *
+     * export const uiExtensions: AdminUiExtension = {
+     *   pathAlias: '@common-ui-module',     // this is the important part
+     *   extensionPath: path.join(__dirname, 'ui'),
+     *   ngModules: [
+     *     {
+     *       type: 'shared' as const,
+     *       ngModuleFileName: 'ui-shared.module.ts',
+     *       ngModuleName: 'CommonSharedUiModule',
+     *     },
+     *   ],
+     * };
+     * ```
+     *
+     * ```json
+     * // tsconfig.json
+     * {
+     *   "compilerOptions": {
+     *     "baseUrl": ".",
+     *     "paths": {
+     *       "@common-ui-module/*": ["packages/common-ui-module/src/ui/*"]
+     *     }
+     *   }
+     * }
+     * ```
+     *
+     * ```ts
+     * // packages/sample-plugin/src/ui/ui-extension.module.ts
+     * import { NgModule } from '@angular/core';
+     * import { SharedModule } from '@vendure/admin-ui/core';
+     * // the import below works both in the context of the custom Admin UI app as well as the main project
+     * // '@common-ui-module' is the value of "pathAlias" and 'ui-shared.module' is the file we want to reference inside "extensionPath"
+     * import { CommonSharedUiModule, CommonUiComponent } from '@common-ui-module/ui-shared.module';
+     *
+     * \@NgModule({
+     *   imports: [
+     *     SharedModule,
+     *     CommonSharedUiModule,
+     *     RouterModule.forChild([
+     *       {
+     *         path: '',
+     *         pathMatch: 'full',
+     *         component: CommonUiComponent,
+     *       },
+     *     ]),
+     *   ],
+     * })
+     * export class SampleUiExtensionModule {}
+     * ```
+     */
+    pathAlias?: string;
 }
 
 /**
@@ -413,4 +367,8 @@ export interface BrandingOptions {
     smallLogoPath?: string;
     largeLogoPath?: string;
     faviconPath?: string;
+}
+
+export interface AdminUiExtensionWithId extends AdminUiExtension {
+    id: string;
 }

--- a/packages/ui-devkit/src/compiler/utils.ts
+++ b/packages/ui-devkit/src/compiler/utils.ts
@@ -8,9 +8,9 @@ import * as path from 'path';
 import { STATIC_ASSETS_OUTPUT_DIR } from './constants';
 import {
     AdminUiExtension,
+    AdminUiExtensionWithId,
     Extension,
     GlobalStylesExtension,
-    ModulePathMappingExtension,
     SassVariableOverridesExtension,
     StaticAssetDefinition,
     StaticAssetExtension,
@@ -80,7 +80,7 @@ export async function copyStaticAsset(outputPath: string, staticAssetDef: Static
  * If not defined by the user, a deterministic ID is generated
  * from a hash of the extension config.
  */
-export function normalizeExtensions(extensions?: AdminUiExtension[]): Array<Required<AdminUiExtension>> {
+export function normalizeExtensions(extensions?: AdminUiExtension[]): Array<AdminUiExtensionWithId> {
     return (extensions || []).map(e => {
         let id = e.id;
         if (!id) {
@@ -111,8 +111,4 @@ export function isGlobalStylesExtension(input: Extension): input is GlobalStyles
 
 export function isSassVariableOverridesExtension(input: Extension): input is SassVariableOverridesExtension {
     return input.hasOwnProperty('sassVariableOverrides');
-}
-
-export function isModulePathMappingExtension(input: Extension): input is ModulePathMappingExtension {
-    return input.hasOwnProperty('modulePathMapping');
 }

--- a/packages/ui-devkit/src/compiler/utils.ts
+++ b/packages/ui-devkit/src/compiler/utils.ts
@@ -10,6 +10,7 @@ import {
     AdminUiExtension,
     Extension,
     GlobalStylesExtension,
+    ModulePathMappingExtension,
     SassVariableOverridesExtension,
     StaticAssetDefinition,
     StaticAssetExtension,
@@ -110,4 +111,8 @@ export function isGlobalStylesExtension(input: Extension): input is GlobalStyles
 
 export function isSassVariableOverridesExtension(input: Extension): input is SassVariableOverridesExtension {
     return input.hasOwnProperty('sassVariableOverrides');
+}
+
+export function isModulePathMappingExtension(input: Extension): input is ModulePathMappingExtension {
+    return input.hasOwnProperty('modulePathMapping');
 }


### PR DESCRIPTION
### Context

Given the composable and extensible nature of Vendure, a monorepo codebase where each package encapsulates a custom plugin is most likely a common practice. Often times, different plugins that include Admin UI extensions share similar behaviour/UX and could depend on the same set of custom Angular components, services, etc. However, considering how Admin UI extensions are compiled - the `extensionPath` directory gets copied as is to the output and is "self-contained" so to speak - referencing code outside the folder and, more importantly, modules declared in other extensions is tricky and unintuitive. Sure, you can give `id`s to `AdminUiExtension`s and use relative imports but that requires knowledge of the inner workings of `ui-devkit` and is a brittle approach as the implementation details might change at some point, rendering the solution obsolete (and broken). Additionally, relative paths make sense in the context of the `ui-devkit` build process but not to the project's main TypeScript configuration since the path will always be invalid. As a result, IDE features such as code completion and quick navigation, as well as linting do not work. An alternative is to create an NPM package for the common module, but besides all the hassle (build/packaging process, private NPM registry, CI, etc) it doesn't give you the same developer experience where changes can be immediately verified.

### Proposed solution

Allow developers to specify module path mapping for UI extensions so they are able to import code from other bundled extensions, while at the same time maintaining compatibility with the project's main `tsconfig.json`.

### Description of changes

* Update `@vendure/ui-devkit` to support a new `pathAlias` property in `AdminUiExtension` objects, which represents an alias for the module so it can be referenced in `import` statements from other UI extensions. The path is resolved relative to the `extensions` directory of the compiled `admin-ui` folder, whose children are every declared UI extension. A full example has been added as a docstring.
* Change `scaffold.ts` to check if any extensions have `pathAlias` defined; if that's the case, update the [`paths` property](https://www.typescriptlang.org/docs/handbook/module-resolution.html#path-mapping) of the bundled `tsconfig.json` file to map each `pathAlias` to its corresponding compiled folder. Since the attribute is resolved relative to `baseUrl` - the root of the compiled `admin-ui` folder - each path is prepended with `src/extensions/`.
* Minor tweaks to existing docs and removal of an unused import from `scaffold.ts`.

#### Notes

* Development and testing were executed using [this approach](https://vendure-ecommerce.slack.com/archives/CKYMF0ZTJ/p1644346353760739?thread_ts=1643753248.067699&cid=CKYMF0ZTJ)
* I really hope the feature gets accepted as I've already [patch packaged](https://www.npmjs.com/package/patch-package) Vendure in our project because we desperately need this! 😅 