### PR TITLE
feat(ui-devkit): Add "exclude" option to UI extensions

### DIFF
--- a/packages/ui-devkit/src/compiler/scaffold.ts
+++ b/packages/ui-devkit/src/compiler/scaffold.ts
@@ -1,6 +1,7 @@
 /* tslint:disable:no-console */
 import { spawn } from 'child_process';
 import * as fs from 'fs-extra';
+import glob from 'glob';
 import * as path from 'path';
 
 import {
@@ -103,7 +104,17 @@ async function copyExtensionModules(outputPath: string, extensions: Array<AdminU
 
     for (const extension of extensions) {
         const dest = path.join(outputPath, MODULES_OUTPUT_DIR, extension.id);
-        fs.copySync(extension.extensionPath, dest);
+        if (!extension.exclude) {
+            fs.copySync(extension.extensionPath, dest);
+            continue;
+        }
+
+        const exclude = extension.exclude
+            .map(e => glob.sync(path.join(extension.extensionPath, e)))
+            .flatMap(e => e);
+        fs.copySync(extension.extensionPath, dest, {
+            filter: name => name === extension.extensionPath || exclude.every(e => e !== name),
+        });
     }
 }
 

--- a/packages/ui-devkit/src/compiler/types.ts
+++ b/packages/ui-devkit/src/compiler/types.ts
@@ -206,6 +206,18 @@ export interface AdminUiExtension
      * ```
      */
     pathAlias?: string;
+
+    /**
+     * @description
+     * Optional array specifying filenames or [glob](https://github.com/isaacs/node-glob) patterns that should
+     * be skipped when copying the directory defined by `extensionPath`.
+     *
+     * @example
+     * ```ts
+     * exclude: ['**\/*.spec.ts']
+     * ```
+     */
+    exclude?: string[];
 }
 
 /**


### PR DESCRIPTION
### Context

As custom UI extensions mature, a Vendure developer might want to write unit tests or perhaps [Storybook stories](https://storybook.js.org/docs/react/writing-stories/introduction) and choose to colocate them with the corresponding component. Currently, UI Devkit copies **everything** inside the `extensionPath` directory, which could also bring unintended files to the output.

### Proposed solution

Allow developers to optionally specify files within their UI extension to be skipped during the copy process.

### Description of changes

* Update `@vendure/ui-devkit` to support a new optional `exclude` property in `AdminUiExtension` objects, which takes a string array and works the exact same way as [TypeScript's `tsconfig.json` counterpart](https://www.typescriptlang.org/tsconfig#exclude).
* Update `typescript-doc-parser.ts` to support escaped `/*` tokens in comment descriptions. I decided to introduce this additional change because the best example of `exclude` is using a [globstar pattern](https://metacpan.org/dist/File-Globstar/view/lib/File/Globstar.pod), which causes a [multi-line comment to end](https://github.com/microsoft/tsdoc/issues/166). Escaping it using the same existing approach as the `@` token seemed like an obvious choice, however, I'm more than happy not to include changes to that logic and use a different pattern in the `exclude` comment description.