### PR TITLE
fix(payments-plugin): Fix Stripe plugin docs to reference the correct webhook host

### DIFF
--- a/packages/payments-plugin/src/stripe/stripe-order-process.ts
+++ b/packages/payments-plugin/src/stripe/stripe-order-process.ts
@@ -1,9 +1,0 @@
-import { CustomOrderProcess, OrderState } from '@vendure/core';
-
-const stripeOrderProcess: CustomOrderProcess<never> = {
-    async onTransitionEnd(fromState, toState, data) {
-        if (fromState === 'ArrangingPayment' && toState === 'AddingItems') {
-            data.order;
-        }
-    },
-};

--- a/packages/payments-plugin/src/stripe/stripe.handler.ts
+++ b/packages/payments-plugin/src/stripe/stripe.handler.ts
@@ -8,7 +8,7 @@ import {
 } from '@vendure/core';
 import Stripe from 'stripe';
 
-import { getAmountFromStripeMinorUnits, getAmountInStripeMinorUnits } from './stripe-utils';
+import { getAmountFromStripeMinorUnits } from './stripe-utils';
 import { StripeService } from './stripe.service';
 
 const { StripeError } = Stripe.errors;

--- a/packages/payments-plugin/src/stripe/stripe.plugin.ts
+++ b/packages/payments-plugin/src/stripe/stripe.plugin.ts
@@ -17,8 +17,8 @@ import { StripePluginOptions } from './types';
  *
  * 1. You will need to create a Stripe account and get your secret key in the dashboard.
  * 2. Create a webhook endpoint in the Stripe dashboard (Developers -> Webhooks, "Add an endpoint") which listens to the `payment_intent.succeeded`
- * and `payment_intent.payment_failed` events. The URL should be `https://my-shop.com/payments/stripe`, where
- * `my-shop.com` is the host of your storefront application. *Note:* for local development, you'll need to use
+ * and `payment_intent.payment_failed` events. The URL should be `https://my-server.com/payments/stripe`, where
+ * `my-server.com` is the host of your Vendure server. *Note:* for local development, you'll need to use
  * the Stripe CLI to test your webhook locally. See the _local development_ section below.
  * 3. Get the signing secret for the newly created webhook.
  * 4. Install the Payments plugin and the Stripe Node library:

--- a/packages/payments-plugin/src/stripe/types.ts
+++ b/packages/payments-plugin/src/stripe/types.ts
@@ -1,6 +1,5 @@
 import '@vendure/core/dist/entity/custom-entity-fields';
 import { Request } from 'express';
-import { IncomingMessage } from 'http';
 
 // Note: deep import is necessary here because CustomCustomerFields is also extended in the Braintree
 // plugin. Reference: https://github.com/microsoft/TypeScript/issues/46617


### PR DESCRIPTION
Fixing Stripe plugin docs to properly reference the host of the webhook to be created - refer to [this Slack thread](https://vendure-ecommerce.slack.com/archives/CKYMF0ZTJ/p1674384816161209) for more information. Additionally, I deleted a couple unused imports and took the freedom to remove a file that was introduced as part of [this commit](https://github.com/vendure-ecommerce/vendure/commit/6e320cc8b4aee5ed7158655cc292aa93def8e0d9#diff-438dac4bcf33db60b21f01b448a20d18f1981ffe1f24bce2624381d2bfb0009a) but is not used anywhere. Perhaps a leftover?

