### PR TITLE
fix(core): Fix auth of admin and customer users with the same email

### DIFF
--- a/packages/core/e2e/auth.e2e-spec.ts
+++ b/packages/core/e2e/auth.e2e-spec.ts
@@ -1,6 +1,6 @@
 /* tslint:disable:no-non-null-assertion */
 import { SUPER_ADMIN_USER_IDENTIFIER, SUPER_ADMIN_USER_PASSWORD } from '@vendure/common/lib/shared-constants';
-import { createTestEnvironment } from '@vendure/testing';
+import { createErrorResultGuard, createTestEnvironment, ErrorResultGuard } from '@vendure/testing';
 import { DocumentNode } from 'graphql';
 import gql from 'graphql-tag';
 import path from 'path';
@@ -10,9 +10,12 @@ import { testConfig, TEST_SETUP_TIMEOUT_MS } from '../../../e2e-common/test-conf
 
 import { ProtectedFieldsPlugin, transactions } from './fixtures/test-plugins/with-protected-field-resolver';
 import {
+    AttemptLogin,
     CreateAdministrator,
+    CreateCustomer,
     CreateCustomerGroup,
     CreateRole,
+    CurrentUserFragment,
     ErrorCode,
     GetCustomerList,
     GetTaxRates,
@@ -26,6 +29,7 @@ import {
 import {
     ATTEMPT_LOGIN,
     CREATE_ADMINISTRATOR,
+    CREATE_CUSTOMER,
     CREATE_CUSTOMER_GROUP,
     CREATE_PRODUCT,
     CREATE_ROLE,
@@ -181,6 +185,99 @@ describe('Authorization & permissions', () => {
                     }
                 `);
             });
+        });
+    });
+
+    describe('administrator and customer users with the same email address', () => {
+        const emailAddress = 'same-email@test.com';
+        const adminPassword = 'admin-password';
+        const customerPassword = 'customer-password';
+
+        const loginErrorGuard: ErrorResultGuard<CurrentUserFragment> = createErrorResultGuard(
+            input => !!input.identifier,
+        );
+
+        beforeAll(async () => {
+            await adminClient.asSuperAdmin();
+
+            await adminClient.query<CreateAdministrator.Mutation, CreateAdministrator.Variables>(
+                CREATE_ADMINISTRATOR,
+                {
+                    input: {
+                        emailAddress,
+                        firstName: 'First',
+                        lastName: 'Last',
+                        password: adminPassword,
+                        roleIds: ['1'],
+                    },
+                },
+            );
+
+            await adminClient.query<CreateCustomer.Mutation, CreateCustomer.Variables>(CREATE_CUSTOMER, {
+                input: {
+                    emailAddress,
+                    firstName: 'First',
+                    lastName: 'Last',
+                },
+                password: customerPassword,
+            });
+        });
+
+        beforeEach(async () => {
+            await adminClient.asAnonymousUser();
+            await shopClient.asAnonymousUser();
+        });
+
+        it('can log in as an administrator', async () => {
+            const loginResult = await adminClient.query<AttemptLogin.Mutation, AttemptLogin.Variables>(
+                ATTEMPT_LOGIN,
+                {
+                    username: emailAddress,
+                    password: adminPassword,
+                },
+            );
+
+            loginErrorGuard.assertSuccess(loginResult.login);
+            expect(loginResult.login.identifier).toEqual(emailAddress);
+        });
+
+        it('can log in as a customer', async () => {
+            const loginResult = await shopClient.query<AttemptLogin.Mutation, AttemptLogin.Variables>(
+                ATTEMPT_LOGIN,
+                {
+                    username: emailAddress,
+                    password: customerPassword,
+                },
+            );
+
+            loginErrorGuard.assertSuccess(loginResult.login);
+            expect(loginResult.login.identifier).toEqual(emailAddress);
+        });
+
+        it('cannot log in as an administrator using a customer password', async () => {
+            const loginResult = await adminClient.query<AttemptLogin.Mutation, AttemptLogin.Variables>(
+                ATTEMPT_LOGIN,
+                {
+                    username: emailAddress,
+                    password: customerPassword,
+                },
+            );
+
+            loginErrorGuard.assertErrorResult(loginResult.login);
+            expect(loginResult.login.errorCode).toEqual(ErrorCode.INVALID_CREDENTIALS_ERROR);
+        });
+
+        it('cannot log in as a customer using an administrator password', async () => {
+            const loginResult = await shopClient.query<AttemptLogin.Mutation, AttemptLogin.Variables>(
+                ATTEMPT_LOGIN,
+                {
+                    username: emailAddress,
+                    password: adminPassword,
+                },
+            );
+
+            loginErrorGuard.assertErrorResult(loginResult.login);
+            expect(loginResult.login.errorCode).toEqual(ErrorCode.INVALID_CREDENTIALS_ERROR);
         });
     });
 

--- a/packages/core/e2e/graphql/generated-e2e-admin-types.ts
+++ b/packages/core/e2e/graphql/generated-e2e-admin-types.ts
@@ -18,7 +18,14 @@ export type Scalars = {
   Upload: any;
 };
 
-export type AddFulfillmentToOrderResult = Fulfillment | EmptyOrderLineSelectionError | ItemsAlreadyFulfilledError | InsufficientStockOnHandError | InvalidFulfillmentHandlerError | FulfillmentStateTransitionError | CreateFulfillmentError;
+export type AddFulfillmentToOrderResult =
+  | Fulfillment
+  | EmptyOrderLineSelectionError
+  | ItemsAlreadyFulfilledError
+  | InsufficientStockOnHandError
+  | InvalidFulfillmentHandlerError
+  | FulfillmentStateTransitionError
+  | CreateFulfillmentError;
 
 export type AddItemInput = {
   productVariantId: Scalars['ID'];
@@ -82,7 +89,7 @@ export type Adjustment = {
 export enum AdjustmentType {
   PROMOTION = 'PROMOTION',
   DISTRIBUTED_ORDER_PROMOTION = 'DISTRIBUTED_ORDER_PROMOTION',
-  OTHER = 'OTHER'
+  OTHER = 'OTHER',
 }
 
 export type Administrator = Node & {
@@ -142,15 +149,16 @@ export type AdministratorSortParameter = {
   emailAddress?: Maybe<SortOrder>;
 };
 
-export type Allocation = Node & StockMovement & {
-  id: Scalars['ID'];
-  createdAt: Scalars['DateTime'];
-  updatedAt: Scalars['DateTime'];
-  productVariant: ProductVariant;
-  type: StockMovementType;
-  quantity: Scalars['Int'];
-  orderLine: OrderLine;
-};
+export type Allocation = Node &
+  StockMovement & {
+    id: Scalars['ID'];
+    createdAt: Scalars['DateTime'];
+    updatedAt: Scalars['DateTime'];
+    productVariant: ProductVariant;
+    type: StockMovementType;
+    quantity: Scalars['Int'];
+    orderLine: OrderLine;
+  };
 
 /** Returned if an attempting to refund an OrderItem which has already been refunded */
 export type AlreadyRefundedError = ErrorResult & {
@@ -159,7 +167,11 @@ export type AlreadyRefundedError = ErrorResult & {
   refundId: Scalars['ID'];
 };
 
-export type ApplyCouponCodeResult = Order | CouponCodeExpiredError | CouponCodeInvalidError | CouponCodeLimitError;
+export type ApplyCouponCodeResult =
+  | Order
+  | CouponCodeExpiredError
+  | CouponCodeInvalidError
+  | CouponCodeLimitError;
 
 export type Asset = Node & {
   tags: Array<Tag>;
@@ -228,7 +240,7 @@ export type AssetSortParameter = {
 export enum AssetType {
   IMAGE = 'IMAGE',
   VIDEO = 'VIDEO',
-  BINARY = 'BINARY'
+  BINARY = 'BINARY',
 }
 
 export type AssignAssetsToChannelInput = {
@@ -260,6 +272,11 @@ export type AssignProductsToChannelInput = {
 
 export type AssignPromotionsToChannelInput = {
   promotionIds: Array<Scalars['ID']>;
+  channelId: Scalars['ID'];
+};
+
+export type AssignVendorsToChannelInput = {
+  vendorIds: Array<Scalars['ID']>;
   channelId: Scalars['ID'];
 };
 
@@ -299,6 +316,15 @@ export type BooleanOperators = {
   isNull?: Maybe<Scalars['Boolean']>;
 };
 
+export type Brand = Node & {
+  id: Scalars['ID'];
+  createdAt: Scalars['DateTime'];
+  updatedAt: Scalars['DateTime'];
+  vendorId: Scalars['ID'];
+  name?: Maybe<Scalars['String']>;
+  slug?: Maybe<Scalars['String']>;
+};
+
 /** Returned if an attempting to cancel lines from an Order which is still active */
 export type CancelActiveOrderError = ErrorResult & {
   errorCode: ErrorCode;
@@ -316,7 +342,13 @@ export type CancelOrderInput = {
   reason?: Maybe<Scalars['String']>;
 };
 
-export type CancelOrderResult = Order | EmptyOrderLineSelectionError | QuantityTooGreatError | MultipleOrderError | CancelActiveOrderError | OrderStateTransitionError;
+export type CancelOrderResult =
+  | Order
+  | EmptyOrderLineSelectionError
+  | QuantityTooGreatError
+  | MultipleOrderError
+  | CancelActiveOrderError
+  | OrderStateTransitionError;
 
 /** Returned if the Payment cancellation fails */
 export type CancelPaymentError = ErrorResult & {
@@ -327,15 +359,16 @@ export type CancelPaymentError = ErrorResult & {
 
 export type CancelPaymentResult = Payment | CancelPaymentError | PaymentStateTransitionError;
 
-export type Cancellation = Node & StockMovement & {
-  id: Scalars['ID'];
-  createdAt: Scalars['DateTime'];
-  updatedAt: Scalars['DateTime'];
-  productVariant: ProductVariant;
-  type: StockMovementType;
-  quantity: Scalars['Int'];
-  orderLine: OrderLine;
-};
+export type Cancellation = Node &
+  StockMovement & {
+    id: Scalars['ID'];
+    createdAt: Scalars['DateTime'];
+    updatedAt: Scalars['DateTime'];
+    productVariant: ProductVariant;
+    type: StockMovementType;
+    quantity: Scalars['Int'];
+    orderLine: OrderLine;
+  };
 
 export type Channel = Node & {
   id: Scalars['ID'];
@@ -382,7 +415,6 @@ export type Collection = Node & {
   productVariants: ProductVariantList;
   customFields?: Maybe<Scalars['JSON']>;
 };
-
 
 export type CollectionProductVariantsArgs = {
   options?: Maybe<ProductVariantListOptions>;
@@ -715,13 +747,17 @@ export type CreatePaymentMethodInput = {
   customFields?: Maybe<Scalars['JSON']>;
 };
 
+export type CreateProductCustomFieldsInput = {
+  brandId?: Maybe<Scalars['ID']>;
+};
+
 export type CreateProductInput = {
   featuredAssetId?: Maybe<Scalars['ID']>;
   enabled?: Maybe<Scalars['Boolean']>;
   assetIds?: Maybe<Array<Scalars['ID']>>;
   facetValueIds?: Maybe<Array<Scalars['ID']>>;
   translations: Array<ProductTranslationInput>;
-  customFields?: Maybe<Scalars['JSON']>;
+  customFields?: Maybe<CreateProductCustomFieldsInput>;
 };
 
 export type CreateProductOptionGroupInput = {
@@ -738,6 +774,10 @@ export type CreateProductOptionInput = {
   customFields?: Maybe<Scalars['JSON']>;
 };
 
+export type CreateProductVariantCustomFieldsInput = {
+  costPerItem?: Maybe<Scalars['Int']>;
+};
+
 export type CreateProductVariantInput = {
   productId: Scalars['ID'];
   translations: Array<ProductVariantTranslationInput>;
@@ -752,7 +792,7 @@ export type CreateProductVariantInput = {
   outOfStockThreshold?: Maybe<Scalars['Int']>;
   useGlobalOutOfStockThreshold?: Maybe<Scalars['Boolean']>;
   trackInventory?: Maybe<GlobalFlag>;
-  customFields?: Maybe<Scalars['JSON']>;
+  customFields?: Maybe<CreateProductVariantCustomFieldsInput>;
 };
 
 export type CreateProductVariantOptionInput = {
@@ -809,6 +849,31 @@ export type CreateTaxRateInput = {
   zoneId: Scalars['ID'];
   customerGroupId?: Maybe<Scalars['ID']>;
   customFields?: Maybe<Scalars['JSON']>;
+};
+
+export type CreateVendorBrandInput = {
+  name: Scalars['String'];
+  slug: Scalars['String'];
+};
+
+export type CreateVendorInput = {
+  name: Scalars['String'];
+  slug: Scalars['String'];
+  address?: Maybe<Scalars['String']>;
+  phone?: Maybe<Scalars['String']>;
+  websiteUrl?: Maybe<Scalars['String']>;
+  featuredAssetId?: Maybe<Scalars['ID']>;
+  stripeConnectedAccountId?: Maybe<Scalars['String']>;
+  assetIds?: Maybe<Array<Scalars['ID']>>;
+  translations: Array<CreateVendorTranslationInput>;
+  shopifyId?: Maybe<Scalars['Int']>;
+  brands?: Maybe<Array<CreateVendorBrandInput>>;
+  colabId?: Maybe<Scalars['Int']>;
+};
+
+export type CreateVendorTranslationInput = {
+  languageCode: LanguageCode;
+  description: Scalars['String'];
 };
 
 export type CreateZoneInput = {
@@ -1137,7 +1202,7 @@ export enum CurrencyCode {
   /** Zambian kwacha */
   ZMW = 'ZMW',
   /** Zimbabwean dollar */
-  ZWL = 'ZWL'
+  ZWL = 'ZWL',
 }
 
 export type CurrentUser = {
@@ -1165,7 +1230,15 @@ export type CustomField = {
   ui?: Maybe<Scalars['JSON']>;
 };
 
-export type CustomFieldConfig = StringCustomFieldConfig | LocaleStringCustomFieldConfig | IntCustomFieldConfig | FloatCustomFieldConfig | BooleanCustomFieldConfig | DateTimeCustomFieldConfig | RelationCustomFieldConfig | TextCustomFieldConfig;
+export type CustomFieldConfig =
+  | StringCustomFieldConfig
+  | LocaleStringCustomFieldConfig
+  | IntCustomFieldConfig
+  | FloatCustomFieldConfig
+  | BooleanCustomFieldConfig
+  | DateTimeCustomFieldConfig
+  | RelationCustomFieldConfig
+  | TextCustomFieldConfig;
 
 export type CustomFields = {
   Address: Array<CustomFieldConfig>;
@@ -1195,6 +1268,11 @@ export type CustomFields = {
   Zone: Array<CustomFieldConfig>;
 };
 
+export type CustomProductMappings = {
+  vendorId: Scalars['ID'];
+  vendorName: Scalars['String'];
+};
+
 export type Customer = Node & {
   groups: Array<CustomerGroup>;
   history: HistoryEntryList;
@@ -1209,17 +1287,19 @@ export type Customer = Node & {
   addresses?: Maybe<Array<Address>>;
   orders: OrderList;
   user?: Maybe<User>;
-  customFields?: Maybe<Scalars['JSON']>;
+  customFields?: Maybe<CustomerCustomFields>;
 };
-
 
 export type CustomerHistoryArgs = {
   options?: Maybe<HistoryEntryListOptions>;
 };
 
-
 export type CustomerOrdersArgs = {
   options?: Maybe<OrderListOptions>;
+};
+
+export type CustomerCustomFields = {
+  shopifyId?: Maybe<Scalars['Float']>;
 };
 
 export type CustomerFilterParameter = {
@@ -1232,6 +1312,7 @@ export type CustomerFilterParameter = {
   lastName?: Maybe<StringOperators>;
   phoneNumber?: Maybe<StringOperators>;
   emailAddress?: Maybe<StringOperators>;
+  shopifyId?: Maybe<NumberOperators>;
 };
 
 export type CustomerGroup = Node & {
@@ -1242,7 +1323,6 @@ export type CustomerGroup = Node & {
   customers: CustomerList;
   customFields?: Maybe<Scalars['JSON']>;
 };
-
 
 export type CustomerGroupCustomersArgs = {
   options?: Maybe<CustomerListOptions>;
@@ -1307,6 +1387,7 @@ export type CustomerSortParameter = {
   lastName?: Maybe<SortOrder>;
   phoneNumber?: Maybe<SortOrder>;
   emailAddress?: Maybe<SortOrder>;
+  shopifyId?: Maybe<SortOrder>;
 };
 
 /** Operators for filtering on a list of Date fields */
@@ -1327,7 +1408,6 @@ export type DateRange = {
   start: Scalars['DateTime'];
   end: Scalars['DateTime'];
 };
-
 
 /**
  * Expects the same validation formats as the `<input type="datetime-local">` HTML element.
@@ -1369,7 +1449,7 @@ export enum DeletionResult {
   /** The entity was successfully deleted */
   DELETED = 'DELETED',
   /** Deletion did not take place, reason given in message */
-  NOT_DELETED = 'NOT_DELETED'
+  NOT_DELETED = 'NOT_DELETED',
 }
 
 export type Discount = {
@@ -1434,7 +1514,7 @@ export enum ErrorCode {
   COUPON_CODE_LIMIT_ERROR = 'COUPON_CODE_LIMIT_ERROR',
   ORDER_MODIFICATION_ERROR = 'ORDER_MODIFICATION_ERROR',
   INELIGIBLE_SHIPPING_METHOD_ERROR = 'INELIGIBLE_SHIPPING_METHOD_ERROR',
-  NO_ACTIVE_ORDER_ERROR = 'NO_ACTIVE_ORDER_ERROR'
+  NO_ACTIVE_ORDER_ERROR = 'NO_ACTIVE_ORDER_ERROR',
 }
 
 export type ErrorResult = {
@@ -1628,7 +1708,11 @@ export type Fulfillment = Node & {
   state: Scalars['String'];
   method: Scalars['String'];
   trackingCode?: Maybe<Scalars['String']>;
-  customFields?: Maybe<Scalars['JSON']>;
+  customFields?: Maybe<FulfillmentCustomFields>;
+};
+
+export type FulfillmentCustomFields = {
+  fulfilmentCentre?: Maybe<Scalars['String']>;
 };
 
 export type FulfillmentLineSummary = {
@@ -1648,7 +1732,7 @@ export type FulfillmentStateTransitionError = ErrorResult & {
 export enum GlobalFlag {
   TRUE = 'TRUE',
   FALSE = 'FALSE',
-  INHERIT = 'INHERIT'
+  INHERIT = 'INHERIT',
 }
 
 export type GlobalSettings = {
@@ -1728,7 +1812,7 @@ export enum HistoryEntryType {
   ORDER_NOTE = 'ORDER_NOTE',
   ORDER_COUPON_APPLIED = 'ORDER_COUPON_APPLIED',
   ORDER_COUPON_REMOVED = 'ORDER_COUPON_REMOVED',
-  ORDER_MODIFIED = 'ORDER_MODIFIED'
+  ORDER_MODIFIED = 'ORDER_MODIFIED',
 }
 
 /** Operators for filtering on a list of ID fields */
@@ -1805,12 +1889,57 @@ export type InvalidFulfillmentHandlerError = ErrorResult & {
   message: Scalars['String'];
 };
 
+export type InventoryItem = Node & {
+  id: Scalars['ID'];
+  sku: Scalars['String'];
+  name: Scalars['String'];
+  quantity: Scalars['Int'];
+};
+
+export type InventoryItemFilterParameter = {
+  id?: Maybe<IdOperators>;
+  sku?: Maybe<StringOperators>;
+  name?: Maybe<StringOperators>;
+  quantity?: Maybe<NumberOperators>;
+};
+
+export type InventoryItemList = PaginatedList & {
+  items: Array<InventoryItem>;
+  totalItems: Scalars['Int'];
+  lastUpdatedAt?: Maybe<Scalars['DateTime']>;
+};
+
+export type InventoryItemListOptions = {
+  locationIds: Array<Scalars['ID']>;
+  /** Skips the first n results, for use in pagination */
+  skip?: Maybe<Scalars['Int']>;
+  /** Takes n results, for use in pagination */
+  take?: Maybe<Scalars['Int']>;
+  /** Specifies which properties to sort the results by */
+  sort?: Maybe<InventoryItemSortParameter>;
+  /** Allows the results to be filtered */
+  filter?: Maybe<InventoryItemFilterParameter>;
+  /** Specifies whether multiple "filter" arguments should be combines with a logical AND or OR operation. Defaults to AND. */
+  filterOperator?: Maybe<LogicalOperator>;
+};
+
+export type InventoryItemSortParameter = {
+  id?: Maybe<SortOrder>;
+  sku?: Maybe<SortOrder>;
+  name?: Maybe<SortOrder>;
+  quantity?: Maybe<SortOrder>;
+};
+
+export type InventoryLocation = {
+  id: Scalars['ID'];
+  name: Scalars['String'];
+};
+
 /** Returned if the specified items are already part of a Fulfillment */
 export type ItemsAlreadyFulfilledError = ErrorResult & {
   errorCode: ErrorCode;
   message: Scalars['String'];
 };
-
 
 export type Job = Node & {
   id: Scalars['ID'];
@@ -1895,7 +2024,7 @@ export enum JobState {
   COMPLETED = 'COMPLETED',
   RETRYING = 'RETRYING',
   FAILED = 'FAILED',
-  CANCELLED = 'CANCELLED'
+  CANCELLED = 'CANCELLED',
 }
 
 /**
@@ -2221,7 +2350,7 @@ export enum LanguageCode {
   /** Yoruba */
   yo = 'yo',
   /** Zulu */
-  zu = 'zu'
+  zu = 'zu',
 }
 
 /** Returned if attempting to set a Channel's defaultLanguageCode to a language which is not enabled in GlobalSettings */
@@ -2252,7 +2381,7 @@ export type LocalizedString = {
 
 export enum LogicalOperator {
   AND = 'AND',
-  OR = 'OR'
+  OR = 'OR',
 }
 
 export type ManualPaymentInput = {
@@ -2296,6 +2425,7 @@ export type ModifyOrderInput = {
   refund?: Maybe<AdministratorRefundInput>;
   options?: Maybe<ModifyOrderOptions>;
   couponCodes?: Maybe<Array<Scalars['String']>>;
+  customFields?: Maybe<UpdateOrderCustomFieldsInput>;
 };
 
 export type ModifyOrderOptions = {
@@ -2303,7 +2433,18 @@ export type ModifyOrderOptions = {
   recalculateShipping?: Maybe<Scalars['Boolean']>;
 };
 
-export type ModifyOrderResult = Order | NoChangesSpecifiedError | OrderModificationStateError | PaymentMethodMissingError | RefundPaymentIdMissingError | OrderLimitError | NegativeQuantityError | InsufficientStockError | CouponCodeExpiredError | CouponCodeInvalidError | CouponCodeLimitError;
+export type ModifyOrderResult =
+  | Order
+  | NoChangesSpecifiedError
+  | OrderModificationStateError
+  | PaymentMethodMissingError
+  | RefundPaymentIdMissingError
+  | OrderLimitError
+  | NegativeQuantityError
+  | InsufficientStockError
+  | CouponCodeExpiredError
+  | CouponCodeInvalidError
+  | CouponCodeLimitError;
 
 export type MoveCollectionInput = {
   collectionId: Scalars['ID'];
@@ -2564,59 +2705,58 @@ export type Mutation = {
   addMembersToZone: Zone;
   /** Remove members from a Zone */
   removeMembersFromZone: Zone;
+  requestAdminPasswordReset?: Maybe<Scalars['Boolean']>;
+  resetAdminPassword: ResetAdminPasswordResponse;
+  createVendor: Vendor;
+  updateVendor: Vendor;
+  deleteVendor: DeletionResponse;
+  assignVendorsToChannel: Array<Vendor>;
+  removeVendorsFromChannel: Array<Vendor>;
+  hardDeleteAdministrator: DeletionResponse;
+  hardDeleteVendor: DeletionResponse;
+  deleteVendorChannel: DeletionResponse;
 };
-
 
 export type MutationCreateAdministratorArgs = {
   input: CreateAdministratorInput;
 };
 
-
 export type MutationUpdateAdministratorArgs = {
   input: UpdateAdministratorInput;
 };
-
 
 export type MutationUpdateActiveAdministratorArgs = {
   input: UpdateActiveAdministratorInput;
 };
 
-
 export type MutationDeleteAdministratorArgs = {
   id: Scalars['ID'];
 };
-
 
 export type MutationAssignRoleToAdministratorArgs = {
   administratorId: Scalars['ID'];
   roleId: Scalars['ID'];
 };
 
-
 export type MutationCreateAssetsArgs = {
   input: Array<CreateAssetInput>;
 };
-
 
 export type MutationUpdateAssetArgs = {
   input: UpdateAssetInput;
 };
 
-
 export type MutationDeleteAssetArgs = {
   input: DeleteAssetInput;
 };
-
 
 export type MutationDeleteAssetsArgs = {
   input: DeleteAssetsInput;
 };
 
-
 export type MutationAssignAssetsToChannelArgs = {
   input: AssignAssetsToChannelInput;
 };
-
 
 export type MutationLoginArgs = {
   username: Scalars['String'];
@@ -2624,326 +2764,264 @@ export type MutationLoginArgs = {
   rememberMe?: Maybe<Scalars['Boolean']>;
 };
 
-
 export type MutationAuthenticateArgs = {
   input: AuthenticationInput;
   rememberMe?: Maybe<Scalars['Boolean']>;
 };
 
-
 export type MutationCreateChannelArgs = {
   input: CreateChannelInput;
 };
-
 
 export type MutationUpdateChannelArgs = {
   input: UpdateChannelInput;
 };
 
-
 export type MutationDeleteChannelArgs = {
   id: Scalars['ID'];
 };
-
 
 export type MutationCreateCollectionArgs = {
   input: CreateCollectionInput;
 };
 
-
 export type MutationUpdateCollectionArgs = {
   input: UpdateCollectionInput;
 };
-
 
 export type MutationDeleteCollectionArgs = {
   id: Scalars['ID'];
 };
 
-
 export type MutationDeleteCollectionsArgs = {
   ids: Array<Scalars['ID']>;
 };
-
 
 export type MutationMoveCollectionArgs = {
   input: MoveCollectionInput;
 };
 
-
 export type MutationAssignCollectionsToChannelArgs = {
   input: AssignCollectionsToChannelInput;
 };
-
 
 export type MutationRemoveCollectionsFromChannelArgs = {
   input: RemoveCollectionsFromChannelInput;
 };
 
-
 export type MutationCreateCountryArgs = {
   input: CreateCountryInput;
 };
-
 
 export type MutationUpdateCountryArgs = {
   input: UpdateCountryInput;
 };
 
-
 export type MutationDeleteCountryArgs = {
   id: Scalars['ID'];
 };
-
 
 export type MutationCreateCustomerGroupArgs = {
   input: CreateCustomerGroupInput;
 };
 
-
 export type MutationUpdateCustomerGroupArgs = {
   input: UpdateCustomerGroupInput;
 };
 
-
 export type MutationDeleteCustomerGroupArgs = {
   id: Scalars['ID'];
 };
-
 
 export type MutationAddCustomersToGroupArgs = {
   customerGroupId: Scalars['ID'];
   customerIds: Array<Scalars['ID']>;
 };
 
-
 export type MutationRemoveCustomersFromGroupArgs = {
   customerGroupId: Scalars['ID'];
   customerIds: Array<Scalars['ID']>;
 };
-
 
 export type MutationCreateCustomerArgs = {
   input: CreateCustomerInput;
   password?: Maybe<Scalars['String']>;
 };
 
-
 export type MutationUpdateCustomerArgs = {
   input: UpdateCustomerInput;
 };
 
-
 export type MutationDeleteCustomerArgs = {
   id: Scalars['ID'];
 };
-
 
 export type MutationCreateCustomerAddressArgs = {
   customerId: Scalars['ID'];
   input: CreateAddressInput;
 };
 
-
 export type MutationUpdateCustomerAddressArgs = {
   input: UpdateAddressInput;
 };
-
 
 export type MutationDeleteCustomerAddressArgs = {
   id: Scalars['ID'];
 };
 
-
 export type MutationAddNoteToCustomerArgs = {
   input: AddNoteToCustomerInput;
 };
-
 
 export type MutationUpdateCustomerNoteArgs = {
   input: UpdateCustomerNoteInput;
 };
 
-
 export type MutationDeleteCustomerNoteArgs = {
   id: Scalars['ID'];
 };
-
 
 export type MutationCreateFacetArgs = {
   input: CreateFacetInput;
 };
 
-
 export type MutationUpdateFacetArgs = {
   input: UpdateFacetInput;
 };
-
 
 export type MutationDeleteFacetArgs = {
   id: Scalars['ID'];
   force?: Maybe<Scalars['Boolean']>;
 };
 
-
 export type MutationDeleteFacetsArgs = {
   ids: Array<Scalars['ID']>;
   force?: Maybe<Scalars['Boolean']>;
 };
 
-
 export type MutationCreateFacetValuesArgs = {
   input: Array<CreateFacetValueInput>;
 };
 
-
 export type MutationUpdateFacetValuesArgs = {
   input: Array<UpdateFacetValueInput>;
 };
-
 
 export type MutationDeleteFacetValuesArgs = {
   ids: Array<Scalars['ID']>;
   force?: Maybe<Scalars['Boolean']>;
 };
 
-
 export type MutationAssignFacetsToChannelArgs = {
   input: AssignFacetsToChannelInput;
 };
-
 
 export type MutationRemoveFacetsFromChannelArgs = {
   input: RemoveFacetsFromChannelInput;
 };
 
-
 export type MutationUpdateGlobalSettingsArgs = {
   input: UpdateGlobalSettingsInput;
 };
 
-
 export type MutationImportProductsArgs = {
   csvFile: Scalars['Upload'];
 };
-
 
 export type MutationRemoveSettledJobsArgs = {
   queueNames?: Maybe<Array<Scalars['String']>>;
   olderThan?: Maybe<Scalars['DateTime']>;
 };
 
-
 export type MutationCancelJobArgs = {
   jobId: Scalars['ID'];
 };
-
 
 export type MutationFlushBufferedJobsArgs = {
   bufferIds?: Maybe<Array<Scalars['String']>>;
 };
 
-
 export type MutationSettlePaymentArgs = {
   id: Scalars['ID'];
 };
-
 
 export type MutationCancelPaymentArgs = {
   id: Scalars['ID'];
 };
 
-
 export type MutationAddFulfillmentToOrderArgs = {
   input: FulfillOrderInput;
 };
-
 
 export type MutationCancelOrderArgs = {
   input: CancelOrderInput;
 };
 
-
 export type MutationRefundOrderArgs = {
   input: RefundOrderInput;
 };
-
 
 export type MutationSettleRefundArgs = {
   input: SettleRefundInput;
 };
 
-
 export type MutationAddNoteToOrderArgs = {
   input: AddNoteToOrderInput;
 };
-
 
 export type MutationUpdateOrderNoteArgs = {
   input: UpdateOrderNoteInput;
 };
 
-
 export type MutationDeleteOrderNoteArgs = {
   id: Scalars['ID'];
 };
-
 
 export type MutationTransitionOrderToStateArgs = {
   id: Scalars['ID'];
   state: Scalars['String'];
 };
 
-
 export type MutationTransitionFulfillmentToStateArgs = {
   id: Scalars['ID'];
   state: Scalars['String'];
 };
-
 
 export type MutationTransitionPaymentToStateArgs = {
   id: Scalars['ID'];
   state: Scalars['String'];
 };
 
-
 export type MutationSetOrderCustomFieldsArgs = {
   input: UpdateOrderInput;
 };
-
 
 export type MutationModifyOrderArgs = {
   input: ModifyOrderInput;
 };
 
-
 export type MutationAddManualPaymentToOrderArgs = {
   input: ManualPaymentInput;
 };
 
-
 export type MutationDeleteDraftOrderArgs = {
   orderId: Scalars['ID'];
 };
-
 
 export type MutationAddItemToDraftOrderArgs = {
   orderId: Scalars['ID'];
   input: AddItemToDraftOrderInput;
 };
 
-
 export type MutationAdjustDraftOrderLineArgs = {
   orderId: Scalars['ID'];
   input: AdjustDraftOrderLineInput;
 };
 
-
 export type MutationRemoveDraftOrderLineArgs = {
   orderId: Scalars['ID'];
   orderLineId: Scalars['ID'];
 };
-
 
 export type MutationSetCustomerForDraftOrderArgs = {
   orderId: Scalars['ID'];
@@ -2951,285 +3029,272 @@ export type MutationSetCustomerForDraftOrderArgs = {
   input?: Maybe<CreateCustomerInput>;
 };
 
-
 export type MutationSetDraftOrderShippingAddressArgs = {
   orderId: Scalars['ID'];
   input: CreateAddressInput;
 };
-
 
 export type MutationSetDraftOrderBillingAddressArgs = {
   orderId: Scalars['ID'];
   input: CreateAddressInput;
 };
 
-
 export type MutationSetDraftOrderCustomFieldsArgs = {
   orderId: Scalars['ID'];
   input: UpdateOrderInput;
 };
-
 
 export type MutationApplyCouponCodeToDraftOrderArgs = {
   orderId: Scalars['ID'];
   couponCode: Scalars['String'];
 };
 
-
 export type MutationRemoveCouponCodeFromDraftOrderArgs = {
   orderId: Scalars['ID'];
   couponCode: Scalars['String'];
 };
-
 
 export type MutationSetDraftOrderShippingMethodArgs = {
   orderId: Scalars['ID'];
   shippingMethodId: Scalars['ID'];
 };
 
-
 export type MutationCreatePaymentMethodArgs = {
   input: CreatePaymentMethodInput;
 };
 
-
 export type MutationUpdatePaymentMethodArgs = {
   input: UpdatePaymentMethodInput;
 };
-
 
 export type MutationDeletePaymentMethodArgs = {
   id: Scalars['ID'];
   force?: Maybe<Scalars['Boolean']>;
 };
 
-
 export type MutationCreateProductOptionGroupArgs = {
   input: CreateProductOptionGroupInput;
 };
-
 
 export type MutationUpdateProductOptionGroupArgs = {
   input: UpdateProductOptionGroupInput;
 };
 
-
 export type MutationCreateProductOptionArgs = {
   input: CreateProductOptionInput;
 };
-
 
 export type MutationUpdateProductOptionArgs = {
   input: UpdateProductOptionInput;
 };
 
-
 export type MutationDeleteProductOptionArgs = {
   id: Scalars['ID'];
 };
-
 
 export type MutationCreateProductArgs = {
   input: CreateProductInput;
 };
 
-
 export type MutationUpdateProductArgs = {
   input: UpdateProductInput;
 };
-
 
 export type MutationUpdateProductsArgs = {
   input: Array<UpdateProductInput>;
 };
 
-
 export type MutationDeleteProductArgs = {
   id: Scalars['ID'];
 };
 
-
 export type MutationDeleteProductsArgs = {
   ids: Array<Scalars['ID']>;
 };
-
 
 export type MutationAddOptionGroupToProductArgs = {
   productId: Scalars['ID'];
   optionGroupId: Scalars['ID'];
 };
 
-
 export type MutationRemoveOptionGroupFromProductArgs = {
   productId: Scalars['ID'];
   optionGroupId: Scalars['ID'];
 };
 
-
 export type MutationCreateProductVariantsArgs = {
   input: Array<CreateProductVariantInput>;
 };
-
 
 export type MutationUpdateProductVariantsArgs = {
   input: Array<UpdateProductVariantInput>;
 };
 
-
 export type MutationDeleteProductVariantArgs = {
   id: Scalars['ID'];
 };
-
 
 export type MutationDeleteProductVariantsArgs = {
   ids: Array<Scalars['ID']>;
 };
 
-
 export type MutationAssignProductsToChannelArgs = {
   input: AssignProductsToChannelInput;
 };
-
 
 export type MutationRemoveProductsFromChannelArgs = {
   input: RemoveProductsFromChannelInput;
 };
 
-
 export type MutationAssignProductVariantsToChannelArgs = {
   input: AssignProductVariantsToChannelInput;
 };
-
 
 export type MutationRemoveProductVariantsFromChannelArgs = {
   input: RemoveProductVariantsFromChannelInput;
 };
 
-
 export type MutationCreatePromotionArgs = {
   input: CreatePromotionInput;
 };
-
 
 export type MutationUpdatePromotionArgs = {
   input: UpdatePromotionInput;
 };
 
-
 export type MutationDeletePromotionArgs = {
   id: Scalars['ID'];
 };
-
 
 export type MutationAssignPromotionsToChannelArgs = {
   input: AssignPromotionsToChannelInput;
 };
 
-
 export type MutationRemovePromotionsFromChannelArgs = {
   input: RemovePromotionsFromChannelInput;
 };
-
 
 export type MutationCreateRoleArgs = {
   input: CreateRoleInput;
 };
 
-
 export type MutationUpdateRoleArgs = {
   input: UpdateRoleInput;
 };
-
 
 export type MutationDeleteRoleArgs = {
   id: Scalars['ID'];
 };
 
-
 export type MutationCreateShippingMethodArgs = {
   input: CreateShippingMethodInput;
 };
-
 
 export type MutationUpdateShippingMethodArgs = {
   input: UpdateShippingMethodInput;
 };
 
-
 export type MutationDeleteShippingMethodArgs = {
   id: Scalars['ID'];
 };
-
 
 export type MutationCreateTagArgs = {
   input: CreateTagInput;
 };
 
-
 export type MutationUpdateTagArgs = {
   input: UpdateTagInput;
 };
-
 
 export type MutationDeleteTagArgs = {
   id: Scalars['ID'];
 };
 
-
 export type MutationCreateTaxCategoryArgs = {
   input: CreateTaxCategoryInput;
 };
-
 
 export type MutationUpdateTaxCategoryArgs = {
   input: UpdateTaxCategoryInput;
 };
 
-
 export type MutationDeleteTaxCategoryArgs = {
   id: Scalars['ID'];
 };
-
 
 export type MutationCreateTaxRateArgs = {
   input: CreateTaxRateInput;
 };
 
-
 export type MutationUpdateTaxRateArgs = {
   input: UpdateTaxRateInput;
 };
-
 
 export type MutationDeleteTaxRateArgs = {
   id: Scalars['ID'];
 };
 
-
 export type MutationCreateZoneArgs = {
   input: CreateZoneInput;
 };
-
 
 export type MutationUpdateZoneArgs = {
   input: UpdateZoneInput;
 };
 
-
 export type MutationDeleteZoneArgs = {
   id: Scalars['ID'];
 };
-
 
 export type MutationAddMembersToZoneArgs = {
   zoneId: Scalars['ID'];
   memberIds: Array<Scalars['ID']>;
 };
 
-
 export type MutationRemoveMembersFromZoneArgs = {
   zoneId: Scalars['ID'];
   memberIds: Array<Scalars['ID']>;
+};
+
+export type MutationRequestAdminPasswordResetArgs = {
+  email: Scalars['String'];
+};
+
+export type MutationResetAdminPasswordArgs = {
+  token: Scalars['String'];
+  password: Scalars['String'];
+};
+
+export type MutationCreateVendorArgs = {
+  input: CreateVendorInput;
+};
+
+export type MutationUpdateVendorArgs = {
+  input: UpdateVendorInput;
+};
+
+export type MutationDeleteVendorArgs = {
+  id: Scalars['ID'];
+};
+
+export type MutationAssignVendorsToChannelArgs = {
+  input: AssignVendorsToChannelInput;
+};
+
+export type MutationRemoveVendorsFromChannelArgs = {
+  input: RemoveVendorsFromChannelInput;
+};
+
+export type MutationHardDeleteAdministratorArgs = {
+  emailAddress: Scalars['String'];
+};
+
+export type MutationHardDeleteVendorArgs = {
+  name: Scalars['String'];
+};
+
+export type MutationDeleteVendorChannelArgs = {
+  vendorSlug: Scalars['String'];
 };
 
 export type NativeAuthInput = {
@@ -3352,9 +3417,8 @@ export type Order = Node & {
   /** A summary of the taxes being applied to this Order */
   taxSummary: Array<OrderTaxSummary>;
   history: HistoryEntryList;
-  customFields?: Maybe<Scalars['JSON']>;
+  customFields?: Maybe<OrderCustomFields>;
 };
-
 
 export type OrderHistoryArgs = {
   options?: Maybe<HistoryEntryListOptions>;
@@ -3372,6 +3436,14 @@ export type OrderAddress = {
   countryCode?: Maybe<Scalars['String']>;
   phoneNumber?: Maybe<Scalars['String']>;
   customFields?: Maybe<Scalars['JSON']>;
+};
+
+export type OrderCustomFields = {
+  deliveryDate?: Maybe<Scalars['String']>;
+  deliveryInstructions?: Maybe<Scalars['String']>;
+  mobileNumber?: Maybe<Scalars['String']>;
+  shopifyId?: Maybe<Scalars['Float']>;
+  giftCard?: Maybe<Scalars['String']>;
 };
 
 export type OrderFilterParameter = {
@@ -3392,6 +3464,11 @@ export type OrderFilterParameter = {
   shippingWithTax?: Maybe<NumberOperators>;
   total?: Maybe<NumberOperators>;
   totalWithTax?: Maybe<NumberOperators>;
+  deliveryDate?: Maybe<StringOperators>;
+  deliveryInstructions?: Maybe<StringOperators>;
+  mobileNumber?: Maybe<StringOperators>;
+  shopifyId?: Maybe<NumberOperators>;
+  giftCard?: Maybe<StringOperators>;
 };
 
 export type OrderItem = Node & {
@@ -3495,7 +3572,13 @@ export type OrderLine = Node & {
   taxLines: Array<TaxLine>;
   order: Order;
   fulfillments?: Maybe<Array<Fulfillment>>;
-  customFields?: Maybe<Scalars['JSON']>;
+  customFields?: Maybe<OrderLineCustomFields>;
+};
+
+export type OrderLineCustomFields = {
+  shopifyId?: Maybe<Scalars['Float']>;
+  costPerItem?: Maybe<Scalars['Float']>;
+  vendorOrder?: Maybe<VendorOrder>;
 };
 
 export type OrderLineInput = {
@@ -3567,6 +3650,11 @@ export type OrderSortParameter = {
   shippingWithTax?: Maybe<SortOrder>;
   total?: Maybe<SortOrder>;
   totalWithTax?: Maybe<SortOrder>;
+  deliveryDate?: Maybe<SortOrder>;
+  deliveryInstructions?: Maybe<SortOrder>;
+  mobileNumber?: Maybe<SortOrder>;
+  shopifyId?: Maybe<SortOrder>;
+  giftCard?: Maybe<SortOrder>;
 };
 
 /** Returned if there is an error in transitioning the Order state */
@@ -3898,7 +3986,23 @@ export enum Permission {
   /** Grants permission to update Zone */
   UpdateZone = 'UpdateZone',
   /** Grants permission to delete Zone */
-  DeleteZone = 'DeleteZone'
+  DeleteZone = 'DeleteZone',
+  /** Allows read access to inventory levels */
+  ReadInventoryLevels = 'ReadInventoryLevels',
+  /** Allows access to temporary links for partners */
+  AccessTemporaryLinks = 'AccessTemporaryLinks',
+  /** Grants permission to create Vendor */
+  CreateVendor = 'CreateVendor',
+  /** Grants permission to read Vendor */
+  ReadVendor = 'ReadVendor',
+  /** Grants permission to update Vendor */
+  UpdateVendor = 'UpdateVendor',
+  /** Grants permission to delete Vendor */
+  DeleteVendor = 'DeleteVendor',
+  /** Allows read access to vendor sales reports */
+  ReadSalesReports = 'ReadSalesReports',
+  /** Allows read access to vendor remittances and payouts */
+  ReadRemittances = 'ReadRemittances',
 }
 
 export type PermissionDefinition = {
@@ -3914,6 +4018,16 @@ export type PreviewCollectionVariantsInput = {
 
 /** The price range where the result has more than one price */
 export type PriceRange = {
+  min: Scalars['Int'];
+  max: Scalars['Int'];
+};
+
+export type PriceRangeBucket = {
+  to: Scalars['Int'];
+  count: Scalars['Int'];
+};
+
+export type PriceRangeInput = {
   min: Scalars['Int'];
   max: Scalars['Int'];
 };
@@ -3938,12 +4052,18 @@ export type Product = Node & {
   facetValues: Array<FacetValue>;
   translations: Array<ProductTranslation>;
   collections: Array<Collection>;
-  customFields?: Maybe<Scalars['JSON']>;
+  customFields?: Maybe<ProductCustomFields>;
 };
-
 
 export type ProductVariantListArgs = {
   options?: Maybe<ProductVariantListOptions>;
+};
+
+export type ProductCustomFields = {
+  shopifyId?: Maybe<Scalars['Float']>;
+  toDisable?: Maybe<Scalars['Boolean']>;
+  isBundle?: Maybe<Scalars['Boolean']>;
+  brand?: Maybe<Brand>;
 };
 
 export type ProductFilterParameter = {
@@ -3955,6 +4075,9 @@ export type ProductFilterParameter = {
   name?: Maybe<StringOperators>;
   slug?: Maybe<StringOperators>;
   description?: Maybe<StringOperators>;
+  shopifyId?: Maybe<NumberOperators>;
+  toDisable?: Maybe<BooleanOperators>;
+  isBundle?: Maybe<BooleanOperators>;
 };
 
 export type ProductList = PaginatedList & {
@@ -3997,7 +4120,11 @@ export type ProductOptionGroup = Node & {
   name: Scalars['String'];
   options: Array<ProductOption>;
   translations: Array<ProductOptionGroupTranslation>;
-  customFields?: Maybe<Scalars['JSON']>;
+  customFields?: Maybe<ProductOptionGroupCustomFields>;
+};
+
+export type ProductOptionGroupCustomFields = {
+  shopifyId?: Maybe<Scalars['Float']>;
 };
 
 export type ProductOptionGroupTranslation = {
@@ -4037,6 +4164,47 @@ export type ProductOptionTranslationInput = {
   customFields?: Maybe<Scalars['JSON']>;
 };
 
+export type ProductSales = Node & {
+  id: Scalars['ID'];
+  name: Scalars['String'];
+  quantitySold: Scalars['Int'];
+  revenue: Scalars['Int'];
+};
+
+export type ProductSalesFilterParameter = {
+  id?: Maybe<IdOperators>;
+  name?: Maybe<StringOperators>;
+  quantitySold?: Maybe<NumberOperators>;
+  revenue?: Maybe<NumberOperators>;
+};
+
+export type ProductSalesList = PaginatedList & {
+  items: Array<ProductSales>;
+  totalItems: Scalars['Int'];
+};
+
+export type ProductSalesListOptions = {
+  startDate: Scalars['DateTime'];
+  endDate: Scalars['DateTime'];
+  /** Skips the first n results, for use in pagination */
+  skip?: Maybe<Scalars['Int']>;
+  /** Takes n results, for use in pagination */
+  take?: Maybe<Scalars['Int']>;
+  /** Specifies which properties to sort the results by */
+  sort?: Maybe<ProductSalesSortParameter>;
+  /** Allows the results to be filtered */
+  filter?: Maybe<ProductSalesFilterParameter>;
+  /** Specifies whether multiple "filter" arguments should be combines with a logical AND or OR operation. Defaults to AND. */
+  filterOperator?: Maybe<LogicalOperator>;
+};
+
+export type ProductSalesSortParameter = {
+  id?: Maybe<SortOrder>;
+  name?: Maybe<SortOrder>;
+  quantitySold?: Maybe<SortOrder>;
+  revenue?: Maybe<SortOrder>;
+};
+
 export type ProductSortParameter = {
   id?: Maybe<SortOrder>;
   createdAt?: Maybe<SortOrder>;
@@ -4044,6 +4212,10 @@ export type ProductSortParameter = {
   name?: Maybe<SortOrder>;
   slug?: Maybe<SortOrder>;
   description?: Maybe<SortOrder>;
+  shopifyId?: Maybe<SortOrder>;
+  toDisable?: Maybe<SortOrder>;
+  isBundle?: Maybe<SortOrder>;
+  brand?: Maybe<SortOrder>;
 };
 
 export type ProductTranslation = {
@@ -4093,12 +4265,16 @@ export type ProductVariant = Node & {
   options: Array<ProductOption>;
   facetValues: Array<FacetValue>;
   translations: Array<ProductVariantTranslation>;
-  customFields?: Maybe<Scalars['JSON']>;
+  customFields?: Maybe<ProductVariantCustomFields>;
 };
-
 
 export type ProductVariantStockMovementsArgs = {
   options?: Maybe<StockMovementListOptions>;
+};
+
+export type ProductVariantCustomFields = {
+  shopifyId?: Maybe<Scalars['Float']>;
+  costPerItem?: Maybe<Scalars['Int']>;
 };
 
 export type ProductVariantFilterParameter = {
@@ -4119,6 +4295,8 @@ export type ProductVariantFilterParameter = {
   currencyCode?: Maybe<StringOperators>;
   priceWithTax?: Maybe<NumberOperators>;
   stockLevel?: Maybe<StringOperators>;
+  shopifyId?: Maybe<NumberOperators>;
+  costPerItem?: Maybe<NumberOperators>;
 };
 
 export type ProductVariantList = PaginatedList & {
@@ -4152,6 +4330,8 @@ export type ProductVariantSortParameter = {
   price?: Maybe<SortOrder>;
   priceWithTax?: Maybe<SortOrder>;
   stockLevel?: Maybe<SortOrder>;
+  shopifyId?: Maybe<SortOrder>;
+  costPerItem?: Maybe<SortOrder>;
 };
 
 export type ProductVariantTranslation = {
@@ -4305,244 +4485,240 @@ export type Query = {
   taxRate?: Maybe<TaxRate>;
   zones: Array<Zone>;
   zone?: Maybe<Zone>;
+  locations: Array<InventoryLocation>;
+  inventory: InventoryItemList;
+  vendors: VendorList;
+  vendor?: Maybe<Vendor>;
+  productSales: ProductSalesList;
+  salesSummary: SalesSummary;
+  remittanceSummaries: RemittanceSummaryList;
+  remittance: Remittance;
 };
-
 
 export type QueryAdministratorsArgs = {
   options?: Maybe<AdministratorListOptions>;
 };
 
-
 export type QueryAdministratorArgs = {
   id: Scalars['ID'];
 };
-
 
 export type QueryAssetsArgs = {
   options?: Maybe<AssetListOptions>;
 };
 
-
 export type QueryAssetArgs = {
   id: Scalars['ID'];
 };
-
 
 export type QueryChannelArgs = {
   id: Scalars['ID'];
 };
 
-
 export type QueryCollectionsArgs = {
   options?: Maybe<CollectionListOptions>;
 };
-
 
 export type QueryCollectionArgs = {
   id?: Maybe<Scalars['ID']>;
   slug?: Maybe<Scalars['String']>;
 };
 
-
 export type QueryPreviewCollectionVariantsArgs = {
   input: PreviewCollectionVariantsInput;
   options?: Maybe<ProductVariantListOptions>;
 };
 
-
 export type QueryCountriesArgs = {
   options?: Maybe<CountryListOptions>;
 };
-
 
 export type QueryCountryArgs = {
   id: Scalars['ID'];
 };
 
-
 export type QueryCustomerGroupsArgs = {
   options?: Maybe<CustomerGroupListOptions>;
 };
-
 
 export type QueryCustomerGroupArgs = {
   id: Scalars['ID'];
 };
 
-
 export type QueryCustomersArgs = {
   options?: Maybe<CustomerListOptions>;
 };
-
 
 export type QueryCustomerArgs = {
   id: Scalars['ID'];
 };
 
-
 export type QueryFacetsArgs = {
   options?: Maybe<FacetListOptions>;
 };
-
 
 export type QueryFacetArgs = {
   id: Scalars['ID'];
 };
 
-
 export type QueryFacetValuesArgs = {
   options?: Maybe<FacetValueListOptions>;
 };
-
 
 export type QueryJobArgs = {
   jobId: Scalars['ID'];
 };
 
-
 export type QueryJobsArgs = {
   options?: Maybe<JobListOptions>;
 };
-
 
 export type QueryJobsByIdArgs = {
   jobIds: Array<Scalars['ID']>;
 };
 
-
 export type QueryJobBufferSizeArgs = {
   bufferIds?: Maybe<Array<Scalars['String']>>;
 };
-
 
 export type QueryOrderArgs = {
   id: Scalars['ID'];
 };
 
-
 export type QueryOrdersArgs = {
   options?: Maybe<OrderListOptions>;
 };
-
 
 export type QueryEligibleShippingMethodsForDraftOrderArgs = {
   orderId: Scalars['ID'];
 };
 
-
 export type QueryPaymentMethodsArgs = {
   options?: Maybe<PaymentMethodListOptions>;
 };
-
 
 export type QueryPaymentMethodArgs = {
   id: Scalars['ID'];
 };
 
-
 export type QueryProductOptionGroupsArgs = {
   filterTerm?: Maybe<Scalars['String']>;
 };
-
 
 export type QueryProductOptionGroupArgs = {
   id: Scalars['ID'];
 };
 
-
 export type QuerySearchArgs = {
   input: SearchInput;
 };
 
-
 export type QueryProductsArgs = {
   options?: Maybe<ProductListOptions>;
 };
-
 
 export type QueryProductArgs = {
   id?: Maybe<Scalars['ID']>;
   slug?: Maybe<Scalars['String']>;
 };
 
-
 export type QueryProductVariantsArgs = {
   options?: Maybe<ProductVariantListOptions>;
   productId?: Maybe<Scalars['ID']>;
 };
 
-
 export type QueryProductVariantArgs = {
   id: Scalars['ID'];
 };
-
 
 export type QueryPromotionArgs = {
   id: Scalars['ID'];
 };
 
-
 export type QueryPromotionsArgs = {
   options?: Maybe<PromotionListOptions>;
 };
-
 
 export type QueryRolesArgs = {
   options?: Maybe<RoleListOptions>;
 };
 
-
 export type QueryRoleArgs = {
   id: Scalars['ID'];
 };
-
 
 export type QueryShippingMethodsArgs = {
   options?: Maybe<ShippingMethodListOptions>;
 };
 
-
 export type QueryShippingMethodArgs = {
   id: Scalars['ID'];
 };
-
 
 export type QueryTestShippingMethodArgs = {
   input: TestShippingMethodInput;
 };
 
-
 export type QueryTestEligibleShippingMethodsArgs = {
   input: TestEligibleShippingMethodsInput;
 };
-
 
 export type QueryTagArgs = {
   id: Scalars['ID'];
 };
 
-
 export type QueryTagsArgs = {
   options?: Maybe<TagListOptions>;
 };
-
 
 export type QueryTaxCategoryArgs = {
   id: Scalars['ID'];
 };
 
-
 export type QueryTaxRatesArgs = {
   options?: Maybe<TaxRateListOptions>;
 };
-
 
 export type QueryTaxRateArgs = {
   id: Scalars['ID'];
 };
 
-
 export type QueryZoneArgs = {
+  id: Scalars['ID'];
+};
+
+export type QueryInventoryArgs = {
+  vendorId: Scalars['ID'];
+  options?: Maybe<InventoryItemListOptions>;
+};
+
+export type QueryVendorsArgs = {
+  options?: Maybe<VendorListOptions>;
+};
+
+export type QueryVendorArgs = {
+  id?: Maybe<Scalars['ID']>;
+  slug?: Maybe<Scalars['String']>;
+};
+
+export type QueryProductSalesArgs = {
+  vendorId: Scalars['ID'];
+  options?: Maybe<ProductSalesListOptions>;
+};
+
+export type QuerySalesSummaryArgs = {
+  vendorId: Scalars['ID'];
+  startDate: Scalars['DateTime'];
+  endDate: Scalars['DateTime'];
+};
+
+export type QueryRemittanceSummariesArgs = {
+  vendorId: Scalars['ID'];
+  options?: Maybe<RemittanceSummaryListOptions>;
+};
+
+export type QueryRemittanceArgs = {
+  vendorId: Scalars['ID'];
   id: Scalars['ID'];
 };
 
@@ -4571,7 +4747,16 @@ export type RefundOrderInput = {
   reason?: Maybe<Scalars['String']>;
 };
 
-export type RefundOrderResult = Refund | QuantityTooGreatError | NothingToRefundError | OrderStateTransitionError | MultipleOrderError | PaymentOrderMismatchError | RefundOrderStateError | AlreadyRefundedError | RefundStateTransitionError;
+export type RefundOrderResult =
+  | Refund
+  | QuantityTooGreatError
+  | NothingToRefundError
+  | OrderStateTransitionError
+  | MultipleOrderError
+  | PaymentOrderMismatchError
+  | RefundOrderStateError
+  | AlreadyRefundedError
+  | RefundStateTransitionError;
 
 /** Returned if an attempting to refund an Order which is not in the expected state */
 export type RefundOrderStateError = ErrorResult & {
@@ -4612,14 +4797,95 @@ export type RelationCustomFieldConfig = CustomField & {
   ui?: Maybe<Scalars['JSON']>;
 };
 
-export type Release = Node & StockMovement & {
+export type Release = Node &
+  StockMovement & {
+    id: Scalars['ID'];
+    createdAt: Scalars['DateTime'];
+    updatedAt: Scalars['DateTime'];
+    productVariant: ProductVariant;
+    type: StockMovementType;
+    quantity: Scalars['Int'];
+    orderItem: OrderItem;
+  };
+
+export type Remittance = {
   id: Scalars['ID'];
-  createdAt: Scalars['DateTime'];
-  updatedAt: Scalars['DateTime'];
-  productVariant: ProductVariant;
-  type: StockMovementType;
-  quantity: Scalars['Int'];
-  orderItem: OrderItem;
+  vendorId: Scalars['ID'];
+  invoiceNumber: Scalars['ID'];
+  invoiceDate: Scalars['DateTime'];
+  paymentDate: Scalars['DateTime'];
+  totalPaid: Scalars['Int'];
+  transactions: Array<RemittanceTransaction>;
+  products: Array<RemittanceProduct>;
+  payout: RemittancePayout;
+  downloadLink: Scalars['String'];
+};
+
+export type RemittancePayout = {
+  subTotal: Scalars['Int'];
+  totalFees: Scalars['Int'];
+  payout: Scalars['Int'];
+  totalPaid: Scalars['Int'];
+};
+
+export type RemittanceProduct = {
+  name: Scalars['String'];
+  productName: Scalars['String'];
+  totalUnits: Scalars['Int'];
+  cost: Scalars['Int'];
+  date: Scalars['DateTime'];
+  subTotal: Scalars['Int'];
+  fee: Scalars['Int'];
+  net: Scalars['Int'];
+};
+
+export type RemittanceSummary = Node & {
+  id: Scalars['ID'];
+  paymentDate: Scalars['DateTime'];
+  amount: Scalars['Int'];
+  downloadLink: Scalars['String'];
+};
+
+export type RemittanceSummaryFilterParameter = {
+  id?: Maybe<IdOperators>;
+  paymentDate?: Maybe<DateOperators>;
+  amount?: Maybe<NumberOperators>;
+  downloadLink?: Maybe<StringOperators>;
+};
+
+export type RemittanceSummaryList = PaginatedList & {
+  items: Array<RemittanceSummary>;
+  totalEarnings: Scalars['Int'];
+  totalItems: Scalars['Int'];
+  vendorId: Scalars['ID'];
+};
+
+export type RemittanceSummaryListOptions = {
+  /** Skips the first n results, for use in pagination */
+  skip?: Maybe<Scalars['Int']>;
+  /** Takes n results, for use in pagination */
+  take?: Maybe<Scalars['Int']>;
+  /** Specifies which properties to sort the results by */
+  sort?: Maybe<RemittanceSummarySortParameter>;
+  /** Allows the results to be filtered */
+  filter?: Maybe<RemittanceSummaryFilterParameter>;
+  /** Specifies whether multiple "filter" arguments should be combines with a logical AND or OR operation. Defaults to AND. */
+  filterOperator?: Maybe<LogicalOperator>;
+};
+
+export type RemittanceSummarySortParameter = {
+  id?: Maybe<SortOrder>;
+  paymentDate?: Maybe<SortOrder>;
+  amount?: Maybe<SortOrder>;
+  downloadLink?: Maybe<SortOrder>;
+};
+
+export type RemittanceTransaction = {
+  transaction: Scalars['String'];
+  date: Scalars['DateTime'];
+  subTotal: Scalars['Int'];
+  fee: Scalars['Int'];
+  net: Scalars['Int'];
 };
 
 export type RemoveCollectionsFromChannelInput = {
@@ -4654,15 +4920,26 @@ export type RemovePromotionsFromChannelInput = {
   channelId: Scalars['ID'];
 };
 
-export type Return = Node & StockMovement & {
-  id: Scalars['ID'];
-  createdAt: Scalars['DateTime'];
-  updatedAt: Scalars['DateTime'];
-  productVariant: ProductVariant;
-  type: StockMovementType;
-  quantity: Scalars['Int'];
-  orderItem: OrderItem;
+export type RemoveVendorsFromChannelInput = {
+  vendorIds: Array<Scalars['ID']>;
+  channelId: Scalars['ID'];
 };
+
+export type ResetAdminPasswordResponse = {
+  success: Scalars['Boolean'];
+  message?: Maybe<Scalars['String']>;
+};
+
+export type Return = Node &
+  StockMovement & {
+    id: Scalars['ID'];
+    createdAt: Scalars['DateTime'];
+    updatedAt: Scalars['DateTime'];
+    productVariant: ProductVariant;
+    type: StockMovementType;
+    quantity: Scalars['Int'];
+    orderItem: OrderItem;
+  };
 
 export type Role = Node & {
   id: Scalars['ID'];
@@ -4708,14 +4985,22 @@ export type RoleSortParameter = {
   description?: Maybe<SortOrder>;
 };
 
-export type Sale = Node & StockMovement & {
-  id: Scalars['ID'];
-  createdAt: Scalars['DateTime'];
-  updatedAt: Scalars['DateTime'];
-  productVariant: ProductVariant;
-  type: StockMovementType;
-  quantity: Scalars['Int'];
-  orderItem: OrderItem;
+export type Sale = Node &
+  StockMovement & {
+    id: Scalars['ID'];
+    createdAt: Scalars['DateTime'];
+    updatedAt: Scalars['DateTime'];
+    productVariant: ProductVariant;
+    type: StockMovementType;
+    quantity: Scalars['Int'];
+    orderItem: OrderItem;
+  };
+
+export type SalesSummary = {
+  vendorId: Scalars['ID'];
+  revenue: Scalars['Int'];
+  orders: Scalars['Int'];
+  itemsSold: Scalars['Int'];
 };
 
 export type SearchInput = {
@@ -4729,6 +5014,10 @@ export type SearchInput = {
   take?: Maybe<Scalars['Int']>;
   skip?: Maybe<Scalars['Int']>;
   sort?: Maybe<SearchResultSortParameter>;
+  priceRange?: Maybe<PriceRangeInput>;
+  priceRangeWithTax?: Maybe<PriceRangeInput>;
+  inStock?: Maybe<Scalars['Boolean']>;
+  vendorId?: Maybe<Scalars['ID']>;
 };
 
 export type SearchReindexResponse = {
@@ -4740,6 +5029,14 @@ export type SearchResponse = {
   totalItems: Scalars['Int'];
   facetValues: Array<FacetValueResult>;
   collections: Array<CollectionResult>;
+  prices: SearchResponsePriceData;
+};
+
+export type SearchResponsePriceData = {
+  range: PriceRange;
+  rangeWithTax: PriceRange;
+  buckets: Array<PriceRangeBucket>;
+  bucketsWithTax: Array<PriceRangeBucket>;
 };
 
 export type SearchResult = {
@@ -4764,6 +5061,10 @@ export type SearchResult = {
   collectionIds: Array<Scalars['ID']>;
   /** A relevance score for the result. Differs between database implementations */
   score: Scalars['Float'];
+  inStock?: Maybe<Scalars['Boolean']>;
+  /** @deprecated Use customProductMappings or customProductVariantMappings */
+  customMappings: CustomProductMappings;
+  customProductMappings: CustomProductMappings;
 };
 
 export type SearchResultAsset = {
@@ -4789,7 +5090,11 @@ export type ServerConfig = {
 
 export type SetCustomerForDraftOrderResult = Order | EmailAddressConflictError;
 
-export type SetOrderShippingMethodResult = Order | OrderModificationError | IneligibleShippingMethodError | NoActiveOrderError;
+export type SetOrderShippingMethodResult =
+  | Order
+  | OrderModificationError
+  | IneligibleShippingMethodError
+  | NoActiveOrderError;
 
 /** Returned if the Payment settlement fails */
 export type SettlePaymentError = ErrorResult & {
@@ -4798,7 +5103,11 @@ export type SettlePaymentError = ErrorResult & {
   paymentErrorMessage: Scalars['String'];
 };
 
-export type SettlePaymentResult = Payment | SettlePaymentError | PaymentStateTransitionError | OrderStateTransitionError;
+export type SettlePaymentResult =
+  | Payment
+  | SettlePaymentError
+  | PaymentStateTransitionError
+  | OrderStateTransitionError;
 
 export type SettleRefundInput = {
   id: Scalars['ID'];
@@ -4907,17 +5216,18 @@ export type SinglePrice = {
 
 export enum SortOrder {
   ASC = 'ASC',
-  DESC = 'DESC'
+  DESC = 'DESC',
 }
 
-export type StockAdjustment = Node & StockMovement & {
-  id: Scalars['ID'];
-  createdAt: Scalars['DateTime'];
-  updatedAt: Scalars['DateTime'];
-  productVariant: ProductVariant;
-  type: StockMovementType;
-  quantity: Scalars['Int'];
-};
+export type StockAdjustment = Node &
+  StockMovement & {
+    id: Scalars['ID'];
+    createdAt: Scalars['DateTime'];
+    updatedAt: Scalars['DateTime'];
+    productVariant: ProductVariant;
+    type: StockMovementType;
+    quantity: Scalars['Int'];
+  };
 
 export type StockMovement = {
   id: Scalars['ID'];
@@ -4947,7 +5257,7 @@ export enum StockMovementType {
   RELEASE = 'RELEASE',
   SALE = 'SALE',
   CANCELLATION = 'CANCELLATION',
-  RETURN = 'RETURN'
+  RETURN = 'RETURN',
 }
 
 export type StringCustomFieldConfig = CustomField & {
@@ -5303,12 +5613,23 @@ export type UpdateOrderAddressInput = {
   phoneNumber?: Maybe<Scalars['String']>;
 };
 
-export type UpdateOrderInput = {
-  id: Scalars['ID'];
-  customFields?: Maybe<Scalars['JSON']>;
+export type UpdateOrderCustomFieldsInput = {
+  deliveryDate?: Maybe<Scalars['String']>;
+  deliveryInstructions?: Maybe<Scalars['String']>;
+  mobileNumber?: Maybe<Scalars['String']>;
 };
 
-export type UpdateOrderItemsResult = Order | OrderModificationError | OrderLimitError | NegativeQuantityError | InsufficientStockError;
+export type UpdateOrderInput = {
+  id: Scalars['ID'];
+  customFields?: Maybe<UpdateOrderCustomFieldsInput>;
+};
+
+export type UpdateOrderItemsResult =
+  | Order
+  | OrderModificationError
+  | OrderLimitError
+  | NegativeQuantityError
+  | InsufficientStockError;
 
 export type UpdateOrderNoteInput = {
   noteId: Scalars['ID'];
@@ -5327,6 +5648,10 @@ export type UpdatePaymentMethodInput = {
   customFields?: Maybe<Scalars['JSON']>;
 };
 
+export type UpdateProductCustomFieldsInput = {
+  brandId?: Maybe<Scalars['ID']>;
+};
+
 export type UpdateProductInput = {
   id: Scalars['ID'];
   enabled?: Maybe<Scalars['Boolean']>;
@@ -5334,7 +5659,7 @@ export type UpdateProductInput = {
   assetIds?: Maybe<Array<Scalars['ID']>>;
   facetValueIds?: Maybe<Array<Scalars['ID']>>;
   translations?: Maybe<Array<ProductTranslationInput>>;
-  customFields?: Maybe<Scalars['JSON']>;
+  customFields?: Maybe<UpdateProductCustomFieldsInput>;
 };
 
 export type UpdateProductOptionGroupInput = {
@@ -5351,6 +5676,10 @@ export type UpdateProductOptionInput = {
   customFields?: Maybe<Scalars['JSON']>;
 };
 
+export type UpdateProductVariantCustomFieldsInput = {
+  costPerItem?: Maybe<Scalars['Int']>;
+};
+
 export type UpdateProductVariantInput = {
   id: Scalars['ID'];
   enabled?: Maybe<Scalars['Boolean']>;
@@ -5365,7 +5694,7 @@ export type UpdateProductVariantInput = {
   outOfStockThreshold?: Maybe<Scalars['Int']>;
   useGlobalOutOfStockThreshold?: Maybe<Scalars['Boolean']>;
   trackInventory?: Maybe<GlobalFlag>;
-  customFields?: Maybe<Scalars['JSON']>;
+  customFields?: Maybe<UpdateProductVariantCustomFieldsInput>;
 };
 
 export type UpdatePromotionInput = {
@@ -5424,12 +5753,39 @@ export type UpdateTaxRateInput = {
   customFields?: Maybe<Scalars['JSON']>;
 };
 
+export type UpdateVendorBrandInput = {
+  name: Scalars['String'];
+  slug: Scalars['String'];
+  id?: Maybe<Scalars['ID']>;
+};
+
+export type UpdateVendorInput = {
+  id: Scalars['ID'];
+  name?: Maybe<Scalars['String']>;
+  slug?: Maybe<Scalars['String']>;
+  address?: Maybe<Scalars['String']>;
+  phone?: Maybe<Scalars['String']>;
+  websiteUrl?: Maybe<Scalars['String']>;
+  featuredAssetId?: Maybe<Scalars['ID']>;
+  stripeConnectedAccountId?: Maybe<Scalars['String']>;
+  assetIds?: Maybe<Array<Scalars['ID']>>;
+  translations?: Maybe<Array<UpdateVendorTranslationInput>>;
+  shopifyId?: Maybe<Scalars['Int']>;
+  brands?: Maybe<Array<UpdateVendorBrandInput>>;
+  colabId?: Maybe<Scalars['Int']>;
+};
+
+export type UpdateVendorTranslationInput = {
+  id?: Maybe<Scalars['ID']>;
+  languageCode: LanguageCode;
+  description?: Maybe<Scalars['String']>;
+};
+
 export type UpdateZoneInput = {
   id: Scalars['ID'];
   name?: Maybe<Scalars['String']>;
   customFields?: Maybe<Scalars['JSON']>;
 };
-
 
 export type User = Node & {
   id: Scalars['ID'];
@@ -5441,6 +5797,90 @@ export type User = Node & {
   lastLogin?: Maybe<Scalars['DateTime']>;
   authenticationMethods: Array<AuthenticationMethod>;
   customFields?: Maybe<Scalars['JSON']>;
+};
+
+export type Vendor = Node & {
+  id: Scalars['ID'];
+  createdAt: Scalars['DateTime'];
+  updatedAt: Scalars['DateTime'];
+  languageCode?: Maybe<LanguageCode>;
+  name: Scalars['String'];
+  slug: Scalars['String'];
+  description: Scalars['String'];
+  address?: Maybe<Scalars['String']>;
+  phone?: Maybe<Scalars['String']>;
+  websiteUrl?: Maybe<Scalars['String']>;
+  featuredAsset?: Maybe<Asset>;
+  assets: Array<Asset>;
+  translations: Array<VendorTranslation>;
+  products?: Maybe<ProductList>;
+  stripeConnectedAccountId?: Maybe<Scalars['String']>;
+  channels: Array<Channel>;
+};
+
+export type VendorProductsArgs = {
+  options?: Maybe<ProductListOptions>;
+};
+
+export type VendorFilterParameter = {
+  id?: Maybe<IdOperators>;
+  createdAt?: Maybe<DateOperators>;
+  updatedAt?: Maybe<DateOperators>;
+  languageCode?: Maybe<StringOperators>;
+  name?: Maybe<StringOperators>;
+  slug?: Maybe<StringOperators>;
+  description?: Maybe<StringOperators>;
+  address?: Maybe<StringOperators>;
+  phone?: Maybe<StringOperators>;
+  websiteUrl?: Maybe<StringOperators>;
+  stripeConnectedAccountId?: Maybe<StringOperators>;
+};
+
+export type VendorList = PaginatedList & {
+  items: Array<Vendor>;
+  totalItems: Scalars['Int'];
+};
+
+export type VendorListOptions = {
+  /** Skips the first n results, for use in pagination */
+  skip?: Maybe<Scalars['Int']>;
+  /** Takes n results, for use in pagination */
+  take?: Maybe<Scalars['Int']>;
+  /** Specifies which properties to sort the results by */
+  sort?: Maybe<VendorSortParameter>;
+  /** Allows the results to be filtered */
+  filter?: Maybe<VendorFilterParameter>;
+  /** Specifies whether multiple "filter" arguments should be combines with a logical AND or OR operation. Defaults to AND. */
+  filterOperator?: Maybe<LogicalOperator>;
+};
+
+export type VendorOrder = {
+  id: Scalars['ID'];
+  createdAt: Scalars['DateTime'];
+  updatedAt: Scalars['DateTime'];
+  vendorId: Scalars['ID'];
+  orderId: Scalars['ID'];
+};
+
+export type VendorSortParameter = {
+  id?: Maybe<SortOrder>;
+  createdAt?: Maybe<SortOrder>;
+  updatedAt?: Maybe<SortOrder>;
+  name?: Maybe<SortOrder>;
+  slug?: Maybe<SortOrder>;
+  description?: Maybe<SortOrder>;
+  address?: Maybe<SortOrder>;
+  phone?: Maybe<SortOrder>;
+  websiteUrl?: Maybe<SortOrder>;
+  stripeConnectedAccountId?: Maybe<SortOrder>;
+};
+
+export type VendorTranslation = {
+  id: Scalars['ID'];
+  createdAt: Scalars['DateTime'];
+  updatedAt: Scalars['DateTime'];
+  languageCode: LanguageCode;
+  description: Scalars['String'];
 };
 
 export type Zone = Node & {
@@ -5456,21 +5896,17 @@ export type GetAdministratorsQueryVariables = Exact<{
   options?: Maybe<AdministratorListOptions>;
 }>;
 
-
-export type GetAdministratorsQuery = { administrators: (
-    Pick<AdministratorList, 'totalItems'>
-    & { items: Array<AdministratorFragment> }
-  ) };
+export type GetAdministratorsQuery = {
+  administrators: Pick<AdministratorList, 'totalItems'> & { items: Array<AdministratorFragment> };
+};
 
 export type GetAdministratorQueryVariables = Exact<{
   id: Scalars['ID'];
 }>;
 
-
 export type GetAdministratorQuery = { administrator?: Maybe<AdministratorFragment> };
 
-export type ActiveAdministratorQueryVariables = Exact<{ [key: string]: never; }>;
-
+export type ActiveAdministratorQueryVariables = Exact<{ [key: string]: never }>;
 
 export type ActiveAdministratorQuery = { activeAdministrator?: Maybe<AdministratorFragment> };
 
@@ -5478,23 +5914,21 @@ export type UpdateActiveAdministratorMutationVariables = Exact<{
   input: UpdateActiveAdministratorInput;
 }>;
 
-
 export type UpdateActiveAdministratorMutation = { updateActiveAdministrator: AdministratorFragment };
 
 export type DeleteAdministratorMutationVariables = Exact<{
   id: Scalars['ID'];
 }>;
 
+export type DeleteAdministratorMutation = {
+  deleteAdministrator: Pick<DeletionResponse, 'message' | 'result'>;
+};
 
-export type DeleteAdministratorMutation = { deleteAdministrator: Pick<DeletionResponse, 'message' | 'result'> };
-
-export type Q1QueryVariables = Exact<{ [key: string]: never; }>;
-
+export type Q1QueryVariables = Exact<{ [key: string]: never }>;
 
 export type Q1Query = { product?: Maybe<Pick<Product, 'id' | 'name'>> };
 
-export type Q2QueryVariables = Exact<{ [key: string]: never; }>;
-
+export type Q2QueryVariables = Exact<{ [key: string]: never }>;
 
 export type Q2Query = { product?: Maybe<Pick<Product, 'id' | 'name'>> };
 
@@ -5502,58 +5936,65 @@ export type AssignAssetsToChannelMutationVariables = Exact<{
   input: AssignAssetsToChannelInput;
 }>;
 
-
 export type AssignAssetsToChannelMutation = { assignAssetsToChannel: Array<AssetFragment> };
 
 export type CanCreateCustomerMutationVariables = Exact<{
   input: CreateCustomerInput;
 }>;
 
-
 export type CanCreateCustomerMutation = { createCustomer: Pick<Customer, 'id'> };
 
-export type GetCustomerCountQueryVariables = Exact<{ [key: string]: never; }>;
-
+export type GetCustomerCountQueryVariables = Exact<{ [key: string]: never }>;
 
 export type GetCustomerCountQuery = { customers: Pick<CustomerList, 'totalItems'> };
 
-export type DeepFieldResolutionTestQueryQueryVariables = Exact<{ [key: string]: never; }>;
+export type DeepFieldResolutionTestQueryQueryVariables = Exact<{ [key: string]: never }>;
 
-
-export type DeepFieldResolutionTestQueryQuery = { product?: Maybe<{ variants: Array<{ taxRateApplied: { customerGroup?: Maybe<{ customers: { items: Array<Pick<Customer, 'id' | 'emailAddress'>> } }> } }> }> };
+export type DeepFieldResolutionTestQueryQuery = {
+  product?: Maybe<{
+    variants: Array<{
+      taxRateApplied: {
+        customerGroup?: Maybe<{ customers: { items: Array<Pick<Customer, 'id' | 'emailAddress'>> } }>;
+      };
+    }>;
+  }>;
+};
 
 export type AuthenticateMutationVariables = Exact<{
   input: AuthenticationInput;
 }>;
 
+export type AuthenticateMutation = {
+  authenticate:
+    | CurrentUserFragment
+    | Pick<InvalidCredentialsError, 'authenticationError' | 'errorCode' | 'message'>;
+};
 
-export type AuthenticateMutation = { authenticate: CurrentUserFragment | Pick<InvalidCredentialsError, 'authenticationError' | 'errorCode' | 'message'> };
+export type GetCustomersQueryVariables = Exact<{ [key: string]: never }>;
 
-export type GetCustomersQueryVariables = Exact<{ [key: string]: never; }>;
-
-
-export type GetCustomersQuery = { customers: (
-    Pick<CustomerList, 'totalItems'>
-    & { items: Array<Pick<Customer, 'id' | 'emailAddress'>> }
-  ) };
+export type GetCustomersQuery = {
+  customers: Pick<CustomerList, 'totalItems'> & { items: Array<Pick<Customer, 'id' | 'emailAddress'>> };
+};
 
 export type GetCustomerUserAuthQueryVariables = Exact<{
   id: Scalars['ID'];
 }>;
 
-
-export type GetCustomerUserAuthQuery = { customer?: Maybe<(
-    Pick<Customer, 'id'>
-    & { user?: Maybe<(
-      Pick<User, 'id' | 'verified'>
-      & { authenticationMethods: Array<Pick<AuthenticationMethod, 'id' | 'strategy'>> }
-    )> }
-  )> };
+export type GetCustomerUserAuthQuery = {
+  customer?: Maybe<
+    Pick<Customer, 'id'> & {
+      user?: Maybe<
+        Pick<User, 'id' | 'verified'> & {
+          authenticationMethods: Array<Pick<AuthenticationMethod, 'id' | 'strategy'>>;
+        }
+      >;
+    }
+  >;
+};
 
 export type DeleteChannelMutationVariables = Exact<{
   id: Scalars['ID'];
 }>;
-
 
 export type DeleteChannelMutation = { deleteChannel: Pick<DeletionResponse, 'message' | 'result'> };
 
@@ -5561,21 +6002,23 @@ export type UpdateGlobalLanguagesMutationVariables = Exact<{
   input: UpdateGlobalSettingsInput;
 }>;
 
+export type UpdateGlobalLanguagesMutation = {
+  updateGlobalSettings: Pick<GlobalSettings, 'id' | 'availableLanguages'>;
+};
 
-export type UpdateGlobalLanguagesMutation = { updateGlobalSettings: Pick<GlobalSettings, 'id' | 'availableLanguages'> };
+export type GetCollectionsWithAssetsQueryVariables = Exact<{ [key: string]: never }>;
 
-export type GetCollectionsWithAssetsQueryVariables = Exact<{ [key: string]: never; }>;
+export type GetCollectionsWithAssetsQuery = {
+  collections: { items: Array<{ assets: Array<Pick<Asset, 'name'>> }> };
+};
 
+export type GetProductsWithVariantIdsQueryVariables = Exact<{ [key: string]: never }>;
 
-export type GetCollectionsWithAssetsQuery = { collections: { items: Array<{ assets: Array<Pick<Asset, 'name'>> }> } };
-
-export type GetProductsWithVariantIdsQueryVariables = Exact<{ [key: string]: never; }>;
-
-
-export type GetProductsWithVariantIdsQuery = { products: { items: Array<(
-      Pick<Product, 'id' | 'name'>
-      & { variants: Array<Pick<ProductVariant, 'id' | 'name'>> }
-    )> } };
+export type GetProductsWithVariantIdsQuery = {
+  products: {
+    items: Array<Pick<Product, 'id' | 'name'> & { variants: Array<Pick<ProductVariant, 'id' | 'name'>> }>;
+  };
+};
 
 export type GetCollectionQueryVariables = Exact<{
   id?: Maybe<Scalars['ID']>;
@@ -5583,31 +6026,29 @@ export type GetCollectionQueryVariables = Exact<{
   variantListOptions?: Maybe<ProductVariantListOptions>;
 }>;
 
-
-export type GetCollectionQuery = { collection?: Maybe<(
-    { productVariants: { items: Array<Pick<ProductVariant, 'id' | 'name' | 'price'>> } }
-    & CollectionFragment
-  )> };
+export type GetCollectionQuery = {
+  collection?: Maybe<
+    {
+      productVariants: { items: Array<Pick<ProductVariant, 'id' | 'name' | 'price'>> };
+    } & CollectionFragment
+  >;
+};
 
 export type GetCollectionListAdminQueryVariables = Exact<{
   options?: Maybe<CollectionListOptions>;
 }>;
 
-
-export type GetCollectionListAdminQuery = { collections: (
-    Pick<CollectionList, 'totalItems'>
-    & { items: Array<CollectionFragment> }
-  ) };
+export type GetCollectionListAdminQuery = {
+  collections: Pick<CollectionList, 'totalItems'> & { items: Array<CollectionFragment> };
+};
 
 export type MoveCollectionMutationVariables = Exact<{
   input: MoveCollectionInput;
 }>;
 
-
 export type MoveCollectionMutation = { moveCollection: CollectionFragment };
 
-export type GetFacetValuesQueryVariables = Exact<{ [key: string]: never; }>;
-
+export type GetFacetValuesQueryVariables = Exact<{ [key: string]: never }>;
 
 export type GetFacetValuesQuery = { facets: { items: Array<{ values: Array<FacetValueFragment> }> } };
 
@@ -5615,46 +6056,51 @@ export type GetCollectionProductsQueryVariables = Exact<{
   id: Scalars['ID'];
 }>;
 
-
-export type GetCollectionProductsQuery = { collection?: Maybe<{ productVariants: { items: Array<(
-        Pick<ProductVariant, 'id' | 'name' | 'productId'>
-        & { facetValues: Array<Pick<FacetValue, 'code'>> }
-      )> } }> };
+export type GetCollectionProductsQuery = {
+  collection?: Maybe<{
+    productVariants: {
+      items: Array<
+        Pick<ProductVariant, 'id' | 'name' | 'productId'> & {
+          facetValues: Array<Pick<FacetValue, 'code'>>;
+        }
+      >;
+    };
+  }>;
+};
 
 export type CreateCollectionSelectVariantsMutationVariables = Exact<{
   input: CreateCollectionInput;
 }>;
 
-
-export type CreateCollectionSelectVariantsMutation = { createCollection: (
-    Pick<Collection, 'id'>
-    & { productVariants: (
-      Pick<ProductVariantList, 'totalItems'>
-      & { items: Array<Pick<ProductVariant, 'name'>> }
-    ) }
-  ) };
+export type CreateCollectionSelectVariantsMutation = {
+  createCollection: Pick<Collection, 'id'> & {
+    productVariants: Pick<ProductVariantList, 'totalItems'> & {
+      items: Array<Pick<ProductVariant, 'name'>>;
+    };
+  };
+};
 
 export type GetCollectionBreadcrumbsQueryVariables = Exact<{
   id: Scalars['ID'];
 }>;
 
-
-export type GetCollectionBreadcrumbsQuery = { collection?: Maybe<{ breadcrumbs: Array<Pick<CollectionBreadcrumb, 'id' | 'name' | 'slug'>> }> };
+export type GetCollectionBreadcrumbsQuery = {
+  collection?: Maybe<{ breadcrumbs: Array<Pick<CollectionBreadcrumb, 'id' | 'name' | 'slug'>> }>;
+};
 
 export type GetCollectionsForProductsQueryVariables = Exact<{
   term: Scalars['String'];
 }>;
 
-
-export type GetCollectionsForProductsQuery = { products: { items: Array<(
-      Pick<Product, 'id' | 'name'>
-      & { collections: Array<Pick<Collection, 'id' | 'name'>> }
-    )> } };
+export type GetCollectionsForProductsQuery = {
+  products: {
+    items: Array<Pick<Product, 'id' | 'name'> & { collections: Array<Pick<Collection, 'id' | 'name'>> }>;
+  };
+};
 
 export type DeleteCollectionMutationVariables = Exact<{
   id: Scalars['ID'];
 }>;
-
 
 export type DeleteCollectionMutation = { deleteCollection: Pick<DeletionResponse, 'result' | 'message'> };
 
@@ -5662,54 +6108,54 @@ export type GetProductCollectionsQueryVariables = Exact<{
   id: Scalars['ID'];
 }>;
 
-
-export type GetProductCollectionsQuery = { product?: Maybe<(
-    Pick<Product, 'id'>
-    & { collections: Array<Pick<Collection, 'id' | 'name'>> }
-  )> };
+export type GetProductCollectionsQuery = {
+  product?: Maybe<Pick<Product, 'id'> & { collections: Array<Pick<Collection, 'id' | 'name'>> }>;
+};
 
 export type GetProductCollectionsWithParentQueryVariables = Exact<{
   id: Scalars['ID'];
 }>;
 
+export type GetProductCollectionsWithParentQuery = {
+  product?: Maybe<
+    Pick<Product, 'id'> & {
+      collections: Array<
+        Pick<Collection, 'id' | 'name'> & { parent?: Maybe<Pick<Collection, 'id' | 'name'>> }
+      >;
+    }
+  >;
+};
 
-export type GetProductCollectionsWithParentQuery = { product?: Maybe<(
-    Pick<Product, 'id'>
-    & { collections: Array<(
-      Pick<Collection, 'id' | 'name'>
-      & { parent?: Maybe<Pick<Collection, 'id' | 'name'>> }
-    )> }
-  )> };
+export type GetCollectionNestedParentsQueryVariables = Exact<{ [key: string]: never }>;
 
-export type GetCollectionNestedParentsQueryVariables = Exact<{ [key: string]: never; }>;
-
-
-export type GetCollectionNestedParentsQuery = { collections: { items: Array<(
-      Pick<Collection, 'id' | 'name'>
-      & { parent?: Maybe<(
-        Pick<Collection, 'name'>
-        & { parent?: Maybe<(
-          Pick<Collection, 'name'>
-          & { parent?: Maybe<Pick<Collection, 'name'>> }
-        )> }
-      )> }
-    )> } };
+export type GetCollectionNestedParentsQuery = {
+  collections: {
+    items: Array<
+      Pick<Collection, 'id' | 'name'> & {
+        parent?: Maybe<
+          Pick<Collection, 'name'> & {
+            parent?: Maybe<Pick<Collection, 'name'> & { parent?: Maybe<Pick<Collection, 'name'>> }>;
+          }
+        >;
+      }
+    >;
+  };
+};
 
 export type PreviewCollectionVariantsQueryVariables = Exact<{
   input: PreviewCollectionVariantsInput;
   options?: Maybe<ProductVariantListOptions>;
 }>;
 
-
-export type PreviewCollectionVariantsQuery = { previewCollectionVariants: (
-    Pick<ProductVariantList, 'totalItems'>
-    & { items: Array<Pick<ProductVariant, 'id' | 'name'>> }
-  ) };
+export type PreviewCollectionVariantsQuery = {
+  previewCollectionVariants: Pick<ProductVariantList, 'totalItems'> & {
+    items: Array<Pick<ProductVariant, 'id' | 'name'>>;
+  };
+};
 
 export type AssignCollectionsToChannelMutationVariables = Exact<{
   input: AssignCollectionsToChannelInput;
 }>;
-
 
 export type AssignCollectionsToChannelMutation = { assignCollectionsToChannel: Array<CollectionFragment> };
 
@@ -5717,28 +6163,36 @@ export type RemoveCollectionsFromChannelMutationVariables = Exact<{
   input: RemoveCollectionsFromChannelInput;
 }>;
 
-
-export type RemoveCollectionsFromChannelMutation = { removeCollectionsFromChannel: Array<CollectionFragment> };
+export type RemoveCollectionsFromChannelMutation = {
+  removeCollectionsFromChannel: Array<CollectionFragment>;
+};
 
 export type DeleteCollectionsBulkMutationVariables = Exact<{
   ids: Array<Scalars['ID']> | Scalars['ID'];
 }>;
 
+export type DeleteCollectionsBulkMutation = {
+  deleteCollections: Array<Pick<DeletionResponse, 'message' | 'result'>>;
+};
 
-export type DeleteCollectionsBulkMutation = { deleteCollections: Array<Pick<DeletionResponse, 'message' | 'result'>> };
+export type GetCheckersQueryVariables = Exact<{ [key: string]: never }>;
 
-export type GetCheckersQueryVariables = Exact<{ [key: string]: never; }>;
-
-
-export type GetCheckersQuery = { shippingEligibilityCheckers: Array<(
-    Pick<ConfigurableOperationDefinition, 'code'>
-    & { args: Array<Pick<ConfigArgDefinition, 'defaultValue' | 'description' | 'label' | 'list' | 'name' | 'required' | 'type'>> }
-  )> };
+export type GetCheckersQuery = {
+  shippingEligibilityCheckers: Array<
+    Pick<ConfigurableOperationDefinition, 'code'> & {
+      args: Array<
+        Pick<
+          ConfigArgDefinition,
+          'defaultValue' | 'description' | 'label' | 'list' | 'name' | 'required' | 'type'
+        >
+      >;
+    }
+  >;
+};
 
 export type DeleteCountryMutationVariables = Exact<{
   id: Scalars['ID'];
 }>;
-
 
 export type DeleteCountryMutation = { deleteCountry: Pick<DeletionResponse, 'result' | 'message'> };
 
@@ -5746,13 +6200,11 @@ export type GetCountryQueryVariables = Exact<{
   id: Scalars['ID'];
 }>;
 
-
 export type GetCountryQuery = { country?: Maybe<CountryFragment> };
 
 export type CreateCountryMutationVariables = Exact<{
   input: CreateCountryInput;
 }>;
-
 
 export type CreateCountryMutation = { createCountry: CountryFragment };
 
@@ -5760,38 +6212,31 @@ export type DeleteCustomerAddressMutationVariables = Exact<{
   id: Scalars['ID'];
 }>;
 
-
 export type DeleteCustomerAddressMutation = { deleteCustomerAddress: Pick<Success, 'success'> };
 
 export type GetCustomerWithUserQueryVariables = Exact<{
   id: Scalars['ID'];
 }>;
 
-
-export type GetCustomerWithUserQuery = { customer?: Maybe<(
-    Pick<Customer, 'id'>
-    & { user?: Maybe<Pick<User, 'id' | 'identifier' | 'verified'>> }
-  )> };
+export type GetCustomerWithUserQuery = {
+  customer?: Maybe<Pick<Customer, 'id'> & { user?: Maybe<Pick<User, 'id' | 'identifier' | 'verified'>> }>;
+};
 
 export type GetCustomerOrdersQueryVariables = Exact<{
   id: Scalars['ID'];
 }>;
 
-
-export type GetCustomerOrdersQuery = { customer?: Maybe<{ orders: (
-      Pick<OrderList, 'totalItems'>
-      & { items: Array<Pick<Order, 'id'>> }
-    ) }> };
+export type GetCustomerOrdersQuery = {
+  customer?: Maybe<{ orders: Pick<OrderList, 'totalItems'> & { items: Array<Pick<Order, 'id'>> } }>;
+};
 
 export type AddNoteToCustomerMutationVariables = Exact<{
   input: AddNoteToCustomerInput;
 }>;
 
-
 export type AddNoteToCustomerMutation = { addNoteToCustomer: CustomerFragment };
 
-export type ReindexMutationVariables = Exact<{ [key: string]: never; }>;
-
+export type ReindexMutationVariables = Exact<{ [key: string]: never }>;
 
 export type ReindexMutation = { reindex: Pick<Job, 'id'> };
 
@@ -5799,66 +6244,81 @@ export type SearchProductsAdminQueryVariables = Exact<{
   input: SearchInput;
 }>;
 
-
-export type SearchProductsAdminQuery = { search: (
-    Pick<SearchResponse, 'totalItems'>
-    & { items: Array<Pick<SearchResult, 'enabled' | 'productId' | 'productName' | 'slug' | 'description' | 'productVariantId' | 'productVariantName' | 'sku'>> }
-  ) };
+export type SearchProductsAdminQuery = {
+  search: Pick<SearchResponse, 'totalItems'> & {
+    items: Array<
+      Pick<
+        SearchResult,
+        | 'enabled'
+        | 'productId'
+        | 'productName'
+        | 'slug'
+        | 'description'
+        | 'productVariantId'
+        | 'productVariantName'
+        | 'sku'
+      >
+    >;
+  };
+};
 
 export type SearchFacetValuesQueryVariables = Exact<{
   input: SearchInput;
 }>;
 
-
-export type SearchFacetValuesQuery = { search: (
-    Pick<SearchResponse, 'totalItems'>
-    & { facetValues: Array<(
-      Pick<FacetValueResult, 'count'>
-      & { facetValue: Pick<FacetValue, 'id' | 'name'> }
-    )> }
-  ) };
+export type SearchFacetValuesQuery = {
+  search: Pick<SearchResponse, 'totalItems'> & {
+    facetValues: Array<Pick<FacetValueResult, 'count'> & { facetValue: Pick<FacetValue, 'id' | 'name'> }>;
+  };
+};
 
 export type SearchCollectionsQueryVariables = Exact<{
   input: SearchInput;
 }>;
 
-
-export type SearchCollectionsQuery = { search: (
-    Pick<SearchResponse, 'totalItems'>
-    & { collections: Array<(
-      Pick<CollectionResult, 'count'>
-      & { collection: Pick<Collection, 'id' | 'name'> }
-    )> }
-  ) };
+export type SearchCollectionsQuery = {
+  search: Pick<SearchResponse, 'totalItems'> & {
+    collections: Array<Pick<CollectionResult, 'count'> & { collection: Pick<Collection, 'id' | 'name'> }>;
+  };
+};
 
 export type SearchGetAssetsQueryVariables = Exact<{
   input: SearchInput;
 }>;
 
-
-export type SearchGetAssetsQuery = { search: (
-    Pick<SearchResponse, 'totalItems'>
-    & { items: Array<(
-      Pick<SearchResult, 'productId' | 'productName' | 'productVariantName'>
-      & { productAsset?: Maybe<(
-        Pick<SearchResultAsset, 'id' | 'preview'>
-        & { focalPoint?: Maybe<Pick<Coordinate, 'x' | 'y'>> }
-      )>, productVariantAsset?: Maybe<(
-        Pick<SearchResultAsset, 'id' | 'preview'>
-        & { focalPoint?: Maybe<Pick<Coordinate, 'x' | 'y'>> }
-      )> }
-    )> }
-  ) };
+export type SearchGetAssetsQuery = {
+  search: Pick<SearchResponse, 'totalItems'> & {
+    items: Array<
+      Pick<SearchResult, 'productId' | 'productName' | 'productVariantName'> & {
+        productAsset?: Maybe<
+          Pick<SearchResultAsset, 'id' | 'preview'> & {
+            focalPoint?: Maybe<Pick<Coordinate, 'x' | 'y'>>;
+          }
+        >;
+        productVariantAsset?: Maybe<
+          Pick<SearchResultAsset, 'id' | 'preview'> & {
+            focalPoint?: Maybe<Pick<Coordinate, 'x' | 'y'>>;
+          }
+        >;
+      }
+    >;
+  };
+};
 
 export type SearchGetPricesQueryVariables = Exact<{
   input: SearchInput;
 }>;
 
+export type SearchGetPricesQuery = {
+  search: {
+    items: Array<{
+      price: Pick<PriceRange, 'min' | 'max'> | Pick<SinglePrice, 'value'>;
+      priceWithTax: Pick<PriceRange, 'min' | 'max'> | Pick<SinglePrice, 'value'>;
+    }>;
+  };
+};
 
-export type SearchGetPricesQuery = { search: { items: Array<{ price: Pick<PriceRange, 'min' | 'max'> | Pick<SinglePrice, 'value'>, priceWithTax: Pick<PriceRange, 'min' | 'max'> | Pick<SinglePrice, 'value'> }> } };
-
-export type CreateDraftOrderMutationVariables = Exact<{ [key: string]: never; }>;
-
+export type CreateDraftOrderMutationVariables = Exact<{ [key: string]: never }>;
 
 export type CreateDraftOrderMutation = { createDraftOrder: OrderWithLinesFragment };
 
@@ -5867,24 +6327,37 @@ export type AddItemToDraftOrderMutationVariables = Exact<{
   input: AddItemToDraftOrderInput;
 }>;
 
-
-export type AddItemToDraftOrderMutation = { addItemToDraftOrder: OrderWithLinesFragment | Pick<OrderModificationError, 'errorCode' | 'message'> | Pick<OrderLimitError, 'errorCode' | 'message'> | Pick<NegativeQuantityError, 'errorCode' | 'message'> | Pick<InsufficientStockError, 'errorCode' | 'message'> };
+export type AddItemToDraftOrderMutation = {
+  addItemToDraftOrder:
+    | OrderWithLinesFragment
+    | Pick<OrderModificationError, 'errorCode' | 'message'>
+    | Pick<OrderLimitError, 'errorCode' | 'message'>
+    | Pick<NegativeQuantityError, 'errorCode' | 'message'>
+    | Pick<InsufficientStockError, 'errorCode' | 'message'>;
+};
 
 export type AdjustDraftOrderLineMutationVariables = Exact<{
   orderId: Scalars['ID'];
   input: AdjustDraftOrderLineInput;
 }>;
 
-
-export type AdjustDraftOrderLineMutation = { adjustDraftOrderLine: OrderWithLinesFragment | Pick<OrderModificationError, 'errorCode' | 'message'> | Pick<OrderLimitError, 'errorCode' | 'message'> | Pick<NegativeQuantityError, 'errorCode' | 'message'> | Pick<InsufficientStockError, 'errorCode' | 'message'> };
+export type AdjustDraftOrderLineMutation = {
+  adjustDraftOrderLine:
+    | OrderWithLinesFragment
+    | Pick<OrderModificationError, 'errorCode' | 'message'>
+    | Pick<OrderLimitError, 'errorCode' | 'message'>
+    | Pick<NegativeQuantityError, 'errorCode' | 'message'>
+    | Pick<InsufficientStockError, 'errorCode' | 'message'>;
+};
 
 export type RemoveDraftOrderLineMutationVariables = Exact<{
   orderId: Scalars['ID'];
   orderLineId: Scalars['ID'];
 }>;
 
-
-export type RemoveDraftOrderLineMutation = { removeDraftOrderLine: OrderWithLinesFragment | Pick<OrderModificationError, 'errorCode' | 'message'> };
+export type RemoveDraftOrderLineMutation = {
+  removeDraftOrderLine: OrderWithLinesFragment | Pick<OrderModificationError, 'errorCode' | 'message'>;
+};
 
 export type SetCustomerForDraftOrderMutationVariables = Exact<{
   orderId: Scalars['ID'];
@@ -5892,14 +6365,14 @@ export type SetCustomerForDraftOrderMutationVariables = Exact<{
   input?: Maybe<CreateCustomerInput>;
 }>;
 
-
-export type SetCustomerForDraftOrderMutation = { setCustomerForDraftOrder: OrderWithLinesFragment | Pick<EmailAddressConflictError, 'errorCode' | 'message'> };
+export type SetCustomerForDraftOrderMutation = {
+  setCustomerForDraftOrder: OrderWithLinesFragment | Pick<EmailAddressConflictError, 'errorCode' | 'message'>;
+};
 
 export type SetDraftOrderShippingAddressMutationVariables = Exact<{
   orderId: Scalars['ID'];
   input: CreateAddressInput;
 }>;
-
 
 export type SetDraftOrderShippingAddressMutation = { setDraftOrderShippingAddress: OrderWithLinesFragment };
 
@@ -5908,80 +6381,82 @@ export type SetDraftOrderBillingAddressMutationVariables = Exact<{
   input: CreateAddressInput;
 }>;
 
-
-export type SetDraftOrderBillingAddressMutation = { setDraftOrderBillingAddress: (
-    { billingAddress?: Maybe<ShippingAddressFragment> }
-    & OrderWithLinesFragment
-  ) };
+export type SetDraftOrderBillingAddressMutation = {
+  setDraftOrderBillingAddress: { billingAddress?: Maybe<ShippingAddressFragment> } & OrderWithLinesFragment;
+};
 
 export type ApplyCouponCodeToDraftOrderMutationVariables = Exact<{
   orderId: Scalars['ID'];
   couponCode: Scalars['String'];
 }>;
 
-
-export type ApplyCouponCodeToDraftOrderMutation = { applyCouponCodeToDraftOrder: (
-    Pick<Order, 'couponCodes'>
-    & OrderWithLinesFragment
-  ) | Pick<CouponCodeExpiredError, 'errorCode' | 'message'> | Pick<CouponCodeInvalidError, 'errorCode' | 'message'> | Pick<CouponCodeLimitError, 'errorCode' | 'message'> };
+export type ApplyCouponCodeToDraftOrderMutation = {
+  applyCouponCodeToDraftOrder:
+    | (Pick<Order, 'couponCodes'> & OrderWithLinesFragment)
+    | Pick<CouponCodeExpiredError, 'errorCode' | 'message'>
+    | Pick<CouponCodeInvalidError, 'errorCode' | 'message'>
+    | Pick<CouponCodeLimitError, 'errorCode' | 'message'>;
+};
 
 export type RemoveCouponCodeFromDraftOrderMutationVariables = Exact<{
   orderId: Scalars['ID'];
   couponCode: Scalars['String'];
 }>;
 
-
-export type RemoveCouponCodeFromDraftOrderMutation = { removeCouponCodeFromDraftOrder?: Maybe<(
-    Pick<Order, 'couponCodes'>
-    & OrderWithLinesFragment
-  )> };
+export type RemoveCouponCodeFromDraftOrderMutation = {
+  removeCouponCodeFromDraftOrder?: Maybe<Pick<Order, 'couponCodes'> & OrderWithLinesFragment>;
+};
 
 export type DraftOrderEligibleShippingMethodsQueryVariables = Exact<{
   orderId: Scalars['ID'];
 }>;
 
-
-export type DraftOrderEligibleShippingMethodsQuery = { eligibleShippingMethodsForDraftOrder: Array<Pick<ShippingMethodQuote, 'id' | 'name' | 'code' | 'description' | 'price' | 'priceWithTax' | 'metadata'>> };
+export type DraftOrderEligibleShippingMethodsQuery = {
+  eligibleShippingMethodsForDraftOrder: Array<
+    Pick<ShippingMethodQuote, 'id' | 'name' | 'code' | 'description' | 'price' | 'priceWithTax' | 'metadata'>
+  >;
+};
 
 export type SetDraftOrderShippingMethodMutationVariables = Exact<{
   orderId: Scalars['ID'];
   shippingMethodId: Scalars['ID'];
 }>;
 
+export type SetDraftOrderShippingMethodMutation = {
+  setDraftOrderShippingMethod:
+    | OrderWithLinesFragment
+    | Pick<OrderModificationError, 'errorCode' | 'message'>
+    | Pick<IneligibleShippingMethodError, 'errorCode' | 'message'>
+    | Pick<NoActiveOrderError, 'errorCode' | 'message'>;
+};
 
-export type SetDraftOrderShippingMethodMutation = { setDraftOrderShippingMethod: OrderWithLinesFragment | Pick<OrderModificationError, 'errorCode' | 'message'> | Pick<IneligibleShippingMethodError, 'errorCode' | 'message'> | Pick<NoActiveOrderError, 'errorCode' | 'message'> };
-
-export type IdTest1QueryVariables = Exact<{ [key: string]: never; }>;
-
+export type IdTest1QueryVariables = Exact<{ [key: string]: never }>;
 
 export type IdTest1Query = { products: { items: Array<Pick<Product, 'id'>> } };
 
-export type IdTest2QueryVariables = Exact<{ [key: string]: never; }>;
+export type IdTest2QueryVariables = Exact<{ [key: string]: never }>;
 
+export type IdTest2Query = {
+  products: {
+    items: Array<
+      Pick<Product, 'id'> & {
+        variants: Array<Pick<ProductVariant, 'id'> & { options: Array<Pick<ProductOption, 'id' | 'name'>> }>;
+      }
+    >;
+  };
+};
 
-export type IdTest2Query = { products: { items: Array<(
-      Pick<Product, 'id'>
-      & { variants: Array<(
-        Pick<ProductVariant, 'id'>
-        & { options: Array<Pick<ProductOption, 'id' | 'name'>> }
-      )> }
-    )> } };
-
-export type IdTest3QueryVariables = Exact<{ [key: string]: never; }>;
-
+export type IdTest3QueryVariables = Exact<{ [key: string]: never }>;
 
 export type IdTest3Query = { product?: Maybe<Pick<Product, 'id'>> };
 
-export type IdTest4MutationVariables = Exact<{ [key: string]: never; }>;
+export type IdTest4MutationVariables = Exact<{ [key: string]: never }>;
 
+export type IdTest4Mutation = {
+  updateProduct: Pick<Product, 'id'> & { featuredAsset?: Maybe<Pick<Asset, 'id'>> };
+};
 
-export type IdTest4Mutation = { updateProduct: (
-    Pick<Product, 'id'>
-    & { featuredAsset?: Maybe<Pick<Asset, 'id'>> }
-  ) };
-
-export type IdTest5MutationVariables = Exact<{ [key: string]: never; }>;
-
+export type IdTest5MutationVariables = Exact<{ [key: string]: never }>;
 
 export type IdTest5Mutation = { updateProduct: Pick<Product, 'id' | 'name'> };
 
@@ -5989,50 +6464,37 @@ export type IdTest6QueryVariables = Exact<{
   id: Scalars['ID'];
 }>;
 
-
 export type IdTest6Query = { product?: Maybe<Pick<Product, 'id'>> };
 
 export type IdTest7MutationVariables = Exact<{
   input: UpdateProductInput;
 }>;
 
-
-export type IdTest7Mutation = { updateProduct: (
-    Pick<Product, 'id'>
-    & { featuredAsset?: Maybe<Pick<Asset, 'id'>> }
-  ) };
+export type IdTest7Mutation = {
+  updateProduct: Pick<Product, 'id'> & { featuredAsset?: Maybe<Pick<Asset, 'id'>> };
+};
 
 export type IdTest8MutationVariables = Exact<{
   input: UpdateProductInput;
 }>;
 
-
 export type IdTest8Mutation = { updateProduct: Pick<Product, 'id' | 'name'> };
 
-export type IdTest9QueryVariables = Exact<{ [key: string]: never; }>;
-
+export type IdTest9QueryVariables = Exact<{ [key: string]: never }>;
 
 export type IdTest9Query = { products: { items: Array<ProdFragmentFragment> } };
 
-export type ProdFragmentFragment = (
-  Pick<Product, 'id'>
-  & { featuredAsset?: Maybe<Pick<Asset, 'id'>> }
-);
+export type ProdFragmentFragment = Pick<Product, 'id'> & { featuredAsset?: Maybe<Pick<Asset, 'id'>> };
 
-export type IdTest10QueryVariables = Exact<{ [key: string]: never; }>;
-
+export type IdTest10QueryVariables = Exact<{ [key: string]: never }>;
 
 export type IdTest10Query = { products: { items: Array<ProdFragment1Fragment> } };
 
 export type ProdFragment1Fragment = ProdFragment2Fragment;
 
-export type ProdFragment2Fragment = (
-  Pick<Product, 'id'>
-  & { featuredAsset?: Maybe<Pick<Asset, 'id'>> }
-);
+export type ProdFragment2Fragment = Pick<Product, 'id'> & { featuredAsset?: Maybe<Pick<Asset, 'id'>> };
 
-export type IdTest11QueryVariables = Exact<{ [key: string]: never; }>;
-
+export type IdTest11QueryVariables = Exact<{ [key: string]: never }>;
 
 export type IdTest11Query = { products: { items: Array<ProdFragment1_1Fragment> } };
 
@@ -6040,15 +6502,11 @@ export type ProdFragment1_1Fragment = ProdFragment2_1Fragment;
 
 export type ProdFragment2_1Fragment = ProdFragment3_1Fragment;
 
-export type ProdFragment3_1Fragment = (
-  Pick<Product, 'id'>
-  & { featuredAsset?: Maybe<Pick<Asset, 'id'>> }
-);
+export type ProdFragment3_1Fragment = Pick<Product, 'id'> & { featuredAsset?: Maybe<Pick<Asset, 'id'>> };
 
 export type GetFacetWithValuesQueryVariables = Exact<{
   id: Scalars['ID'];
 }>;
-
 
 export type GetFacetWithValuesQuery = { facet?: Maybe<FacetWithValuesFragment> };
 
@@ -6057,14 +6515,14 @@ export type DeleteFacetValuesMutationVariables = Exact<{
   force?: Maybe<Scalars['Boolean']>;
 }>;
 
-
-export type DeleteFacetValuesMutation = { deleteFacetValues: Array<Pick<DeletionResponse, 'result' | 'message'>> };
+export type DeleteFacetValuesMutation = {
+  deleteFacetValues: Array<Pick<DeletionResponse, 'result' | 'message'>>;
+};
 
 export type DeleteFacetMutationVariables = Exact<{
   id: Scalars['ID'];
   force?: Maybe<Scalars['Boolean']>;
 }>;
-
 
 export type DeleteFacetMutation = { deleteFacet: Pick<DeletionResponse, 'result' | 'message'> };
 
@@ -6072,30 +6530,28 @@ export type GetProductWithFacetValuesQueryVariables = Exact<{
   id: Scalars['ID'];
 }>;
 
+export type GetProductWithFacetValuesQuery = {
+  product?: Maybe<
+    Pick<Product, 'id'> & {
+      facetValues: Array<Pick<FacetValue, 'id' | 'name' | 'code'>>;
+      variants: Array<
+        Pick<ProductVariant, 'id'> & { facetValues: Array<Pick<FacetValue, 'id' | 'name' | 'code'>> }
+      >;
+    }
+  >;
+};
 
-export type GetProductWithFacetValuesQuery = { product?: Maybe<(
-    Pick<Product, 'id'>
-    & { facetValues: Array<Pick<FacetValue, 'id' | 'name' | 'code'>>, variants: Array<(
-      Pick<ProductVariant, 'id'>
-      & { facetValues: Array<Pick<FacetValue, 'id' | 'name' | 'code'>> }
-    )> }
-  )> };
+export type GetProductListWithVariantsQueryVariables = Exact<{ [key: string]: never }>;
 
-export type GetProductListWithVariantsQueryVariables = Exact<{ [key: string]: never; }>;
-
-
-export type GetProductListWithVariantsQuery = { products: (
-    Pick<ProductList, 'totalItems'>
-    & { items: Array<(
-      Pick<Product, 'id' | 'name'>
-      & { variants: Array<Pick<ProductVariant, 'id' | 'name'>> }
-    )> }
-  ) };
+export type GetProductListWithVariantsQuery = {
+  products: Pick<ProductList, 'totalItems'> & {
+    items: Array<Pick<Product, 'id' | 'name'> & { variants: Array<Pick<ProductVariant, 'id' | 'name'>> }>;
+  };
+};
 
 export type CreateFacetValuesMutationVariables = Exact<{
   input: Array<CreateFacetValueInput> | CreateFacetValueInput;
 }>;
-
 
 export type CreateFacetValuesMutation = { createFacetValues: Array<FacetValueFragment> };
 
@@ -6103,13 +6559,11 @@ export type UpdateFacetValuesMutationVariables = Exact<{
   input: Array<UpdateFacetValueInput> | UpdateFacetValueInput;
 }>;
 
-
 export type UpdateFacetValuesMutation = { updateFacetValues: Array<FacetValueFragment> };
 
 export type AssignFacetsToChannelMutationVariables = Exact<{
   input: AssignFacetsToChannelInput;
 }>;
-
 
 export type AssignFacetsToChannelMutation = { assignFacetsToChannel: Array<Pick<Facet, 'id' | 'name'>> };
 
@@ -6117,192 +6571,282 @@ export type RemoveFacetsFromChannelMutationVariables = Exact<{
   input: RemoveFacetsFromChannelInput;
 }>;
 
+export type RemoveFacetsFromChannelMutation = {
+  removeFacetsFromChannel: Array<
+    | Pick<Facet, 'id' | 'name'>
+    | Pick<FacetInUseError, 'errorCode' | 'message' | 'productCount' | 'variantCount'>
+  >;
+};
 
-export type RemoveFacetsFromChannelMutation = { removeFacetsFromChannel: Array<Pick<Facet, 'id' | 'name'> | Pick<FacetInUseError, 'errorCode' | 'message' | 'productCount' | 'variantCount'>> };
-
-export type GetGlobalSettingsQueryVariables = Exact<{ [key: string]: never; }>;
-
+export type GetGlobalSettingsQueryVariables = Exact<{ [key: string]: never }>;
 
 export type GetGlobalSettingsQuery = { globalSettings: GlobalSettingsFragment };
 
-export type AdministratorFragment = (
-  Pick<Administrator, 'id' | 'firstName' | 'lastName' | 'emailAddress'>
-  & { user: (
-    Pick<User, 'id' | 'identifier' | 'lastLogin'>
-    & { roles: Array<Pick<Role, 'id' | 'code' | 'description' | 'permissions'>> }
-  ) }
-);
+export type AdministratorFragment = Pick<Administrator, 'id' | 'firstName' | 'lastName' | 'emailAddress'> & {
+  user: Pick<User, 'id' | 'identifier' | 'lastLogin'> & {
+    roles: Array<Pick<Role, 'id' | 'code' | 'description' | 'permissions'>>;
+  };
+};
 
-export type AssetFragment = Pick<Asset, 'id' | 'name' | 'fileSize' | 'mimeType' | 'type' | 'preview' | 'source'>;
+export type AssetFragment = Pick<
+  Asset,
+  'id' | 'name' | 'fileSize' | 'mimeType' | 'type' | 'preview' | 'source'
+>;
 
-export type ProductVariantFragment = (
-  Pick<ProductVariant, 'id' | 'createdAt' | 'updatedAt' | 'enabled' | 'languageCode' | 'name' | 'currencyCode' | 'price' | 'priceWithTax' | 'stockOnHand' | 'trackInventory' | 'sku'>
-  & { taxRateApplied: Pick<TaxRate, 'id' | 'name' | 'value'>, taxCategory: Pick<TaxCategory, 'id' | 'name'>, options: Array<Pick<ProductOption, 'id' | 'code' | 'languageCode' | 'name'>>, facetValues: Array<(
-    Pick<FacetValue, 'id' | 'code' | 'name'>
-    & { facet: Pick<Facet, 'id' | 'name'> }
-  )>, featuredAsset?: Maybe<AssetFragment>, assets: Array<AssetFragment>, translations: Array<Pick<ProductVariantTranslation, 'id' | 'languageCode' | 'name'>>, channels: Array<Pick<Channel, 'id' | 'code'>> }
-);
+export type ProductVariantFragment = Pick<
+  ProductVariant,
+  | 'id'
+  | 'createdAt'
+  | 'updatedAt'
+  | 'enabled'
+  | 'languageCode'
+  | 'name'
+  | 'currencyCode'
+  | 'price'
+  | 'priceWithTax'
+  | 'stockOnHand'
+  | 'trackInventory'
+  | 'sku'
+> & {
+  taxRateApplied: Pick<TaxRate, 'id' | 'name' | 'value'>;
+  taxCategory: Pick<TaxCategory, 'id' | 'name'>;
+  options: Array<Pick<ProductOption, 'id' | 'code' | 'languageCode' | 'name'>>;
+  facetValues: Array<Pick<FacetValue, 'id' | 'code' | 'name'> & { facet: Pick<Facet, 'id' | 'name'> }>;
+  featuredAsset?: Maybe<AssetFragment>;
+  assets: Array<AssetFragment>;
+  translations: Array<Pick<ProductVariantTranslation, 'id' | 'languageCode' | 'name'>>;
+  channels: Array<Pick<Channel, 'id' | 'code'>>;
+};
 
-export type ProductWithVariantsFragment = (
-  Pick<Product, 'id' | 'enabled' | 'languageCode' | 'name' | 'slug' | 'description'>
-  & { featuredAsset?: Maybe<AssetFragment>, assets: Array<AssetFragment>, translations: Array<Pick<ProductTranslation, 'languageCode' | 'name' | 'slug' | 'description'>>, optionGroups: Array<Pick<ProductOptionGroup, 'id' | 'languageCode' | 'code' | 'name'>>, variants: Array<ProductVariantFragment>, facetValues: Array<(
-    Pick<FacetValue, 'id' | 'code' | 'name'>
-    & { facet: Pick<Facet, 'id' | 'name'> }
-  )>, channels: Array<Pick<Channel, 'id' | 'code'>> }
-);
+export type ProductWithVariantsFragment = Pick<
+  Product,
+  'id' | 'enabled' | 'languageCode' | 'name' | 'slug' | 'description'
+> & {
+  featuredAsset?: Maybe<AssetFragment>;
+  assets: Array<AssetFragment>;
+  translations: Array<Pick<ProductTranslation, 'languageCode' | 'name' | 'slug' | 'description'>>;
+  optionGroups: Array<Pick<ProductOptionGroup, 'id' | 'languageCode' | 'code' | 'name'>>;
+  variants: Array<ProductVariantFragment>;
+  facetValues: Array<Pick<FacetValue, 'id' | 'code' | 'name'> & { facet: Pick<Facet, 'id' | 'name'> }>;
+  channels: Array<Pick<Channel, 'id' | 'code'>>;
+};
 
-export type RoleFragment = (
-  Pick<Role, 'id' | 'code' | 'description' | 'permissions'>
-  & { channels: Array<Pick<Channel, 'id' | 'code' | 'token'>> }
-);
+export type RoleFragment = Pick<Role, 'id' | 'code' | 'description' | 'permissions'> & {
+  channels: Array<Pick<Channel, 'id' | 'code' | 'token'>>;
+};
 
-export type ConfigurableOperationFragment = (
-  Pick<ConfigurableOperation, 'code'>
-  & { args: Array<Pick<ConfigArg, 'name' | 'value'>> }
-);
+export type ConfigurableOperationFragment = Pick<ConfigurableOperation, 'code'> & {
+  args: Array<Pick<ConfigArg, 'name' | 'value'>>;
+};
 
-export type CollectionFragment = (
-  Pick<Collection, 'id' | 'name' | 'slug' | 'description' | 'isPrivate' | 'languageCode'>
-  & { featuredAsset?: Maybe<AssetFragment>, assets: Array<AssetFragment>, filters: Array<ConfigurableOperationFragment>, translations: Array<Pick<CollectionTranslation, 'id' | 'languageCode' | 'name' | 'slug' | 'description'>>, parent?: Maybe<Pick<Collection, 'id' | 'name'>>, children?: Maybe<Array<Pick<Collection, 'id' | 'name' | 'position'>>> }
-);
+export type CollectionFragment = Pick<
+  Collection,
+  'id' | 'name' | 'slug' | 'description' | 'isPrivate' | 'languageCode'
+> & {
+  featuredAsset?: Maybe<AssetFragment>;
+  assets: Array<AssetFragment>;
+  filters: Array<ConfigurableOperationFragment>;
+  translations: Array<Pick<CollectionTranslation, 'id' | 'languageCode' | 'name' | 'slug' | 'description'>>;
+  parent?: Maybe<Pick<Collection, 'id' | 'name'>>;
+  children?: Maybe<Array<Pick<Collection, 'id' | 'name' | 'position'>>>;
+};
 
-export type FacetValueFragment = (
-  Pick<FacetValue, 'id' | 'languageCode' | 'code' | 'name'>
-  & { translations: Array<Pick<FacetValueTranslation, 'id' | 'languageCode' | 'name'>>, facet: Pick<Facet, 'id' | 'name'> }
-);
+export type FacetValueFragment = Pick<FacetValue, 'id' | 'languageCode' | 'code' | 'name'> & {
+  translations: Array<Pick<FacetValueTranslation, 'id' | 'languageCode' | 'name'>>;
+  facet: Pick<Facet, 'id' | 'name'>;
+};
 
-export type FacetWithValuesFragment = (
-  Pick<Facet, 'id' | 'languageCode' | 'isPrivate' | 'code' | 'name'>
-  & { translations: Array<Pick<FacetTranslation, 'id' | 'languageCode' | 'name'>>, values: Array<FacetValueFragment> }
-);
+export type FacetWithValuesFragment = Pick<Facet, 'id' | 'languageCode' | 'isPrivate' | 'code' | 'name'> & {
+  translations: Array<Pick<FacetTranslation, 'id' | 'languageCode' | 'name'>>;
+  values: Array<FacetValueFragment>;
+};
 
-export type CountryFragment = (
-  Pick<Country, 'id' | 'code' | 'name' | 'enabled'>
-  & { translations: Array<Pick<CountryTranslation, 'id' | 'languageCode' | 'name'>> }
-);
+export type CountryFragment = Pick<Country, 'id' | 'code' | 'name' | 'enabled'> & {
+  translations: Array<Pick<CountryTranslation, 'id' | 'languageCode' | 'name'>>;
+};
 
-export type AddressFragment = (
-  Pick<Address, 'id' | 'fullName' | 'company' | 'streetLine1' | 'streetLine2' | 'city' | 'province' | 'postalCode' | 'phoneNumber' | 'defaultShippingAddress' | 'defaultBillingAddress'>
-  & { country: Pick<Country, 'id' | 'code' | 'name'> }
-);
+export type AddressFragment = Pick<
+  Address,
+  | 'id'
+  | 'fullName'
+  | 'company'
+  | 'streetLine1'
+  | 'streetLine2'
+  | 'city'
+  | 'province'
+  | 'postalCode'
+  | 'phoneNumber'
+  | 'defaultShippingAddress'
+  | 'defaultBillingAddress'
+> & { country: Pick<Country, 'id' | 'code' | 'name'> };
 
-export type CustomerFragment = (
-  Pick<Customer, 'id' | 'title' | 'firstName' | 'lastName' | 'phoneNumber' | 'emailAddress'>
-  & { user?: Maybe<Pick<User, 'id' | 'identifier' | 'verified' | 'lastLogin'>>, addresses?: Maybe<Array<AddressFragment>> }
-);
+export type CustomerFragment = Pick<
+  Customer,
+  'id' | 'title' | 'firstName' | 'lastName' | 'phoneNumber' | 'emailAddress'
+> & {
+  user?: Maybe<Pick<User, 'id' | 'identifier' | 'verified' | 'lastLogin'>>;
+  addresses?: Maybe<Array<AddressFragment>>;
+};
 
 export type AdjustmentFragment = Pick<Adjustment, 'adjustmentSource' | 'amount' | 'description' | 'type'>;
 
-export type ShippingAddressFragment = Pick<OrderAddress, 'fullName' | 'company' | 'streetLine1' | 'streetLine2' | 'city' | 'province' | 'postalCode' | 'country' | 'phoneNumber'>;
+export type ShippingAddressFragment = Pick<
+  OrderAddress,
+  | 'fullName'
+  | 'company'
+  | 'streetLine1'
+  | 'streetLine2'
+  | 'city'
+  | 'province'
+  | 'postalCode'
+  | 'country'
+  | 'phoneNumber'
+>;
 
-export type OrderFragment = (
-  Pick<Order, 'id' | 'createdAt' | 'updatedAt' | 'code' | 'active' | 'state' | 'total' | 'totalWithTax' | 'totalQuantity' | 'currencyCode'>
-  & { customer?: Maybe<Pick<Customer, 'id' | 'firstName' | 'lastName'>> }
-);
+export type OrderFragment = Pick<
+  Order,
+  | 'id'
+  | 'createdAt'
+  | 'updatedAt'
+  | 'code'
+  | 'active'
+  | 'state'
+  | 'total'
+  | 'totalWithTax'
+  | 'totalQuantity'
+  | 'currencyCode'
+> & { customer?: Maybe<Pick<Customer, 'id' | 'firstName' | 'lastName'>> };
 
-export type OrderItemFragment = (
-  Pick<OrderItem, 'id' | 'cancelled' | 'unitPrice' | 'unitPriceWithTax' | 'taxRate'>
-  & { fulfillment?: Maybe<Pick<Fulfillment, 'id'>> }
-);
+export type OrderItemFragment = Pick<
+  OrderItem,
+  'id' | 'cancelled' | 'unitPrice' | 'unitPriceWithTax' | 'taxRate'
+> & { fulfillment?: Maybe<Pick<Fulfillment, 'id'>> };
 
-export type PaymentFragment = (
-  Pick<Payment, 'id' | 'transactionId' | 'amount' | 'method' | 'state' | 'nextStates' | 'metadata'>
-  & { refunds: Array<Pick<Refund, 'id' | 'total' | 'reason'>> }
-);
+export type PaymentFragment = Pick<
+  Payment,
+  'id' | 'transactionId' | 'amount' | 'method' | 'state' | 'nextStates' | 'metadata'
+> & { refunds: Array<Pick<Refund, 'id' | 'total' | 'reason'>> };
 
-export type OrderWithLinesFragment = (
-  Pick<Order, 'id' | 'createdAt' | 'updatedAt' | 'code' | 'state' | 'active' | 'subTotal' | 'subTotalWithTax' | 'total' | 'totalWithTax' | 'totalQuantity' | 'currencyCode' | 'shipping' | 'shippingWithTax'>
-  & { customer?: Maybe<Pick<Customer, 'id' | 'firstName' | 'lastName'>>, lines: Array<(
-    Pick<OrderLine, 'id' | 'unitPrice' | 'unitPriceWithTax' | 'quantity' | 'linePriceWithTax'>
-    & { featuredAsset?: Maybe<Pick<Asset, 'preview'>>, productVariant: Pick<ProductVariant, 'id' | 'name' | 'sku'>, items: Array<OrderItemFragment> }
-  )>, surcharges: Array<Pick<Surcharge, 'id' | 'description' | 'sku' | 'price' | 'priceWithTax'>>, shippingLines: Array<(
-    Pick<ShippingLine, 'priceWithTax'>
-    & { shippingMethod: Pick<ShippingMethod, 'id' | 'code' | 'name' | 'description'> }
-  )>, shippingAddress?: Maybe<ShippingAddressFragment>, payments?: Maybe<Array<PaymentFragment>> }
-);
+export type OrderWithLinesFragment = Pick<
+  Order,
+  | 'id'
+  | 'createdAt'
+  | 'updatedAt'
+  | 'code'
+  | 'state'
+  | 'active'
+  | 'subTotal'
+  | 'subTotalWithTax'
+  | 'total'
+  | 'totalWithTax'
+  | 'totalQuantity'
+  | 'currencyCode'
+  | 'shipping'
+  | 'shippingWithTax'
+> & {
+  customer?: Maybe<Pick<Customer, 'id' | 'firstName' | 'lastName'>>;
+  lines: Array<
+    Pick<OrderLine, 'id' | 'unitPrice' | 'unitPriceWithTax' | 'quantity' | 'linePriceWithTax'> & {
+      featuredAsset?: Maybe<Pick<Asset, 'preview'>>;
+      productVariant: Pick<ProductVariant, 'id' | 'name' | 'sku'>;
+      items: Array<OrderItemFragment>;
+    }
+  >;
+  surcharges: Array<Pick<Surcharge, 'id' | 'description' | 'sku' | 'price' | 'priceWithTax'>>;
+  shippingLines: Array<
+    Pick<ShippingLine, 'priceWithTax'> & {
+      shippingMethod: Pick<ShippingMethod, 'id' | 'code' | 'name' | 'description'>;
+    }
+  >;
+  shippingAddress?: Maybe<ShippingAddressFragment>;
+  payments?: Maybe<Array<PaymentFragment>>;
+};
 
-export type PromotionFragment = (
-  Pick<Promotion, 'id' | 'createdAt' | 'updatedAt' | 'couponCode' | 'startsAt' | 'endsAt' | 'name' | 'enabled'>
-  & { conditions: Array<ConfigurableOperationFragment>, actions: Array<ConfigurableOperationFragment> }
-);
+export type PromotionFragment = Pick<
+  Promotion,
+  'id' | 'createdAt' | 'updatedAt' | 'couponCode' | 'startsAt' | 'endsAt' | 'name' | 'enabled'
+> & { conditions: Array<ConfigurableOperationFragment>; actions: Array<ConfigurableOperationFragment> };
 
-export type ZoneFragment = (
-  Pick<Zone, 'id' | 'name'>
-  & { members: Array<CountryFragment> }
-);
+export type ZoneFragment = Pick<Zone, 'id' | 'name'> & { members: Array<CountryFragment> };
 
-export type TaxRateFragment = (
-  Pick<TaxRate, 'id' | 'name' | 'enabled' | 'value'>
-  & { category: Pick<TaxCategory, 'id' | 'name'>, zone: Pick<Zone, 'id' | 'name'>, customerGroup?: Maybe<Pick<CustomerGroup, 'id' | 'name'>> }
-);
+export type TaxRateFragment = Pick<TaxRate, 'id' | 'name' | 'enabled' | 'value'> & {
+  category: Pick<TaxCategory, 'id' | 'name'>;
+  zone: Pick<Zone, 'id' | 'name'>;
+  customerGroup?: Maybe<Pick<CustomerGroup, 'id' | 'name'>>;
+};
 
-export type CurrentUserFragment = (
-  Pick<CurrentUser, 'id' | 'identifier'>
-  & { channels: Array<Pick<CurrentUserChannel, 'code' | 'token' | 'permissions'>> }
-);
+export type CurrentUserFragment = Pick<CurrentUser, 'id' | 'identifier'> & {
+  channels: Array<Pick<CurrentUserChannel, 'code' | 'token' | 'permissions'>>;
+};
 
-export type VariantWithStockFragment = (
-  Pick<ProductVariant, 'id' | 'stockOnHand' | 'stockAllocated'>
-  & { stockMovements: (
-    Pick<StockMovementList, 'totalItems'>
-    & { items: Array<Pick<StockAdjustment, 'id' | 'type' | 'quantity'> | Pick<Allocation, 'id' | 'type' | 'quantity'> | Pick<Sale, 'id' | 'type' | 'quantity'> | Pick<Cancellation, 'id' | 'type' | 'quantity'> | Pick<Return, 'id' | 'type' | 'quantity'> | Pick<Release, 'id' | 'type' | 'quantity'>> }
-  ) }
-);
+export type VariantWithStockFragment = Pick<ProductVariant, 'id' | 'stockOnHand' | 'stockAllocated'> & {
+  stockMovements: Pick<StockMovementList, 'totalItems'> & {
+    items: Array<
+      | Pick<StockAdjustment, 'id' | 'type' | 'quantity'>
+      | Pick<Allocation, 'id' | 'type' | 'quantity'>
+      | Pick<Sale, 'id' | 'type' | 'quantity'>
+      | Pick<Cancellation, 'id' | 'type' | 'quantity'>
+      | Pick<Return, 'id' | 'type' | 'quantity'>
+      | Pick<Release, 'id' | 'type' | 'quantity'>
+    >;
+  };
+};
 
-export type FulfillmentFragment = (
-  Pick<Fulfillment, 'id' | 'state' | 'nextStates' | 'method' | 'trackingCode'>
-  & { orderItems: Array<Pick<OrderItem, 'id'>> }
-);
+export type FulfillmentFragment = Pick<
+  Fulfillment,
+  'id' | 'state' | 'nextStates' | 'method' | 'trackingCode'
+> & { orderItems: Array<Pick<OrderItem, 'id'>> };
 
-export type ChannelFragment = (
-  Pick<Channel, 'id' | 'code' | 'token' | 'currencyCode' | 'defaultLanguageCode' | 'pricesIncludeTax'>
-  & { defaultShippingZone?: Maybe<Pick<Zone, 'id'>>, defaultTaxZone?: Maybe<Pick<Zone, 'id'>> }
-);
+export type ChannelFragment = Pick<
+  Channel,
+  'id' | 'code' | 'token' | 'currencyCode' | 'defaultLanguageCode' | 'pricesIncludeTax'
+> & { defaultShippingZone?: Maybe<Pick<Zone, 'id'>>; defaultTaxZone?: Maybe<Pick<Zone, 'id'>> };
 
-export type GlobalSettingsFragment = (
-  Pick<GlobalSettings, 'id' | 'availableLanguages' | 'trackInventory' | 'outOfStockThreshold'>
-  & { serverConfig: (
-    Pick<ServerConfig, 'permittedAssetTypes'>
-    & { orderProcess: Array<Pick<OrderProcessState, 'name' | 'to'>>, permissions: Array<Pick<PermissionDefinition, 'name' | 'description' | 'assignable'>>, customFieldConfig: { Customer: Array<Pick<StringCustomFieldConfig, 'name'> | Pick<LocaleStringCustomFieldConfig, 'name'> | Pick<IntCustomFieldConfig, 'name'> | Pick<FloatCustomFieldConfig, 'name'> | Pick<BooleanCustomFieldConfig, 'name'> | Pick<DateTimeCustomFieldConfig, 'name'> | Pick<RelationCustomFieldConfig, 'name'> | Pick<TextCustomFieldConfig, 'name'>> } }
-  ) }
-);
+export type GlobalSettingsFragment = Pick<
+  GlobalSettings,
+  'id' | 'availableLanguages' | 'trackInventory' | 'outOfStockThreshold'
+> & {
+  serverConfig: Pick<ServerConfig, 'permittedAssetTypes'> & {
+    orderProcess: Array<Pick<OrderProcessState, 'name' | 'to'>>;
+    permissions: Array<Pick<PermissionDefinition, 'name' | 'description' | 'assignable'>>;
+    customFieldConfig: {
+      Customer: Array<
+        | Pick<StringCustomFieldConfig, 'name'>
+        | Pick<LocaleStringCustomFieldConfig, 'name'>
+        | Pick<IntCustomFieldConfig, 'name'>
+        | Pick<FloatCustomFieldConfig, 'name'>
+        | Pick<BooleanCustomFieldConfig, 'name'>
+        | Pick<DateTimeCustomFieldConfig, 'name'>
+        | Pick<RelationCustomFieldConfig, 'name'>
+        | Pick<TextCustomFieldConfig, 'name'>
+      >;
+    };
+  };
+};
 
-export type CustomerGroupFragment = (
-  Pick<CustomerGroup, 'id' | 'name'>
-  & { customers: (
-    Pick<CustomerList, 'totalItems'>
-    & { items: Array<Pick<Customer, 'id'>> }
-  ) }
-);
+export type CustomerGroupFragment = Pick<CustomerGroup, 'id' | 'name'> & {
+  customers: Pick<CustomerList, 'totalItems'> & { items: Array<Pick<Customer, 'id'>> };
+};
 
-export type ProductOptionGroupFragment = (
-  Pick<ProductOptionGroup, 'id' | 'code' | 'name'>
-  & { options: Array<Pick<ProductOption, 'id' | 'code' | 'name'>>, translations: Array<Pick<ProductOptionGroupTranslation, 'id' | 'languageCode' | 'name'>> }
-);
+export type ProductOptionGroupFragment = Pick<ProductOptionGroup, 'id' | 'code' | 'name'> & {
+  options: Array<Pick<ProductOption, 'id' | 'code' | 'name'>>;
+  translations: Array<Pick<ProductOptionGroupTranslation, 'id' | 'languageCode' | 'name'>>;
+};
 
-export type ProductWithOptionsFragment = (
-  Pick<Product, 'id'>
-  & { optionGroups: Array<(
-    Pick<ProductOptionGroup, 'id' | 'code'>
-    & { options: Array<Pick<ProductOption, 'id' | 'code'>> }
-  )> }
-);
+export type ProductWithOptionsFragment = Pick<Product, 'id'> & {
+  optionGroups: Array<
+    Pick<ProductOptionGroup, 'id' | 'code'> & { options: Array<Pick<ProductOption, 'id' | 'code'>> }
+  >;
+};
 
-export type ShippingMethodFragment = (
-  Pick<ShippingMethod, 'id' | 'code' | 'name' | 'description'>
-  & { calculator: (
-    Pick<ConfigurableOperation, 'code'>
-    & { args: Array<Pick<ConfigArg, 'name' | 'value'>> }
-  ), checker: (
-    Pick<ConfigurableOperation, 'code'>
-    & { args: Array<Pick<ConfigArg, 'name' | 'value'>> }
-  ) }
-);
+export type ShippingMethodFragment = Pick<ShippingMethod, 'id' | 'code' | 'name' | 'description'> & {
+  calculator: Pick<ConfigurableOperation, 'code'> & { args: Array<Pick<ConfigArg, 'name' | 'value'>> };
+  checker: Pick<ConfigurableOperation, 'code'> & { args: Array<Pick<ConfigArg, 'name' | 'value'>> };
+};
 
 export type CreateAdministratorMutationVariables = Exact<{
   input: CreateAdministratorInput;
 }>;
-
 
 export type CreateAdministratorMutation = { createAdministrator: AdministratorFragment };
 
@@ -6310,13 +6854,11 @@ export type UpdateProductMutationVariables = Exact<{
   input: UpdateProductInput;
 }>;
 
-
 export type UpdateProductMutation = { updateProduct: ProductWithVariantsFragment };
 
 export type CreateProductMutationVariables = Exact<{
   input: CreateProductInput;
 }>;
-
 
 export type CreateProductMutation = { createProduct: ProductWithVariantsFragment };
 
@@ -6325,26 +6867,25 @@ export type GetProductWithVariantsQueryVariables = Exact<{
   slug?: Maybe<Scalars['String']>;
 }>;
 
-
 export type GetProductWithVariantsQuery = { product?: Maybe<ProductWithVariantsFragment> };
 
 export type GetProductListQueryVariables = Exact<{
   options?: Maybe<ProductListOptions>;
 }>;
 
-
-export type GetProductListQuery = { products: (
-    Pick<ProductList, 'totalItems'>
-    & { items: Array<(
-      Pick<Product, 'id' | 'languageCode' | 'name' | 'slug'>
-      & { featuredAsset?: Maybe<Pick<Asset, 'id' | 'preview'>> }
-    )> }
-  ) };
+export type GetProductListQuery = {
+  products: Pick<ProductList, 'totalItems'> & {
+    items: Array<
+      Pick<Product, 'id' | 'languageCode' | 'name' | 'slug'> & {
+        featuredAsset?: Maybe<Pick<Asset, 'id' | 'preview'>>;
+      }
+    >;
+  };
+};
 
 export type CreateProductVariantsMutationVariables = Exact<{
   input: Array<CreateProductVariantInput> | CreateProductVariantInput;
 }>;
-
 
 export type CreateProductVariantsMutation = { createProductVariants: Array<Maybe<ProductVariantFragment>> };
 
@@ -6352,13 +6893,11 @@ export type UpdateProductVariantsMutationVariables = Exact<{
   input: Array<UpdateProductVariantInput> | UpdateProductVariantInput;
 }>;
 
-
 export type UpdateProductVariantsMutation = { updateProductVariants: Array<Maybe<ProductVariantFragment>> };
 
 export type UpdateTaxRateMutationVariables = Exact<{
   input: UpdateTaxRateInput;
 }>;
-
 
 export type UpdateTaxRateMutation = { updateTaxRate: TaxRateFragment };
 
@@ -6366,13 +6905,11 @@ export type CreateFacetMutationVariables = Exact<{
   input: CreateFacetInput;
 }>;
 
-
 export type CreateFacetMutation = { createFacet: FacetWithValuesFragment };
 
 export type UpdateFacetMutationVariables = Exact<{
   input: UpdateFacetInput;
 }>;
-
 
 export type UpdateFacetMutation = { updateFacet: FacetWithValuesFragment };
 
@@ -6380,29 +6917,25 @@ export type GetCustomerListQueryVariables = Exact<{
   options?: Maybe<CustomerListOptions>;
 }>;
 
-
-export type GetCustomerListQuery = { customers: (
-    Pick<CustomerList, 'totalItems'>
-    & { items: Array<(
-      Pick<Customer, 'id' | 'title' | 'firstName' | 'lastName' | 'emailAddress' | 'phoneNumber'>
-      & { user?: Maybe<Pick<User, 'id' | 'verified'>> }
-    )> }
-  ) };
+export type GetCustomerListQuery = {
+  customers: Pick<CustomerList, 'totalItems'> & {
+    items: Array<
+      Pick<Customer, 'id' | 'title' | 'firstName' | 'lastName' | 'emailAddress' | 'phoneNumber'> & {
+        user?: Maybe<Pick<User, 'id' | 'verified'>>;
+      }
+    >;
+  };
+};
 
 export type GetAssetListQueryVariables = Exact<{
   options?: Maybe<AssetListOptions>;
 }>;
 
-
-export type GetAssetListQuery = { assets: (
-    Pick<AssetList, 'totalItems'>
-    & { items: Array<AssetFragment> }
-  ) };
+export type GetAssetListQuery = { assets: Pick<AssetList, 'totalItems'> & { items: Array<AssetFragment> } };
 
 export type CreateRoleMutationVariables = Exact<{
   input: CreateRoleInput;
 }>;
-
 
 export type CreateRoleMutation = { createRole: RoleFragment };
 
@@ -6410,13 +6943,11 @@ export type CreateCollectionMutationVariables = Exact<{
   input: CreateCollectionInput;
 }>;
 
-
 export type CreateCollectionMutation = { createCollection: CollectionFragment };
 
 export type UpdateCollectionMutationVariables = Exact<{
   input: UpdateCollectionInput;
 }>;
-
 
 export type UpdateCollectionMutation = { updateCollection: CollectionFragment };
 
@@ -6425,14 +6956,15 @@ export type GetCustomerQueryVariables = Exact<{
   orderListOptions?: Maybe<OrderListOptions>;
 }>;
 
-
-export type GetCustomerQuery = { customer?: Maybe<(
-    { orders: (
-      Pick<OrderList, 'totalItems'>
-      & { items: Array<Pick<Order, 'id' | 'code' | 'state' | 'total' | 'currencyCode' | 'updatedAt'>> }
-    ) }
-    & CustomerFragment
-  )> };
+export type GetCustomerQuery = {
+  customer?: Maybe<
+    {
+      orders: Pick<OrderList, 'totalItems'> & {
+        items: Array<Pick<Order, 'id' | 'code' | 'state' | 'total' | 'currencyCode' | 'updatedAt'>>;
+      };
+    } & CustomerFragment
+  >;
+};
 
 export type AttemptLoginMutationVariables = Exact<{
   username: Scalars['String'];
@@ -6440,23 +6972,26 @@ export type AttemptLoginMutationVariables = Exact<{
   rememberMe?: Maybe<Scalars['Boolean']>;
 }>;
 
-
-export type AttemptLoginMutation = { login: CurrentUserFragment };
+export type AttemptLoginMutation = {
+  login:
+    | CurrentUserFragment
+    | Pick<InvalidCredentialsError, 'errorCode' | 'message'>
+    | Pick<NativeAuthStrategyError, 'errorCode' | 'message'>;
+};
 
 export type GetCountryListQueryVariables = Exact<{
   options?: Maybe<CountryListOptions>;
 }>;
 
-
-export type GetCountryListQuery = { countries: (
-    Pick<CountryList, 'totalItems'>
-    & { items: Array<Pick<Country, 'id' | 'code' | 'name' | 'enabled'>> }
-  ) };
+export type GetCountryListQuery = {
+  countries: Pick<CountryList, 'totalItems'> & {
+    items: Array<Pick<Country, 'id' | 'code' | 'name' | 'enabled'>>;
+  };
+};
 
 export type UpdateCountryMutationVariables = Exact<{
   input: UpdateCountryInput;
 }>;
-
 
 export type UpdateCountryMutation = { updateCountry: CountryFragment };
 
@@ -6464,26 +6999,21 @@ export type GetFacetListQueryVariables = Exact<{
   options?: Maybe<FacetListOptions>;
 }>;
 
-
-export type GetFacetListQuery = { facets: (
-    Pick<FacetList, 'totalItems'>
-    & { items: Array<FacetWithValuesFragment> }
-  ) };
+export type GetFacetListQuery = {
+  facets: Pick<FacetList, 'totalItems'> & { items: Array<FacetWithValuesFragment> };
+};
 
 export type GetFacetListSimpleQueryVariables = Exact<{
   options?: Maybe<FacetListOptions>;
 }>;
 
-
-export type GetFacetListSimpleQuery = { facets: (
-    Pick<FacetList, 'totalItems'>
-    & { items: Array<Pick<Facet, 'id' | 'name'>> }
-  ) };
+export type GetFacetListSimpleQuery = {
+  facets: Pick<FacetList, 'totalItems'> & { items: Array<Pick<Facet, 'id' | 'name'>> };
+};
 
 export type DeleteProductMutationVariables = Exact<{
   id: Scalars['ID'];
 }>;
-
 
 export type DeleteProductMutation = { deleteProduct: Pick<DeletionResponse, 'result'> };
 
@@ -6492,38 +7022,35 @@ export type GetProductSimpleQueryVariables = Exact<{
   slug?: Maybe<Scalars['String']>;
 }>;
 
-
 export type GetProductSimpleQuery = { product?: Maybe<Pick<Product, 'id' | 'slug'>> };
 
 export type GetStockMovementQueryVariables = Exact<{
   id: Scalars['ID'];
 }>;
 
-
-export type GetStockMovementQuery = { product?: Maybe<(
-    Pick<Product, 'id'>
-    & { variants: Array<VariantWithStockFragment> }
-  )> };
+export type GetStockMovementQuery = {
+  product?: Maybe<Pick<Product, 'id'> & { variants: Array<VariantWithStockFragment> }>;
+};
 
 export type GetRunningJobsQueryVariables = Exact<{
   options?: Maybe<JobListOptions>;
 }>;
 
-
-export type GetRunningJobsQuery = { jobs: (
-    Pick<JobList, 'totalItems'>
-    & { items: Array<Pick<Job, 'id' | 'queueName' | 'state' | 'isSettled' | 'duration'>> }
-  ) };
+export type GetRunningJobsQuery = {
+  jobs: Pick<JobList, 'totalItems'> & {
+    items: Array<Pick<Job, 'id' | 'queueName' | 'state' | 'isSettled' | 'duration'>>;
+  };
+};
 
 export type CreatePromotionMutationVariables = Exact<{
   input: CreatePromotionInput;
 }>;
 
+export type CreatePromotionMutation = {
+  createPromotion: PromotionFragment | Pick<MissingConditionsError, 'errorCode' | 'message'>;
+};
 
-export type CreatePromotionMutation = { createPromotion: PromotionFragment | Pick<MissingConditionsError, 'errorCode' | 'message'> };
-
-export type MeQueryVariables = Exact<{ [key: string]: never; }>;
-
+export type MeQueryVariables = Exact<{ [key: string]: never }>;
 
 export type MeQuery = { me?: Maybe<CurrentUserFragment> };
 
@@ -6531,20 +7058,21 @@ export type CreateChannelMutationVariables = Exact<{
   input: CreateChannelInput;
 }>;
 
-
-export type CreateChannelMutation = { createChannel: ChannelFragment | Pick<LanguageNotAvailableError, 'errorCode' | 'message' | 'languageCode'> };
+export type CreateChannelMutation = {
+  createChannel: ChannelFragment | Pick<LanguageNotAvailableError, 'errorCode' | 'message' | 'languageCode'>;
+};
 
 export type DeleteProductVariantMutationVariables = Exact<{
   id: Scalars['ID'];
 }>;
 
-
-export type DeleteProductVariantMutation = { deleteProductVariant: Pick<DeletionResponse, 'result' | 'message'> };
+export type DeleteProductVariantMutation = {
+  deleteProductVariant: Pick<DeletionResponse, 'result' | 'message'>;
+};
 
 export type AssignProductsToChannelMutationVariables = Exact<{
   input: AssignProductsToChannelInput;
 }>;
-
 
 export type AssignProductsToChannelMutation = { assignProductsToChannel: Array<ProductWithVariantsFragment> };
 
@@ -6552,37 +7080,40 @@ export type RemoveProductsFromChannelMutationVariables = Exact<{
   input: RemoveProductsFromChannelInput;
 }>;
 
-
-export type RemoveProductsFromChannelMutation = { removeProductsFromChannel: Array<ProductWithVariantsFragment> };
+export type RemoveProductsFromChannelMutation = {
+  removeProductsFromChannel: Array<ProductWithVariantsFragment>;
+};
 
 export type AssignProductVariantsToChannelMutationVariables = Exact<{
   input: AssignProductVariantsToChannelInput;
 }>;
 
-
-export type AssignProductVariantsToChannelMutation = { assignProductVariantsToChannel: Array<ProductVariantFragment> };
+export type AssignProductVariantsToChannelMutation = {
+  assignProductVariantsToChannel: Array<ProductVariantFragment>;
+};
 
 export type RemoveProductVariantsFromChannelMutationVariables = Exact<{
   input: RemoveProductVariantsFromChannelInput;
 }>;
 
-
-export type RemoveProductVariantsFromChannelMutation = { removeProductVariantsFromChannel: Array<ProductVariantFragment> };
+export type RemoveProductVariantsFromChannelMutation = {
+  removeProductVariantsFromChannel: Array<ProductVariantFragment>;
+};
 
 export type UpdateAssetMutationVariables = Exact<{
   input: UpdateAssetInput;
 }>;
 
-
-export type UpdateAssetMutation = { updateAsset: (
-    { tags: Array<Pick<Tag, 'id' | 'value'>>, focalPoint?: Maybe<Pick<Coordinate, 'x' | 'y'>> }
-    & AssetFragment
-  ) };
+export type UpdateAssetMutation = {
+  updateAsset: {
+    tags: Array<Pick<Tag, 'id' | 'value'>>;
+    focalPoint?: Maybe<Pick<Coordinate, 'x' | 'y'>>;
+  } & AssetFragment;
+};
 
 export type DeleteAssetMutationVariables = Exact<{
   input: DeleteAssetInput;
 }>;
-
 
 export type DeleteAssetMutation = { deleteAsset: Pick<DeletionResponse, 'result' | 'message'> };
 
@@ -6590,37 +7121,38 @@ export type UpdateChannelMutationVariables = Exact<{
   input: UpdateChannelInput;
 }>;
 
-
-export type UpdateChannelMutation = { updateChannel: ChannelFragment | Pick<LanguageNotAvailableError, 'errorCode' | 'message' | 'languageCode'> };
+export type UpdateChannelMutation = {
+  updateChannel: ChannelFragment | Pick<LanguageNotAvailableError, 'errorCode' | 'message' | 'languageCode'>;
+};
 
 export type GetCustomerHistoryQueryVariables = Exact<{
   id: Scalars['ID'];
   options?: Maybe<HistoryEntryListOptions>;
 }>;
 
-
-export type GetCustomerHistoryQuery = { customer?: Maybe<(
-    Pick<Customer, 'id'>
-    & { history: (
-      Pick<HistoryEntryList, 'totalItems'>
-      & { items: Array<(
-        Pick<HistoryEntry, 'id' | 'type' | 'data'>
-        & { administrator?: Maybe<Pick<Administrator, 'id'>> }
-      )> }
-    ) }
-  )> };
+export type GetCustomerHistoryQuery = {
+  customer?: Maybe<
+    Pick<Customer, 'id'> & {
+      history: Pick<HistoryEntryList, 'totalItems'> & {
+        items: Array<
+          Pick<HistoryEntry, 'id' | 'type' | 'data'> & {
+            administrator?: Maybe<Pick<Administrator, 'id'>>;
+          }
+        >;
+      };
+    }
+  >;
+};
 
 export type GetOrderQueryVariables = Exact<{
   id: Scalars['ID'];
 }>;
-
 
 export type GetOrderQuery = { order?: Maybe<OrderWithLinesFragment> };
 
 export type CreateCustomerGroupMutationVariables = Exact<{
   input: CreateCustomerGroupInput;
 }>;
-
 
 export type CreateCustomerGroupMutation = { createCustomerGroup: CustomerGroupFragment };
 
@@ -6629,90 +7161,113 @@ export type RemoveCustomersFromGroupMutationVariables = Exact<{
   customerIds: Array<Scalars['ID']> | Scalars['ID'];
 }>;
 
-
 export type RemoveCustomersFromGroupMutation = { removeCustomersFromGroup: CustomerGroupFragment };
 
 export type CreateFulfillmentMutationVariables = Exact<{
   input: FulfillOrderInput;
 }>;
 
-
-export type CreateFulfillmentMutation = { addFulfillmentToOrder: FulfillmentFragment | Pick<EmptyOrderLineSelectionError, 'errorCode' | 'message'> | Pick<ItemsAlreadyFulfilledError, 'errorCode' | 'message'> | Pick<InsufficientStockOnHandError, 'errorCode' | 'message'> | Pick<InvalidFulfillmentHandlerError, 'errorCode' | 'message'> | Pick<FulfillmentStateTransitionError, 'errorCode' | 'message'> | Pick<CreateFulfillmentError, 'errorCode' | 'message' | 'fulfillmentHandlerError'> };
+export type CreateFulfillmentMutation = {
+  addFulfillmentToOrder:
+    | FulfillmentFragment
+    | Pick<EmptyOrderLineSelectionError, 'errorCode' | 'message'>
+    | Pick<ItemsAlreadyFulfilledError, 'errorCode' | 'message'>
+    | Pick<InsufficientStockOnHandError, 'errorCode' | 'message'>
+    | Pick<InvalidFulfillmentHandlerError, 'errorCode' | 'message'>
+    | Pick<FulfillmentStateTransitionError, 'errorCode' | 'message'>
+    | Pick<CreateFulfillmentError, 'errorCode' | 'message' | 'fulfillmentHandlerError'>;
+};
 
 export type TransitFulfillmentMutationVariables = Exact<{
   id: Scalars['ID'];
   state: Scalars['String'];
 }>;
 
-
-export type TransitFulfillmentMutation = { transitionFulfillmentToState: FulfillmentFragment | Pick<FulfillmentStateTransitionError, 'errorCode' | 'message' | 'transitionError' | 'fromState' | 'toState'> };
+export type TransitFulfillmentMutation = {
+  transitionFulfillmentToState:
+    | FulfillmentFragment
+    | Pick<
+        FulfillmentStateTransitionError,
+        'errorCode' | 'message' | 'transitionError' | 'fromState' | 'toState'
+      >;
+};
 
 export type GetOrderFulfillmentsQueryVariables = Exact<{
   id: Scalars['ID'];
 }>;
 
-
-export type GetOrderFulfillmentsQuery = { order?: Maybe<(
-    Pick<Order, 'id' | 'state'>
-    & { fulfillments?: Maybe<Array<(
-      Pick<Fulfillment, 'id' | 'state' | 'nextStates' | 'method'>
-      & { summary: Array<(
-        Pick<FulfillmentLineSummary, 'quantity'>
-        & { orderLine: Pick<OrderLine, 'id'> }
-      )> }
-    )>> }
-  )> };
+export type GetOrderFulfillmentsQuery = {
+  order?: Maybe<
+    Pick<Order, 'id' | 'state'> & {
+      fulfillments?: Maybe<
+        Array<
+          Pick<Fulfillment, 'id' | 'state' | 'nextStates' | 'method'> & {
+            summary: Array<Pick<FulfillmentLineSummary, 'quantity'> & { orderLine: Pick<OrderLine, 'id'> }>;
+          }
+        >
+      >;
+    }
+  >;
+};
 
 export type GetOrderListQueryVariables = Exact<{
   options?: Maybe<OrderListOptions>;
 }>;
 
-
-export type GetOrderListQuery = { orders: (
-    Pick<OrderList, 'totalItems'>
-    & { items: Array<OrderFragment> }
-  ) };
+export type GetOrderListQuery = { orders: Pick<OrderList, 'totalItems'> & { items: Array<OrderFragment> } };
 
 export type CreateAddressMutationVariables = Exact<{
   id: Scalars['ID'];
   input: CreateAddressInput;
 }>;
 
-
-export type CreateAddressMutation = { createCustomerAddress: (
-    Pick<Address, 'id' | 'fullName' | 'company' | 'streetLine1' | 'streetLine2' | 'city' | 'province' | 'postalCode' | 'phoneNumber' | 'defaultShippingAddress' | 'defaultBillingAddress'>
-    & { country: Pick<Country, 'code' | 'name'> }
-  ) };
+export type CreateAddressMutation = {
+  createCustomerAddress: Pick<
+    Address,
+    | 'id'
+    | 'fullName'
+    | 'company'
+    | 'streetLine1'
+    | 'streetLine2'
+    | 'city'
+    | 'province'
+    | 'postalCode'
+    | 'phoneNumber'
+    | 'defaultShippingAddress'
+    | 'defaultBillingAddress'
+  > & { country: Pick<Country, 'code' | 'name'> };
+};
 
 export type UpdateAddressMutationVariables = Exact<{
   input: UpdateAddressInput;
 }>;
 
-
-export type UpdateAddressMutation = { updateCustomerAddress: (
-    Pick<Address, 'id' | 'defaultShippingAddress' | 'defaultBillingAddress'>
-    & { country: Pick<Country, 'code' | 'name'> }
-  ) };
+export type UpdateAddressMutation = {
+  updateCustomerAddress: Pick<Address, 'id' | 'defaultShippingAddress' | 'defaultBillingAddress'> & {
+    country: Pick<Country, 'code' | 'name'>;
+  };
+};
 
 export type CreateCustomerMutationVariables = Exact<{
   input: CreateCustomerInput;
   password?: Maybe<Scalars['String']>;
 }>;
 
-
-export type CreateCustomerMutation = { createCustomer: CustomerFragment | Pick<EmailAddressConflictError, 'errorCode' | 'message'> };
+export type CreateCustomerMutation = {
+  createCustomer: CustomerFragment | Pick<EmailAddressConflictError, 'errorCode' | 'message'>;
+};
 
 export type UpdateCustomerMutationVariables = Exact<{
   input: UpdateCustomerInput;
 }>;
 
-
-export type UpdateCustomerMutation = { updateCustomer: CustomerFragment | Pick<EmailAddressConflictError, 'errorCode' | 'message'> };
+export type UpdateCustomerMutation = {
+  updateCustomer: CustomerFragment | Pick<EmailAddressConflictError, 'errorCode' | 'message'>;
+};
 
 export type DeleteCustomerMutationVariables = Exact<{
   id: Scalars['ID'];
 }>;
-
 
 export type DeleteCustomerMutation = { deleteCustomer: Pick<DeletionResponse, 'result'> };
 
@@ -6720,13 +7275,13 @@ export type UpdateCustomerNoteMutationVariables = Exact<{
   input: UpdateCustomerNoteInput;
 }>;
 
-
-export type UpdateCustomerNoteMutation = { updateCustomerNote: Pick<HistoryEntry, 'id' | 'data' | 'isPublic'> };
+export type UpdateCustomerNoteMutation = {
+  updateCustomerNote: Pick<HistoryEntry, 'id' | 'data' | 'isPublic'>;
+};
 
 export type DeleteCustomerNoteMutationVariables = Exact<{
   id: Scalars['ID'];
 }>;
-
 
 export type DeleteCustomerNoteMutation = { deleteCustomerNote: Pick<DeletionResponse, 'result' | 'message'> };
 
@@ -6734,45 +7289,43 @@ export type UpdateCustomerGroupMutationVariables = Exact<{
   input: UpdateCustomerGroupInput;
 }>;
 
-
 export type UpdateCustomerGroupMutation = { updateCustomerGroup: CustomerGroupFragment };
 
 export type DeleteCustomerGroupMutationVariables = Exact<{
   id: Scalars['ID'];
 }>;
 
-
-export type DeleteCustomerGroupMutation = { deleteCustomerGroup: Pick<DeletionResponse, 'result' | 'message'> };
+export type DeleteCustomerGroupMutation = {
+  deleteCustomerGroup: Pick<DeletionResponse, 'result' | 'message'>;
+};
 
 export type GetCustomerGroupsQueryVariables = Exact<{
   options?: Maybe<CustomerGroupListOptions>;
 }>;
 
-
-export type GetCustomerGroupsQuery = { customerGroups: (
-    Pick<CustomerGroupList, 'totalItems'>
-    & { items: Array<Pick<CustomerGroup, 'id' | 'name'>> }
-  ) };
+export type GetCustomerGroupsQuery = {
+  customerGroups: Pick<CustomerGroupList, 'totalItems'> & {
+    items: Array<Pick<CustomerGroup, 'id' | 'name'>>;
+  };
+};
 
 export type GetCustomerGroupQueryVariables = Exact<{
   id: Scalars['ID'];
   options?: Maybe<CustomerListOptions>;
 }>;
 
-
-export type GetCustomerGroupQuery = { customerGroup?: Maybe<(
-    Pick<CustomerGroup, 'id' | 'name'>
-    & { customers: (
-      Pick<CustomerList, 'totalItems'>
-      & { items: Array<Pick<Customer, 'id'>> }
-    ) }
-  )> };
+export type GetCustomerGroupQuery = {
+  customerGroup?: Maybe<
+    Pick<CustomerGroup, 'id' | 'name'> & {
+      customers: Pick<CustomerList, 'totalItems'> & { items: Array<Pick<Customer, 'id'>> };
+    }
+  >;
+};
 
 export type AddCustomersToGroupMutationVariables = Exact<{
   groupId: Scalars['ID'];
   customerIds: Array<Scalars['ID']> | Scalars['ID'];
 }>;
-
 
 export type AddCustomersToGroupMutation = { addCustomersToGroup: CustomerGroupFragment };
 
@@ -6780,64 +7333,73 @@ export type GetCustomerWithGroupsQueryVariables = Exact<{
   id: Scalars['ID'];
 }>;
 
-
-export type GetCustomerWithGroupsQuery = { customer?: Maybe<(
-    Pick<Customer, 'id'>
-    & { groups: Array<Pick<CustomerGroup, 'id' | 'name'>> }
-  )> };
+export type GetCustomerWithGroupsQuery = {
+  customer?: Maybe<Pick<Customer, 'id'> & { groups: Array<Pick<CustomerGroup, 'id' | 'name'>> }>;
+};
 
 export type AdminTransitionMutationVariables = Exact<{
   id: Scalars['ID'];
   state: Scalars['String'];
 }>;
 
-
-export type AdminTransitionMutation = { transitionOrderToState?: Maybe<OrderFragment | Pick<OrderStateTransitionError, 'errorCode' | 'message' | 'transitionError' | 'fromState' | 'toState'>> };
+export type AdminTransitionMutation = {
+  transitionOrderToState?: Maybe<
+    | OrderFragment
+    | Pick<OrderStateTransitionError, 'errorCode' | 'message' | 'transitionError' | 'fromState' | 'toState'>
+  >;
+};
 
 export type CancelOrderMutationVariables = Exact<{
   input: CancelOrderInput;
 }>;
 
+export type CancelOrderMutation = {
+  cancelOrder:
+    | CanceledOrderFragment
+    | Pick<EmptyOrderLineSelectionError, 'errorCode' | 'message'>
+    | Pick<QuantityTooGreatError, 'errorCode' | 'message'>
+    | Pick<MultipleOrderError, 'errorCode' | 'message'>
+    | Pick<CancelActiveOrderError, 'errorCode' | 'message'>
+    | Pick<OrderStateTransitionError, 'errorCode' | 'message'>;
+};
 
-export type CancelOrderMutation = { cancelOrder: CanceledOrderFragment | Pick<EmptyOrderLineSelectionError, 'errorCode' | 'message'> | Pick<QuantityTooGreatError, 'errorCode' | 'message'> | Pick<MultipleOrderError, 'errorCode' | 'message'> | Pick<CancelActiveOrderError, 'errorCode' | 'message'> | Pick<OrderStateTransitionError, 'errorCode' | 'message'> };
-
-export type CanceledOrderFragment = (
-  Pick<Order, 'id' | 'state'>
-  & { lines: Array<(
-    Pick<OrderLine, 'quantity'>
-    & { items: Array<Pick<OrderItem, 'id' | 'cancelled'>> }
-  )> }
-);
+export type CanceledOrderFragment = Pick<Order, 'id' | 'state'> & {
+  lines: Array<Pick<OrderLine, 'quantity'> & { items: Array<Pick<OrderItem, 'id' | 'cancelled'>> }>;
+};
 
 export type UpdateGlobalSettingsMutationVariables = Exact<{
   input: UpdateGlobalSettingsInput;
 }>;
 
-
-export type UpdateGlobalSettingsMutation = { updateGlobalSettings: GlobalSettingsFragment | Pick<ChannelDefaultLanguageError, 'errorCode' | 'message'> };
+export type UpdateGlobalSettingsMutation = {
+  updateGlobalSettings: GlobalSettingsFragment | Pick<ChannelDefaultLanguageError, 'errorCode' | 'message'>;
+};
 
 export type UpdateRoleMutationVariables = Exact<{
   input: UpdateRoleInput;
 }>;
 
-
 export type UpdateRoleMutation = { updateRole: RoleFragment };
 
-export type GetProductsWithVariantPricesQueryVariables = Exact<{ [key: string]: never; }>;
+export type GetProductsWithVariantPricesQueryVariables = Exact<{ [key: string]: never }>;
 
-
-export type GetProductsWithVariantPricesQuery = { products: { items: Array<(
-      Pick<Product, 'id' | 'slug'>
-      & { variants: Array<(
-        Pick<ProductVariant, 'id' | 'price' | 'priceWithTax' | 'sku'>
-        & { facetValues: Array<Pick<FacetValue, 'id' | 'code'>> }
-      )> }
-    )> } };
+export type GetProductsWithVariantPricesQuery = {
+  products: {
+    items: Array<
+      Pick<Product, 'id' | 'slug'> & {
+        variants: Array<
+          Pick<ProductVariant, 'id' | 'price' | 'priceWithTax' | 'sku'> & {
+            facetValues: Array<Pick<FacetValue, 'id' | 'code'>>;
+          }
+        >;
+      }
+    >;
+  };
+};
 
 export type CreateProductOptionGroupMutationVariables = Exact<{
   input: CreateProductOptionGroupInput;
 }>;
-
 
 export type CreateProductOptionGroupMutation = { createProductOptionGroup: ProductOptionGroupFragment };
 
@@ -6846,13 +7408,11 @@ export type AddOptionGroupToProductMutationVariables = Exact<{
   optionGroupId: Scalars['ID'];
 }>;
 
-
 export type AddOptionGroupToProductMutation = { addOptionGroupToProduct: ProductWithOptionsFragment };
 
 export type CreateShippingMethodMutationVariables = Exact<{
   input: CreateShippingMethodInput;
 }>;
-
 
 export type CreateShippingMethodMutation = { createShippingMethod: ShippingMethodFragment };
 
@@ -6860,30 +7420,36 @@ export type SettlePaymentMutationVariables = Exact<{
   id: Scalars['ID'];
 }>;
 
-
-export type SettlePaymentMutation = { settlePayment: PaymentFragment | Pick<SettlePaymentError, 'errorCode' | 'message' | 'paymentErrorMessage'> | Pick<PaymentStateTransitionError, 'errorCode' | 'message'> | Pick<OrderStateTransitionError, 'errorCode' | 'message'> };
+export type SettlePaymentMutation = {
+  settlePayment:
+    | PaymentFragment
+    | Pick<SettlePaymentError, 'errorCode' | 'message' | 'paymentErrorMessage'>
+    | Pick<PaymentStateTransitionError, 'errorCode' | 'message'>
+    | Pick<OrderStateTransitionError, 'errorCode' | 'message'>;
+};
 
 export type GetOrderHistoryQueryVariables = Exact<{
   id: Scalars['ID'];
   options?: Maybe<HistoryEntryListOptions>;
 }>;
 
-
-export type GetOrderHistoryQuery = { order?: Maybe<(
-    Pick<Order, 'id'>
-    & { history: (
-      Pick<HistoryEntryList, 'totalItems'>
-      & { items: Array<(
-        Pick<HistoryEntry, 'id' | 'type' | 'data'>
-        & { administrator?: Maybe<Pick<Administrator, 'id'>> }
-      )> }
-    ) }
-  )> };
+export type GetOrderHistoryQuery = {
+  order?: Maybe<
+    Pick<Order, 'id'> & {
+      history: Pick<HistoryEntryList, 'totalItems'> & {
+        items: Array<
+          Pick<HistoryEntry, 'id' | 'type' | 'data'> & {
+            administrator?: Maybe<Pick<Administrator, 'id'>>;
+          }
+        >;
+      };
+    }
+  >;
+};
 
 export type UpdateShippingMethodMutationVariables = Exact<{
   input: UpdateShippingMethodInput;
 }>;
-
 
 export type UpdateShippingMethodMutation = { updateShippingMethod: ShippingMethodFragment };
 
@@ -6891,11 +7457,7 @@ export type GetAssetQueryVariables = Exact<{
   id: Scalars['ID'];
 }>;
 
-
-export type GetAssetQuery = { asset?: Maybe<(
-    Pick<Asset, 'width' | 'height'>
-    & AssetFragment
-  )> };
+export type GetAssetQuery = { asset?: Maybe<Pick<Asset, 'width' | 'height'> & AssetFragment> };
 
 export type AssetFragFirstFragment = Pick<Asset, 'id' | 'preview'>;
 
@@ -6903,94 +7465,99 @@ export type GetAssetFragmentFirstQueryVariables = Exact<{
   id: Scalars['ID'];
 }>;
 
-
 export type GetAssetFragmentFirstQuery = { asset?: Maybe<AssetFragFirstFragment> };
 
 export type CreateAssetsMutationVariables = Exact<{
   input: Array<CreateAssetInput> | CreateAssetInput;
 }>;
 
-
-export type CreateAssetsMutation = { createAssets: Array<(
-    { focalPoint?: Maybe<Pick<Coordinate, 'x' | 'y'>>, tags: Array<Pick<Tag, 'id' | 'value'>> }
-    & AssetFragment
-  ) | Pick<MimeTypeError, 'message' | 'fileName' | 'mimeType'>> };
+export type CreateAssetsMutation = {
+  createAssets: Array<
+    | ({
+        focalPoint?: Maybe<Pick<Coordinate, 'x' | 'y'>>;
+        tags: Array<Pick<Tag, 'id' | 'value'>>;
+      } & AssetFragment)
+    | Pick<MimeTypeError, 'message' | 'fileName' | 'mimeType'>
+  >;
+};
 
 export type DeleteShippingMethodMutationVariables = Exact<{
   id: Scalars['ID'];
 }>;
 
-
-export type DeleteShippingMethodMutation = { deleteShippingMethod: Pick<DeletionResponse, 'result' | 'message'> };
+export type DeleteShippingMethodMutation = {
+  deleteShippingMethod: Pick<DeletionResponse, 'result' | 'message'>;
+};
 
 export type AssignPromotionToChannelMutationVariables = Exact<{
   input: AssignPromotionsToChannelInput;
 }>;
 
-
-export type AssignPromotionToChannelMutation = { assignPromotionsToChannel: Array<Pick<Promotion, 'id' | 'name'>> };
+export type AssignPromotionToChannelMutation = {
+  assignPromotionsToChannel: Array<Pick<Promotion, 'id' | 'name'>>;
+};
 
 export type RemovePromotionFromChannelMutationVariables = Exact<{
   input: RemovePromotionsFromChannelInput;
 }>;
 
-
-export type RemovePromotionFromChannelMutation = { removePromotionsFromChannel: Array<Pick<Promotion, 'id' | 'name'>> };
+export type RemovePromotionFromChannelMutation = {
+  removePromotionsFromChannel: Array<Pick<Promotion, 'id' | 'name'>>;
+};
 
 export type GetTaxRatesQueryVariables = Exact<{
   options?: Maybe<TaxRateListOptions>;
 }>;
 
+export type GetTaxRatesQuery = {
+  taxRates: Pick<TaxRateList, 'totalItems'> & { items: Array<TaxRateFragment> };
+};
 
-export type GetTaxRatesQuery = { taxRates: (
-    Pick<TaxRateList, 'totalItems'>
-    & { items: Array<TaxRateFragment> }
-  ) };
+export type GetShippingMethodListQueryVariables = Exact<{ [key: string]: never }>;
 
-export type GetShippingMethodListQueryVariables = Exact<{ [key: string]: never; }>;
+export type GetShippingMethodListQuery = {
+  shippingMethods: Pick<ShippingMethodList, 'totalItems'> & { items: Array<ShippingMethodFragment> };
+};
 
+export type GetCollectionsQueryVariables = Exact<{ [key: string]: never }>;
 
-export type GetShippingMethodListQuery = { shippingMethods: (
-    Pick<ShippingMethodList, 'totalItems'>
-    & { items: Array<ShippingMethodFragment> }
-  ) };
-
-export type GetCollectionsQueryVariables = Exact<{ [key: string]: never; }>;
-
-
-export type GetCollectionsQuery = { collections: { items: Array<(
-      Pick<Collection, 'id' | 'name' | 'position'>
-      & { parent?: Maybe<Pick<Collection, 'id' | 'name'>> }
-    )> } };
+export type GetCollectionsQuery = {
+  collections: {
+    items: Array<
+      Pick<Collection, 'id' | 'name' | 'position'> & { parent?: Maybe<Pick<Collection, 'id' | 'name'>> }
+    >;
+  };
+};
 
 export type TransitionPaymentToStateMutationVariables = Exact<{
   id: Scalars['ID'];
   state: Scalars['String'];
 }>;
 
-
-export type TransitionPaymentToStateMutation = { transitionPaymentToState: PaymentFragment | Pick<PaymentStateTransitionError, 'errorCode' | 'message' | 'transitionError'> };
+export type TransitionPaymentToStateMutation = {
+  transitionPaymentToState:
+    | PaymentFragment
+    | Pick<PaymentStateTransitionError, 'errorCode' | 'message' | 'transitionError'>;
+};
 
 export type GetProductVariantListQueryVariables = Exact<{
   options?: Maybe<ProductVariantListOptions>;
   productId?: Maybe<Scalars['ID']>;
 }>;
 
-
-export type GetProductVariantListQuery = { productVariants: (
-    Pick<ProductVariantList, 'totalItems'>
-    & { items: Array<Pick<ProductVariant, 'id' | 'name' | 'sku' | 'price' | 'priceWithTax'>> }
-  ) };
+export type GetProductVariantListQuery = {
+  productVariants: Pick<ProductVariantList, 'totalItems'> & {
+    items: Array<Pick<ProductVariant, 'id' | 'name' | 'sku' | 'price' | 'priceWithTax'>>;
+  };
+};
 
 export type DeletePromotionMutationVariables = Exact<{
   id: Scalars['ID'];
 }>;
 
-
 export type DeletePromotionMutation = { deletePromotion: Pick<DeletionResponse, 'result'> };
 
-export type GetChannelsQueryVariables = Exact<{ [key: string]: never; }>;
-
+export type GetChannelsQueryVariables = Exact<{ [key: string]: never }>;
 
 export type GetChannelsQuery = { channels: Array<Pick<Channel, 'id' | 'code' | 'token'>> };
 
@@ -6998,13 +7565,11 @@ export type UpdateAdministratorMutationVariables = Exact<{
   input: UpdateAdministratorInput;
 }>;
 
-
 export type UpdateAdministratorMutation = { updateAdministrator: AdministratorFragment };
 
 export type CancelJobMutationVariables = Exact<{
   id: Scalars['ID'];
 }>;
-
 
 export type CancelJobMutation = { cancelJob: Pick<Job, 'id' | 'state' | 'isSettled' | 'settledAt'> };
 
@@ -7012,35 +7577,66 @@ export type UpdateOptionGroupMutationVariables = Exact<{
   input: UpdateProductOptionGroupInput;
 }>;
 
-
 export type UpdateOptionGroupMutation = { updateProductOptionGroup: Pick<ProductOptionGroup, 'id'> };
 
-export type GetFulfillmentHandlersQueryVariables = Exact<{ [key: string]: never; }>;
+export type GetFulfillmentHandlersQueryVariables = Exact<{ [key: string]: never }>;
 
+export type GetFulfillmentHandlersQuery = {
+  fulfillmentHandlers: Array<
+    Pick<ConfigurableOperationDefinition, 'code' | 'description'> & {
+      args: Array<Pick<ConfigArgDefinition, 'name' | 'type' | 'description' | 'label' | 'ui'>>;
+    }
+  >;
+};
 
-export type GetFulfillmentHandlersQuery = { fulfillmentHandlers: Array<(
-    Pick<ConfigurableOperationDefinition, 'code' | 'description'>
-    & { args: Array<Pick<ConfigArgDefinition, 'name' | 'type' | 'description' | 'label' | 'ui'>> }
-  )> };
-
-export type OrderWithModificationsFragment = (
-  Pick<Order, 'id' | 'state' | 'subTotal' | 'subTotalWithTax' | 'shipping' | 'shippingWithTax' | 'total' | 'totalWithTax'>
-  & { lines: Array<(
-    Pick<OrderLine, 'id' | 'quantity' | 'linePrice' | 'linePriceWithTax' | 'discountedLinePriceWithTax' | 'proratedLinePriceWithTax'>
-    & { discounts: Array<Pick<Discount, 'description' | 'amountWithTax'>>, productVariant: Pick<ProductVariant, 'id' | 'name'>, items: Array<Pick<OrderItem, 'id' | 'createdAt' | 'updatedAt' | 'cancelled' | 'unitPrice'>> }
-  )>, surcharges: Array<Pick<Surcharge, 'id' | 'description' | 'sku' | 'price' | 'priceWithTax' | 'taxRate'>>, payments?: Maybe<Array<(
-    Pick<Payment, 'id' | 'transactionId' | 'state' | 'amount' | 'method' | 'metadata'>
-    & { refunds: Array<Pick<Refund, 'id' | 'state' | 'total' | 'paymentId'>> }
-  )>>, modifications: Array<(
-    Pick<OrderModification, 'id' | 'note' | 'priceChange' | 'isSettled'>
-    & { orderItems?: Maybe<Array<Pick<OrderItem, 'id'>>>, surcharges?: Maybe<Array<Pick<Surcharge, 'id'>>>, payment?: Maybe<Pick<Payment, 'id' | 'state' | 'amount' | 'method'>>, refund?: Maybe<Pick<Refund, 'id' | 'state' | 'total' | 'paymentId'>> }
-  )>, promotions: Array<Pick<Promotion, 'id' | 'name' | 'couponCode'>>, discounts: Array<Pick<Discount, 'description' | 'adjustmentSource' | 'amount' | 'amountWithTax'>>, shippingAddress?: Maybe<Pick<OrderAddress, 'streetLine1' | 'city' | 'postalCode' | 'province' | 'countryCode' | 'country'>>, billingAddress?: Maybe<Pick<OrderAddress, 'streetLine1' | 'city' | 'postalCode' | 'province' | 'countryCode' | 'country'>> }
-);
+export type OrderWithModificationsFragment = Pick<
+  Order,
+  'id' | 'state' | 'subTotal' | 'subTotalWithTax' | 'shipping' | 'shippingWithTax' | 'total' | 'totalWithTax'
+> & {
+  lines: Array<
+    Pick<
+      OrderLine,
+      | 'id'
+      | 'quantity'
+      | 'linePrice'
+      | 'linePriceWithTax'
+      | 'discountedLinePriceWithTax'
+      | 'proratedLinePriceWithTax'
+    > & {
+      discounts: Array<Pick<Discount, 'description' | 'amountWithTax'>>;
+      productVariant: Pick<ProductVariant, 'id' | 'name'>;
+      items: Array<Pick<OrderItem, 'id' | 'createdAt' | 'updatedAt' | 'cancelled' | 'unitPrice'>>;
+    }
+  >;
+  surcharges: Array<Pick<Surcharge, 'id' | 'description' | 'sku' | 'price' | 'priceWithTax' | 'taxRate'>>;
+  payments?: Maybe<
+    Array<
+      Pick<Payment, 'id' | 'transactionId' | 'state' | 'amount' | 'method' | 'metadata'> & {
+        refunds: Array<Pick<Refund, 'id' | 'state' | 'total' | 'paymentId'>>;
+      }
+    >
+  >;
+  modifications: Array<
+    Pick<OrderModification, 'id' | 'note' | 'priceChange' | 'isSettled'> & {
+      orderItems?: Maybe<Array<Pick<OrderItem, 'id'>>>;
+      surcharges?: Maybe<Array<Pick<Surcharge, 'id'>>>;
+      payment?: Maybe<Pick<Payment, 'id' | 'state' | 'amount' | 'method'>>;
+      refund?: Maybe<Pick<Refund, 'id' | 'state' | 'total' | 'paymentId'>>;
+    }
+  >;
+  promotions: Array<Pick<Promotion, 'id' | 'name' | 'couponCode'>>;
+  discounts: Array<Pick<Discount, 'description' | 'adjustmentSource' | 'amount' | 'amountWithTax'>>;
+  shippingAddress?: Maybe<
+    Pick<OrderAddress, 'streetLine1' | 'city' | 'postalCode' | 'province' | 'countryCode' | 'country'>
+  >;
+  billingAddress?: Maybe<
+    Pick<OrderAddress, 'streetLine1' | 'city' | 'postalCode' | 'province' | 'countryCode' | 'country'>
+  >;
+};
 
 export type GetOrderWithModificationsQueryVariables = Exact<{
   id: Scalars['ID'];
 }>;
-
 
 export type GetOrderWithModificationsQuery = { order?: Maybe<OrderWithModificationsFragment> };
 
@@ -7048,18 +7644,32 @@ export type ModifyOrderMutationVariables = Exact<{
   input: ModifyOrderInput;
 }>;
 
-
-export type ModifyOrderMutation = { modifyOrder: OrderWithModificationsFragment | Pick<NoChangesSpecifiedError, 'errorCode' | 'message'> | Pick<OrderModificationStateError, 'errorCode' | 'message'> | Pick<PaymentMethodMissingError, 'errorCode' | 'message'> | Pick<RefundPaymentIdMissingError, 'errorCode' | 'message'> | Pick<OrderLimitError, 'errorCode' | 'message'> | Pick<NegativeQuantityError, 'errorCode' | 'message'> | Pick<InsufficientStockError, 'errorCode' | 'message'> | Pick<CouponCodeExpiredError, 'errorCode' | 'message'> | Pick<CouponCodeInvalidError, 'errorCode' | 'message'> | Pick<CouponCodeLimitError, 'errorCode' | 'message'> };
+export type ModifyOrderMutation = {
+  modifyOrder:
+    | OrderWithModificationsFragment
+    | Pick<NoChangesSpecifiedError, 'errorCode' | 'message'>
+    | Pick<OrderModificationStateError, 'errorCode' | 'message'>
+    | Pick<PaymentMethodMissingError, 'errorCode' | 'message'>
+    | Pick<RefundPaymentIdMissingError, 'errorCode' | 'message'>
+    | Pick<OrderLimitError, 'errorCode' | 'message'>
+    | Pick<NegativeQuantityError, 'errorCode' | 'message'>
+    | Pick<InsufficientStockError, 'errorCode' | 'message'>
+    | Pick<CouponCodeExpiredError, 'errorCode' | 'message'>
+    | Pick<CouponCodeInvalidError, 'errorCode' | 'message'>
+    | Pick<CouponCodeLimitError, 'errorCode' | 'message'>;
+};
 
 export type AddManualPaymentMutationVariables = Exact<{
   input: ManualPaymentInput;
 }>;
 
+export type AddManualPaymentMutation = {
+  addManualPaymentToOrder:
+    | OrderWithModificationsFragment
+    | Pick<ManualPaymentStateError, 'errorCode' | 'message'>;
+};
 
-export type AddManualPaymentMutation = { addManualPaymentToOrder: OrderWithModificationsFragment | Pick<ManualPaymentStateError, 'errorCode' | 'message'> };
-
-export type DeletePromotionAdHoc1MutationVariables = Exact<{ [key: string]: never; }>;
-
+export type DeletePromotionAdHoc1MutationVariables = Exact<{ [key: string]: never }>;
 
 export type DeletePromotionAdHoc1Mutation = { deletePromotion: Pick<DeletionResponse, 'result'> };
 
@@ -7067,63 +7677,80 @@ export type GetTaxRateListQueryVariables = Exact<{
   options?: Maybe<TaxRateListOptions>;
 }>;
 
-
-export type GetTaxRateListQuery = { taxRates: (
-    Pick<TaxRateList, 'totalItems'>
-    & { items: Array<(
-      Pick<TaxRate, 'id' | 'name' | 'enabled' | 'value'>
-      & { category: Pick<TaxCategory, 'id' | 'name'>, zone: Pick<Zone, 'id' | 'name'> }
-    )> }
-  ) };
+export type GetTaxRateListQuery = {
+  taxRates: Pick<TaxRateList, 'totalItems'> & {
+    items: Array<
+      Pick<TaxRate, 'id' | 'name' | 'enabled' | 'value'> & {
+        category: Pick<TaxCategory, 'id' | 'name'>;
+        zone: Pick<Zone, 'id' | 'name'>;
+      }
+    >;
+  };
+};
 
 export type GetOrderWithLineCalculatedPropsQueryVariables = Exact<{
   id: Scalars['ID'];
 }>;
 
+export type GetOrderWithLineCalculatedPropsQuery = {
+  order?: Maybe<
+    Pick<Order, 'id'> & { lines: Array<Pick<OrderLine, 'id' | 'linePriceWithTax' | 'quantity'>> }
+  >;
+};
 
-export type GetOrderWithLineCalculatedPropsQuery = { order?: Maybe<(
-    Pick<Order, 'id'>
-    & { lines: Array<Pick<OrderLine, 'id' | 'linePriceWithTax' | 'quantity'>> }
-  )> };
+export type GetOrderListFulfillmentsQueryVariables = Exact<{ [key: string]: never }>;
 
-export type GetOrderListFulfillmentsQueryVariables = Exact<{ [key: string]: never; }>;
-
-
-export type GetOrderListFulfillmentsQuery = { orders: { items: Array<(
-      Pick<Order, 'id' | 'state'>
-      & { fulfillments?: Maybe<Array<Pick<Fulfillment, 'id' | 'state' | 'nextStates' | 'method'>>> }
-    )> } };
+export type GetOrderListFulfillmentsQuery = {
+  orders: {
+    items: Array<
+      Pick<Order, 'id' | 'state'> & {
+        fulfillments?: Maybe<Array<Pick<Fulfillment, 'id' | 'state' | 'nextStates' | 'method'>>>;
+      }
+    >;
+  };
+};
 
 export type GetOrderFulfillmentItemsQueryVariables = Exact<{
   id: Scalars['ID'];
 }>;
 
+export type GetOrderFulfillmentItemsQuery = {
+  order?: Maybe<Pick<Order, 'id' | 'state'> & { fulfillments?: Maybe<Array<FulfillmentFragment>> }>;
+};
 
-export type GetOrderFulfillmentItemsQuery = { order?: Maybe<(
-    Pick<Order, 'id' | 'state'>
-    & { fulfillments?: Maybe<Array<FulfillmentFragment>> }
-  )> };
-
-export type RefundFragment = Pick<Refund, 'id' | 'state' | 'items' | 'transactionId' | 'shipping' | 'total' | 'metadata'>;
+export type RefundFragment = Pick<
+  Refund,
+  'id' | 'state' | 'items' | 'transactionId' | 'shipping' | 'total' | 'metadata'
+>;
 
 export type RefundOrderMutationVariables = Exact<{
   input: RefundOrderInput;
 }>;
 
-
-export type RefundOrderMutation = { refundOrder: RefundFragment | Pick<QuantityTooGreatError, 'errorCode' | 'message'> | Pick<NothingToRefundError, 'errorCode' | 'message'> | Pick<OrderStateTransitionError, 'errorCode' | 'message'> | Pick<MultipleOrderError, 'errorCode' | 'message'> | Pick<PaymentOrderMismatchError, 'errorCode' | 'message'> | Pick<RefundOrderStateError, 'errorCode' | 'message'> | Pick<AlreadyRefundedError, 'errorCode' | 'message'> | Pick<RefundStateTransitionError, 'errorCode' | 'message'> };
+export type RefundOrderMutation = {
+  refundOrder:
+    | RefundFragment
+    | Pick<QuantityTooGreatError, 'errorCode' | 'message'>
+    | Pick<NothingToRefundError, 'errorCode' | 'message'>
+    | Pick<OrderStateTransitionError, 'errorCode' | 'message'>
+    | Pick<MultipleOrderError, 'errorCode' | 'message'>
+    | Pick<PaymentOrderMismatchError, 'errorCode' | 'message'>
+    | Pick<RefundOrderStateError, 'errorCode' | 'message'>
+    | Pick<AlreadyRefundedError, 'errorCode' | 'message'>
+    | Pick<RefundStateTransitionError, 'errorCode' | 'message'>;
+};
 
 export type SettleRefundMutationVariables = Exact<{
   input: SettleRefundInput;
 }>;
 
-
-export type SettleRefundMutation = { settleRefund: RefundFragment | Pick<RefundStateTransitionError, 'errorCode' | 'message'> };
+export type SettleRefundMutation = {
+  settleRefund: RefundFragment | Pick<RefundStateTransitionError, 'errorCode' | 'message'>;
+};
 
 export type AddNoteToOrderMutationVariables = Exact<{
   input: AddNoteToOrderInput;
 }>;
-
 
 export type AddNoteToOrderMutation = { addNoteToOrder: Pick<Order, 'id'> };
 
@@ -7131,13 +7758,11 @@ export type UpdateOrderNoteMutationVariables = Exact<{
   input: UpdateOrderNoteInput;
 }>;
 
-
 export type UpdateOrderNoteMutation = { updateOrderNote: Pick<HistoryEntry, 'id' | 'data' | 'isPublic'> };
 
 export type DeleteOrderNoteMutationVariables = Exact<{
   id: Scalars['ID'];
 }>;
-
 
 export type DeleteOrderNoteMutation = { deleteOrderNote: Pick<DeletionResponse, 'result' | 'message'> };
 
@@ -7145,66 +7770,82 @@ export type GetOrderWithPaymentsQueryVariables = Exact<{
   id: Scalars['ID'];
 }>;
 
-
-export type GetOrderWithPaymentsQuery = { order?: Maybe<(
-    Pick<Order, 'id'>
-    & { payments?: Maybe<Array<(
-      Pick<Payment, 'id' | 'errorMessage' | 'metadata'>
-      & { refunds: Array<Pick<Refund, 'id' | 'total'>> }
-    )>> }
-  )> };
+export type GetOrderWithPaymentsQuery = {
+  order?: Maybe<
+    Pick<Order, 'id'> & {
+      payments?: Maybe<
+        Array<
+          Pick<Payment, 'id' | 'errorMessage' | 'metadata'> & {
+            refunds: Array<Pick<Refund, 'id' | 'total'>>;
+          }
+        >
+      >;
+    }
+  >;
+};
 
 export type GetOrderLineFulfillmentsQueryVariables = Exact<{
   id: Scalars['ID'];
 }>;
 
-
-export type GetOrderLineFulfillmentsQuery = { order?: Maybe<(
-    Pick<Order, 'id'>
-    & { lines: Array<(
-      Pick<OrderLine, 'id'>
-      & { fulfillments?: Maybe<Array<(
-        Pick<Fulfillment, 'id' | 'state'>
-        & { summary: Array<(
-          Pick<FulfillmentLineSummary, 'quantity'>
-          & { orderLine: Pick<OrderLine, 'id'> }
-        )> }
-      )>> }
-    )> }
-  )> };
+export type GetOrderLineFulfillmentsQuery = {
+  order?: Maybe<
+    Pick<Order, 'id'> & {
+      lines: Array<
+        Pick<OrderLine, 'id'> & {
+          fulfillments?: Maybe<
+            Array<
+              Pick<Fulfillment, 'id' | 'state'> & {
+                summary: Array<
+                  Pick<FulfillmentLineSummary, 'quantity'> & {
+                    orderLine: Pick<OrderLine, 'id'>;
+                  }
+                >;
+              }
+            >
+          >;
+        }
+      >;
+    }
+  >;
+};
 
 export type GetOrderListWithQtyQueryVariables = Exact<{
   options?: Maybe<OrderListOptions>;
 }>;
 
-
-export type GetOrderListWithQtyQuery = { orders: { items: Array<(
-      Pick<Order, 'id' | 'code' | 'totalQuantity'>
-      & { lines: Array<Pick<OrderLine, 'id' | 'quantity'>> }
-    )> } };
+export type GetOrderListWithQtyQuery = {
+  orders: {
+    items: Array<
+      Pick<Order, 'id' | 'code' | 'totalQuantity'> & {
+        lines: Array<Pick<OrderLine, 'id' | 'quantity'>>;
+      }
+    >;
+  };
+};
 
 export type CancelPaymentMutationVariables = Exact<{
   paymentId: Scalars['ID'];
 }>;
 
+export type CancelPaymentMutation = {
+  cancelPayment:
+    | PaymentFragment
+    | Pick<CancelPaymentError, 'errorCode' | 'message' | 'paymentErrorMessage'>
+    | Pick<PaymentStateTransitionError, 'errorCode' | 'message' | 'transitionError'>;
+};
 
-export type CancelPaymentMutation = { cancelPayment: PaymentFragment | Pick<CancelPaymentError, 'errorCode' | 'message' | 'paymentErrorMessage'> | Pick<PaymentStateTransitionError, 'errorCode' | 'message' | 'transitionError'> };
-
-export type PaymentMethodFragment = (
-  Pick<PaymentMethod, 'id' | 'code' | 'name' | 'description' | 'enabled'>
-  & { checker?: Maybe<(
-    Pick<ConfigurableOperation, 'code'>
-    & { args: Array<Pick<ConfigArg, 'name' | 'value'>> }
-  )>, handler: (
-    Pick<ConfigurableOperation, 'code'>
-    & { args: Array<Pick<ConfigArg, 'name' | 'value'>> }
-  ) }
-);
+export type PaymentMethodFragment = Pick<
+  PaymentMethod,
+  'id' | 'code' | 'name' | 'description' | 'enabled'
+> & {
+  checker?: Maybe<Pick<ConfigurableOperation, 'code'> & { args: Array<Pick<ConfigArg, 'name' | 'value'>> }>;
+  handler: Pick<ConfigurableOperation, 'code'> & { args: Array<Pick<ConfigArg, 'name' | 'value'>> };
+};
 
 export type CreatePaymentMethodMutationVariables = Exact<{
   input: CreatePaymentMethodInput;
 }>;
-
 
 export type CreatePaymentMethodMutation = { createPaymentMethod: PaymentMethodFragment };
 
@@ -7212,29 +7853,31 @@ export type UpdatePaymentMethodMutationVariables = Exact<{
   input: UpdatePaymentMethodInput;
 }>;
 
-
 export type UpdatePaymentMethodMutation = { updatePaymentMethod: PaymentMethodFragment };
 
-export type GetPaymentMethodHandlersQueryVariables = Exact<{ [key: string]: never; }>;
+export type GetPaymentMethodHandlersQueryVariables = Exact<{ [key: string]: never }>;
 
+export type GetPaymentMethodHandlersQuery = {
+  paymentMethodHandlers: Array<
+    Pick<ConfigurableOperationDefinition, 'code'> & {
+      args: Array<Pick<ConfigArgDefinition, 'name' | 'type'>>;
+    }
+  >;
+};
 
-export type GetPaymentMethodHandlersQuery = { paymentMethodHandlers: Array<(
-    Pick<ConfigurableOperationDefinition, 'code'>
-    & { args: Array<Pick<ConfigArgDefinition, 'name' | 'type'>> }
-  )> };
+export type GetPaymentMethodCheckersQueryVariables = Exact<{ [key: string]: never }>;
 
-export type GetPaymentMethodCheckersQueryVariables = Exact<{ [key: string]: never; }>;
-
-
-export type GetPaymentMethodCheckersQuery = { paymentMethodEligibilityCheckers: Array<(
-    Pick<ConfigurableOperationDefinition, 'code'>
-    & { args: Array<Pick<ConfigArgDefinition, 'name' | 'type'>> }
-  )> };
+export type GetPaymentMethodCheckersQuery = {
+  paymentMethodEligibilityCheckers: Array<
+    Pick<ConfigurableOperationDefinition, 'code'> & {
+      args: Array<Pick<ConfigArgDefinition, 'name' | 'type'>>;
+    }
+  >;
+};
 
 export type GetPaymentMethodQueryVariables = Exact<{
   id: Scalars['ID'];
 }>;
-
 
 export type GetPaymentMethodQuery = { paymentMethod?: Maybe<PaymentMethodFragment> };
 
@@ -7242,41 +7885,42 @@ export type GetPaymentMethodListQueryVariables = Exact<{
   options?: Maybe<PaymentMethodListOptions>;
 }>;
 
-
-export type GetPaymentMethodListQuery = { paymentMethods: (
-    Pick<PaymentMethodList, 'totalItems'>
-    & { items: Array<PaymentMethodFragment> }
-  ) };
+export type GetPaymentMethodListQuery = {
+  paymentMethods: Pick<PaymentMethodList, 'totalItems'> & { items: Array<PaymentMethodFragment> };
+};
 
 export type DeletePaymentMethodMutationVariables = Exact<{
   id: Scalars['ID'];
   force?: Maybe<Scalars['Boolean']>;
 }>;
 
-
-export type DeletePaymentMethodMutation = { deletePaymentMethod: Pick<DeletionResponse, 'message' | 'result'> };
+export type DeletePaymentMethodMutation = {
+  deletePaymentMethod: Pick<DeletionResponse, 'message' | 'result'>;
+};
 
 export type AddManualPayment2MutationVariables = Exact<{
   input: ManualPaymentInput;
 }>;
 
-
-export type AddManualPayment2Mutation = { addManualPaymentToOrder: OrderWithLinesFragment | Pick<ManualPaymentStateError, 'errorCode' | 'message'> };
+export type AddManualPayment2Mutation = {
+  addManualPaymentToOrder: OrderWithLinesFragment | Pick<ManualPaymentStateError, 'errorCode' | 'message'>;
+};
 
 export type GetProductOptionGroupQueryVariables = Exact<{
   id: Scalars['ID'];
 }>;
 
-
-export type GetProductOptionGroupQuery = { productOptionGroup?: Maybe<(
-    Pick<ProductOptionGroup, 'id' | 'code' | 'name'>
-    & { options: Array<Pick<ProductOption, 'id' | 'code' | 'name'>> }
-  )> };
+export type GetProductOptionGroupQuery = {
+  productOptionGroup?: Maybe<
+    Pick<ProductOptionGroup, 'id' | 'code' | 'name'> & {
+      options: Array<Pick<ProductOption, 'id' | 'code' | 'name'>>;
+    }
+  >;
+};
 
 export type UpdateProductOptionGroupMutationVariables = Exact<{
   input: UpdateProductOptionGroupInput;
 }>;
-
 
 export type UpdateProductOptionGroupMutation = { updateProductOptionGroup: ProductOptionGroupFragment };
 
@@ -7284,48 +7928,52 @@ export type CreateProductOptionMutationVariables = Exact<{
   input: CreateProductOptionInput;
 }>;
 
-
-export type CreateProductOptionMutation = { createProductOption: (
-    Pick<ProductOption, 'id' | 'code' | 'name' | 'groupId'>
-    & { translations: Array<Pick<ProductOptionTranslation, 'id' | 'languageCode' | 'name'>> }
-  ) };
+export type CreateProductOptionMutation = {
+  createProductOption: Pick<ProductOption, 'id' | 'code' | 'name' | 'groupId'> & {
+    translations: Array<Pick<ProductOptionTranslation, 'id' | 'languageCode' | 'name'>>;
+  };
+};
 
 export type UpdateProductOptionMutationVariables = Exact<{
   input: UpdateProductOptionInput;
 }>;
 
-
-export type UpdateProductOptionMutation = { updateProductOption: Pick<ProductOption, 'id' | 'code' | 'name' | 'groupId'> };
+export type UpdateProductOptionMutation = {
+  updateProductOption: Pick<ProductOption, 'id' | 'code' | 'name' | 'groupId'>;
+};
 
 export type DeleteProductOptionMutationVariables = Exact<{
   id: Scalars['ID'];
 }>;
 
-
-export type DeleteProductOptionMutation = { deleteProductOption: Pick<DeletionResponse, 'result' | 'message'> };
+export type DeleteProductOptionMutation = {
+  deleteProductOption: Pick<DeletionResponse, 'result' | 'message'>;
+};
 
 export type RemoveOptionGroupFromProductMutationVariables = Exact<{
   productId: Scalars['ID'];
   optionGroupId: Scalars['ID'];
 }>;
 
-
-export type RemoveOptionGroupFromProductMutation = { removeOptionGroupFromProduct: ProductWithOptionsFragment | Pick<ProductOptionInUseError, 'errorCode' | 'message' | 'optionGroupCode' | 'productVariantCount'> };
+export type RemoveOptionGroupFromProductMutation = {
+  removeOptionGroupFromProduct:
+    | ProductWithOptionsFragment
+    | Pick<ProductOptionInUseError, 'errorCode' | 'message' | 'optionGroupCode' | 'productVariantCount'>;
+};
 
 export type GetOptionGroupQueryVariables = Exact<{
   id: Scalars['ID'];
 }>;
 
-
-export type GetOptionGroupQuery = { productOptionGroup?: Maybe<(
-    Pick<ProductOptionGroup, 'id' | 'code'>
-    & { options: Array<Pick<ProductOption, 'id' | 'code'>> }
-  )> };
+export type GetOptionGroupQuery = {
+  productOptionGroup?: Maybe<
+    Pick<ProductOptionGroup, 'id' | 'code'> & { options: Array<Pick<ProductOption, 'id' | 'code'>> }
+  >;
+};
 
 export type GetProductVariantQueryVariables = Exact<{
   id: Scalars['ID'];
 }>;
-
 
 export type GetProductVariantQuery = { productVariant?: Maybe<Pick<ProductVariant, 'id' | 'name'>> };
 
@@ -7334,29 +7982,25 @@ export type GetProductWithVariantListQueryVariables = Exact<{
   variantListOptions?: Maybe<ProductVariantListOptions>;
 }>;
 
-
-export type GetProductWithVariantListQuery = { product?: Maybe<(
-    Pick<Product, 'id'>
-    & { variantList: (
-      Pick<ProductVariantList, 'totalItems'>
-      & { items: Array<ProductVariantFragment> }
-    ) }
-  )> };
+export type GetProductWithVariantListQuery = {
+  product?: Maybe<
+    Pick<Product, 'id'> & {
+      variantList: Pick<ProductVariantList, 'totalItems'> & { items: Array<ProductVariantFragment> };
+    }
+  >;
+};
 
 export type GetPromotionListQueryVariables = Exact<{
   options?: Maybe<PromotionListOptions>;
 }>;
 
-
-export type GetPromotionListQuery = { promotions: (
-    Pick<PromotionList, 'totalItems'>
-    & { items: Array<PromotionFragment> }
-  ) };
+export type GetPromotionListQuery = {
+  promotions: Pick<PromotionList, 'totalItems'> & { items: Array<PromotionFragment> };
+};
 
 export type GetPromotionQueryVariables = Exact<{
   id: Scalars['ID'];
 }>;
-
 
 export type GetPromotionQuery = { promotion?: Maybe<PromotionFragment> };
 
@@ -7364,33 +8008,31 @@ export type UpdatePromotionMutationVariables = Exact<{
   input: UpdatePromotionInput;
 }>;
 
+export type UpdatePromotionMutation = {
+  updatePromotion: PromotionFragment | Pick<MissingConditionsError, 'errorCode' | 'message'>;
+};
 
-export type UpdatePromotionMutation = { updatePromotion: PromotionFragment | Pick<MissingConditionsError, 'errorCode' | 'message'> };
+export type ConfigurableOperationDefFragment = Pick<
+  ConfigurableOperationDefinition,
+  'code' | 'description'
+> & { args: Array<Pick<ConfigArgDefinition, 'name' | 'type' | 'ui'>> };
 
-export type ConfigurableOperationDefFragment = (
-  Pick<ConfigurableOperationDefinition, 'code' | 'description'>
-  & { args: Array<Pick<ConfigArgDefinition, 'name' | 'type' | 'ui'>> }
-);
+export type GetAdjustmentOperationsQueryVariables = Exact<{ [key: string]: never }>;
 
-export type GetAdjustmentOperationsQueryVariables = Exact<{ [key: string]: never; }>;
-
-
-export type GetAdjustmentOperationsQuery = { promotionActions: Array<ConfigurableOperationDefFragment>, promotionConditions: Array<ConfigurableOperationDefFragment> };
+export type GetAdjustmentOperationsQuery = {
+  promotionActions: Array<ConfigurableOperationDefFragment>;
+  promotionConditions: Array<ConfigurableOperationDefFragment>;
+};
 
 export type GetRolesQueryVariables = Exact<{
   options?: Maybe<RoleListOptions>;
 }>;
 
-
-export type GetRolesQuery = { roles: (
-    Pick<RoleList, 'totalItems'>
-    & { items: Array<RoleFragment> }
-  ) };
+export type GetRolesQuery = { roles: Pick<RoleList, 'totalItems'> & { items: Array<RoleFragment> } };
 
 export type GetRoleQueryVariables = Exact<{
   id: Scalars['ID'];
 }>;
-
 
 export type GetRoleQuery = { role?: Maybe<RoleFragment> };
 
@@ -7398,11 +8040,9 @@ export type DeleteRoleMutationVariables = Exact<{
   id: Scalars['ID'];
 }>;
 
-
 export type DeleteRoleMutation = { deleteRole: Pick<DeletionResponse, 'result' | 'message'> };
 
-export type LogoutMutationVariables = Exact<{ [key: string]: never; }>;
-
+export type LogoutMutationVariables = Exact<{ [key: string]: never }>;
 
 export type LogoutMutation = { logout: Pick<Success, 'success'> };
 
@@ -7410,85 +8050,89 @@ export type GetShippingMethodQueryVariables = Exact<{
   id: Scalars['ID'];
 }>;
 
-
 export type GetShippingMethodQuery = { shippingMethod?: Maybe<ShippingMethodFragment> };
 
-export type GetEligibilityCheckersQueryVariables = Exact<{ [key: string]: never; }>;
+export type GetEligibilityCheckersQueryVariables = Exact<{ [key: string]: never }>;
 
+export type GetEligibilityCheckersQuery = {
+  shippingEligibilityCheckers: Array<
+    Pick<ConfigurableOperationDefinition, 'code' | 'description'> & {
+      args: Array<Pick<ConfigArgDefinition, 'name' | 'type' | 'description' | 'label' | 'ui'>>;
+    }
+  >;
+};
 
-export type GetEligibilityCheckersQuery = { shippingEligibilityCheckers: Array<(
-    Pick<ConfigurableOperationDefinition, 'code' | 'description'>
-    & { args: Array<Pick<ConfigArgDefinition, 'name' | 'type' | 'description' | 'label' | 'ui'>> }
-  )> };
+export type GetCalculatorsQueryVariables = Exact<{ [key: string]: never }>;
 
-export type GetCalculatorsQueryVariables = Exact<{ [key: string]: never; }>;
-
-
-export type GetCalculatorsQuery = { shippingCalculators: Array<(
-    Pick<ConfigurableOperationDefinition, 'code' | 'description'>
-    & { args: Array<Pick<ConfigArgDefinition, 'name' | 'type' | 'description' | 'label' | 'ui'>> }
-  )> };
+export type GetCalculatorsQuery = {
+  shippingCalculators: Array<
+    Pick<ConfigurableOperationDefinition, 'code' | 'description'> & {
+      args: Array<Pick<ConfigArgDefinition, 'name' | 'type' | 'description' | 'label' | 'ui'>>;
+    }
+  >;
+};
 
 export type TestShippingMethodQueryVariables = Exact<{
   input: TestShippingMethodInput;
 }>;
 
-
-export type TestShippingMethodQuery = { testShippingMethod: (
-    Pick<TestShippingMethodResult, 'eligible'>
-    & { quote?: Maybe<Pick<TestShippingMethodQuote, 'price' | 'priceWithTax' | 'metadata'>> }
-  ) };
+export type TestShippingMethodQuery = {
+  testShippingMethod: Pick<TestShippingMethodResult, 'eligible'> & {
+    quote?: Maybe<Pick<TestShippingMethodQuote, 'price' | 'priceWithTax' | 'metadata'>>;
+  };
+};
 
 export type TestEligibleMethodsQueryVariables = Exact<{
   input: TestEligibleShippingMethodsInput;
 }>;
 
+export type TestEligibleMethodsQuery = {
+  testEligibleShippingMethods: Array<
+    Pick<ShippingMethodQuote, 'id' | 'name' | 'description' | 'price' | 'priceWithTax' | 'metadata'>
+  >;
+};
 
-export type TestEligibleMethodsQuery = { testEligibleShippingMethods: Array<Pick<ShippingMethodQuote, 'id' | 'name' | 'description' | 'price' | 'priceWithTax' | 'metadata'>> };
-
-export type GetMeQueryVariables = Exact<{ [key: string]: never; }>;
-
+export type GetMeQueryVariables = Exact<{ [key: string]: never }>;
 
 export type GetMeQuery = { me?: Maybe<Pick<CurrentUser, 'identifier'>> };
 
-export type GetProductsTake3QueryVariables = Exact<{ [key: string]: never; }>;
-
+export type GetProductsTake3QueryVariables = Exact<{ [key: string]: never }>;
 
 export type GetProductsTake3Query = { products: { items: Array<Pick<Product, 'id'>> } };
 
-export type GetProduct1QueryVariables = Exact<{ [key: string]: never; }>;
-
+export type GetProduct1QueryVariables = Exact<{ [key: string]: never }>;
 
 export type GetProduct1Query = { product?: Maybe<Pick<Product, 'id'>> };
 
-export type GetProduct2VariantsQueryVariables = Exact<{ [key: string]: never; }>;
+export type GetProduct2VariantsQueryVariables = Exact<{ [key: string]: never }>;
 
+export type GetProduct2VariantsQuery = {
+  product?: Maybe<Pick<Product, 'id'> & { variants: Array<Pick<ProductVariant, 'id' | 'name'>> }>;
+};
 
-export type GetProduct2VariantsQuery = { product?: Maybe<(
-    Pick<Product, 'id'>
-    & { variants: Array<Pick<ProductVariant, 'id' | 'name'>> }
-  )> };
+export type GetProductCollectionQueryVariables = Exact<{ [key: string]: never }>;
 
-export type GetProductCollectionQueryVariables = Exact<{ [key: string]: never; }>;
-
-
-export type GetProductCollectionQuery = { product?: Maybe<{ collections: Array<Pick<Collection, 'id' | 'name'>> }> };
+export type GetProductCollectionQuery = {
+  product?: Maybe<{ collections: Array<Pick<Collection, 'id' | 'name'>> }>;
+};
 
 export type GetCollectionShopQueryVariables = Exact<{
   id?: Maybe<Scalars['ID']>;
   slug?: Maybe<Scalars['String']>;
 }>;
 
-
-export type GetCollectionShopQuery = { collection?: Maybe<(
-    Pick<Collection, 'id' | 'name' | 'slug' | 'description'>
-    & { parent?: Maybe<Pick<Collection, 'id' | 'name'>>, children?: Maybe<Array<Pick<Collection, 'id' | 'name'>>> }
-  )> };
+export type GetCollectionShopQuery = {
+  collection?: Maybe<
+    Pick<Collection, 'id' | 'name' | 'slug' | 'description'> & {
+      parent?: Maybe<Pick<Collection, 'id' | 'name'>>;
+      children?: Maybe<Array<Pick<Collection, 'id' | 'name'>>>;
+    }
+  >;
+};
 
 export type DisableProductMutationVariables = Exact<{
   id: Scalars['ID'];
 }>;
-
 
 export type DisableProductMutation = { updateProduct: Pick<Product, 'id'> };
 
@@ -7497,14 +8141,13 @@ export type GetCollectionVariantsQueryVariables = Exact<{
   slug?: Maybe<Scalars['String']>;
 }>;
 
+export type GetCollectionVariantsQuery = {
+  collection?: Maybe<
+    Pick<Collection, 'id'> & { productVariants: { items: Array<Pick<ProductVariant, 'id' | 'name'>> } }
+  >;
+};
 
-export type GetCollectionVariantsQuery = { collection?: Maybe<(
-    Pick<Collection, 'id'>
-    & { productVariants: { items: Array<Pick<ProductVariant, 'id' | 'name'>> } }
-  )> };
-
-export type GetCollectionListQueryVariables = Exact<{ [key: string]: never; }>;
-
+export type GetCollectionListQueryVariables = Exact<{ [key: string]: never }>;
 
 export type GetCollectionListQuery = { collections: { items: Array<Pick<Collection, 'id' | 'name'>> } };
 
@@ -7512,34 +8155,29 @@ export type GetProductFacetValuesQueryVariables = Exact<{
   id: Scalars['ID'];
 }>;
 
-
-export type GetProductFacetValuesQuery = { product?: Maybe<(
-    Pick<Product, 'id' | 'name'>
-    & { facetValues: Array<Pick<FacetValue, 'name'>> }
-  )> };
+export type GetProductFacetValuesQuery = {
+  product?: Maybe<Pick<Product, 'id' | 'name'> & { facetValues: Array<Pick<FacetValue, 'name'>> }>;
+};
 
 export type GetVariantFacetValuesQueryVariables = Exact<{
   id: Scalars['ID'];
 }>;
 
+export type GetVariantFacetValuesQuery = {
+  product?: Maybe<
+    Pick<Product, 'id' | 'name'> & {
+      variants: Array<Pick<ProductVariant, 'id'> & { facetValues: Array<Pick<FacetValue, 'name'>> }>;
+    }
+  >;
+};
 
-export type GetVariantFacetValuesQuery = { product?: Maybe<(
-    Pick<Product, 'id' | 'name'>
-    & { variants: Array<(
-      Pick<ProductVariant, 'id'>
-      & { facetValues: Array<Pick<FacetValue, 'name'>> }
-    )> }
-  )> };
-
-export type GetCustomerIdsQueryVariables = Exact<{ [key: string]: never; }>;
-
+export type GetCustomerIdsQueryVariables = Exact<{ [key: string]: never }>;
 
 export type GetCustomerIdsQuery = { customers: { items: Array<Pick<Customer, 'id'>> } };
 
 export type UpdateStockMutationVariables = Exact<{
   input: Array<UpdateProductVariantInput> | UpdateProductVariantInput;
 }>;
-
 
 export type UpdateStockMutation = { updateProductVariants: Array<Maybe<VariantWithStockFragment>> };
 
@@ -7548,13 +8186,15 @@ export type TransitionFulfillmentToStateMutationVariables = Exact<{
   state: Scalars['String'];
 }>;
 
-
-export type TransitionFulfillmentToStateMutation = { transitionFulfillmentToState: Pick<Fulfillment, 'id' | 'state' | 'nextStates' | 'createdAt'> | Pick<FulfillmentStateTransitionError, 'errorCode' | 'message' | 'transitionError'> };
+export type TransitionFulfillmentToStateMutation = {
+  transitionFulfillmentToState:
+    | Pick<Fulfillment, 'id' | 'state' | 'nextStates' | 'createdAt'>
+    | Pick<FulfillmentStateTransitionError, 'errorCode' | 'message' | 'transitionError'>;
+};
 
 export type UpdateOrderCustomFieldsMutationVariables = Exact<{
   input: UpdateOrderInput;
 }>;
-
 
 export type UpdateOrderCustomFieldsMutation = { setOrderCustomFields?: Maybe<Pick<Order, 'id'>> };
 
@@ -7562,16 +8202,13 @@ export type GetTagListQueryVariables = Exact<{
   options?: Maybe<TagListOptions>;
 }>;
 
-
-export type GetTagListQuery = { tags: (
-    Pick<TagList, 'totalItems'>
-    & { items: Array<Pick<Tag, 'id' | 'value'>> }
-  ) };
+export type GetTagListQuery = {
+  tags: Pick<TagList, 'totalItems'> & { items: Array<Pick<Tag, 'id' | 'value'>> };
+};
 
 export type GetTagQueryVariables = Exact<{
   id: Scalars['ID'];
 }>;
-
 
 export type GetTagQuery = { tag: Pick<Tag, 'id' | 'value'> };
 
@@ -7579,13 +8216,11 @@ export type CreateTagMutationVariables = Exact<{
   input: CreateTagInput;
 }>;
 
-
 export type CreateTagMutation = { createTag: Pick<Tag, 'id' | 'value'> };
 
 export type UpdateTagMutationVariables = Exact<{
   input: UpdateTagInput;
 }>;
-
 
 export type UpdateTagMutation = { updateTag: Pick<Tag, 'id' | 'value'> };
 
@@ -7593,18 +8228,17 @@ export type DeleteTagMutationVariables = Exact<{
   id: Scalars['ID'];
 }>;
 
-
 export type DeleteTagMutation = { deleteTag: Pick<DeletionResponse, 'message' | 'result'> };
 
-export type GetTaxCategoryListQueryVariables = Exact<{ [key: string]: never; }>;
+export type GetTaxCategoryListQueryVariables = Exact<{ [key: string]: never }>;
 
-
-export type GetTaxCategoryListQuery = { taxCategories: Array<Pick<TaxCategory, 'id' | 'name' | 'isDefault'>> };
+export type GetTaxCategoryListQuery = {
+  taxCategories: Array<Pick<TaxCategory, 'id' | 'name' | 'isDefault'>>;
+};
 
 export type GetTaxCategoryQueryVariables = Exact<{
   id: Scalars['ID'];
 }>;
-
 
 export type GetTaxCategoryQuery = { taxCategory?: Maybe<Pick<TaxCategory, 'id' | 'name' | 'isDefault'>> };
 
@@ -7612,13 +8246,11 @@ export type CreateTaxCategoryMutationVariables = Exact<{
   input: CreateTaxCategoryInput;
 }>;
 
-
 export type CreateTaxCategoryMutation = { createTaxCategory: Pick<TaxCategory, 'id' | 'name' | 'isDefault'> };
 
 export type UpdateTaxCategoryMutationVariables = Exact<{
   input: UpdateTaxCategoryInput;
 }>;
-
 
 export type UpdateTaxCategoryMutation = { updateTaxCategory: Pick<TaxCategory, 'id' | 'name' | 'isDefault'> };
 
@@ -7626,13 +8258,11 @@ export type DeleteTaxCategoryMutationVariables = Exact<{
   id: Scalars['ID'];
 }>;
 
-
 export type DeleteTaxCategoryMutation = { deleteTaxCategory: Pick<DeletionResponse, 'result' | 'message'> };
 
 export type GetTaxRateQueryVariables = Exact<{
   id: Scalars['ID'];
 }>;
-
 
 export type GetTaxRateQuery = { taxRate?: Maybe<TaxRateFragment> };
 
@@ -7640,13 +8270,11 @@ export type CreateTaxRateMutationVariables = Exact<{
   input: CreateTaxRateInput;
 }>;
 
-
 export type CreateTaxRateMutation = { createTaxRate: TaxRateFragment };
 
 export type DeleteTaxRateMutationVariables = Exact<{
   id: Scalars['ID'];
 }>;
-
 
 export type DeleteTaxRateMutation = { deleteTaxRate: Pick<DeletionResponse, 'result' | 'message'> };
 
@@ -7654,11 +8282,9 @@ export type DeleteZoneMutationVariables = Exact<{
   id: Scalars['ID'];
 }>;
 
-
 export type DeleteZoneMutation = { deleteZone: Pick<DeletionResponse, 'result' | 'message'> };
 
-export type GetZonesQueryVariables = Exact<{ [key: string]: never; }>;
-
+export type GetZonesQueryVariables = Exact<{ [key: string]: never }>;
 
 export type GetZonesQuery = { zones: Array<Pick<Zone, 'id' | 'name'>> };
 
@@ -7666,31 +8292,25 @@ export type GetZoneQueryVariables = Exact<{
   id: Scalars['ID'];
 }>;
 
-
 export type GetZoneQuery = { zone?: Maybe<ZoneFragment> };
 
-export type GetActiveChannelWithZoneMembersQueryVariables = Exact<{ [key: string]: never; }>;
+export type GetActiveChannelWithZoneMembersQueryVariables = Exact<{ [key: string]: never }>;
 
-
-export type GetActiveChannelWithZoneMembersQuery = { activeChannel: (
-    Pick<Channel, 'id'>
-    & { defaultShippingZone?: Maybe<(
-      Pick<Zone, 'id'>
-      & { members: Array<Pick<Country, 'name'>> }
-    )> }
-  ) };
+export type GetActiveChannelWithZoneMembersQuery = {
+  activeChannel: Pick<Channel, 'id'> & {
+    defaultShippingZone?: Maybe<Pick<Zone, 'id'> & { members: Array<Pick<Country, 'name'>> }>;
+  };
+};
 
 export type CreateZoneMutationVariables = Exact<{
   input: CreateZoneInput;
 }>;
-
 
 export type CreateZoneMutation = { createZone: ZoneFragment };
 
 export type UpdateZoneMutationVariables = Exact<{
   input: UpdateZoneInput;
 }>;
-
 
 export type UpdateZoneMutation = { updateZone: ZoneFragment };
 
@@ -7699,14 +8319,12 @@ export type AddMembersToZoneMutationVariables = Exact<{
   memberIds: Array<Scalars['ID']> | Scalars['ID'];
 }>;
 
-
 export type AddMembersToZoneMutation = { addMembersToZone: ZoneFragment };
 
 export type RemoveMembersFromZoneMutationVariables = Exact<{
   zoneId: Scalars['ID'];
   memberIds: Array<Scalars['ID']> | Scalars['ID'];
 }>;
-
 
 export type RemoveMembersFromZoneMutation = { removeMembersFromZone: ZoneFragment };
 
@@ -7715,495 +8333,756 @@ type DiscriminateUnion<T, U> = T extends U ? T : never;
 export namespace GetAdministrators {
   export type Variables = GetAdministratorsQueryVariables;
   export type Query = GetAdministratorsQuery;
-  export type Administrators = (NonNullable<GetAdministratorsQuery['administrators']>);
-  export type Items = NonNullable<(NonNullable<(NonNullable<GetAdministratorsQuery['administrators']>)['items']>)[number]>;
+  export type Administrators = NonNullable<GetAdministratorsQuery['administrators']>;
+  export type Items = NonNullable<
+    NonNullable<NonNullable<GetAdministratorsQuery['administrators']>['items']>[number]
+  >;
 }
 
 export namespace GetAdministrator {
   export type Variables = GetAdministratorQueryVariables;
   export type Query = GetAdministratorQuery;
-  export type Administrator = (NonNullable<GetAdministratorQuery['administrator']>);
+  export type Administrator = NonNullable<GetAdministratorQuery['administrator']>;
 }
 
 export namespace ActiveAdministrator {
   export type Variables = ActiveAdministratorQueryVariables;
   export type Query = ActiveAdministratorQuery;
-  export type ActiveAdministrator = (NonNullable<ActiveAdministratorQuery['activeAdministrator']>);
+  export type ActiveAdministrator = NonNullable<ActiveAdministratorQuery['activeAdministrator']>;
 }
 
 export namespace UpdateActiveAdministrator {
   export type Variables = UpdateActiveAdministratorMutationVariables;
   export type Mutation = UpdateActiveAdministratorMutation;
-  export type UpdateActiveAdministrator = (NonNullable<UpdateActiveAdministratorMutation['updateActiveAdministrator']>);
+  export type UpdateActiveAdministrator = NonNullable<
+    UpdateActiveAdministratorMutation['updateActiveAdministrator']
+  >;
 }
 
 export namespace DeleteAdministrator {
   export type Variables = DeleteAdministratorMutationVariables;
   export type Mutation = DeleteAdministratorMutation;
-  export type DeleteAdministrator = (NonNullable<DeleteAdministratorMutation['deleteAdministrator']>);
+  export type DeleteAdministrator = NonNullable<DeleteAdministratorMutation['deleteAdministrator']>;
 }
 
 export namespace Q1 {
   export type Variables = Q1QueryVariables;
   export type Query = Q1Query;
-  export type Product = (NonNullable<Q1Query['product']>);
+  export type Product = NonNullable<Q1Query['product']>;
 }
 
 export namespace Q2 {
   export type Variables = Q2QueryVariables;
   export type Query = Q2Query;
-  export type Product = (NonNullable<Q2Query['product']>);
+  export type Product = NonNullable<Q2Query['product']>;
 }
 
 export namespace AssignAssetsToChannel {
   export type Variables = AssignAssetsToChannelMutationVariables;
   export type Mutation = AssignAssetsToChannelMutation;
-  export type AssignAssetsToChannel = NonNullable<(NonNullable<AssignAssetsToChannelMutation['assignAssetsToChannel']>)[number]>;
+  export type AssignAssetsToChannel = NonNullable<
+    NonNullable<AssignAssetsToChannelMutation['assignAssetsToChannel']>[number]
+  >;
 }
 
 export namespace CanCreateCustomer {
   export type Variables = CanCreateCustomerMutationVariables;
   export type Mutation = CanCreateCustomerMutation;
-  export type CreateCustomer = (NonNullable<CanCreateCustomerMutation['createCustomer']>);
-  export type CustomerInlineFragment = (DiscriminateUnion<(NonNullable<CanCreateCustomerMutation['createCustomer']>), { __typename?: 'Customer' }>);
+  export type CreateCustomer = NonNullable<CanCreateCustomerMutation['createCustomer']>;
+  export type CustomerInlineFragment = DiscriminateUnion<
+    NonNullable<CanCreateCustomerMutation['createCustomer']>,
+    { __typename?: 'Customer' }
+  >;
 }
 
 export namespace GetCustomerCount {
   export type Variables = GetCustomerCountQueryVariables;
   export type Query = GetCustomerCountQuery;
-  export type Customers = (NonNullable<GetCustomerCountQuery['customers']>);
+  export type Customers = NonNullable<GetCustomerCountQuery['customers']>;
 }
 
 export namespace DeepFieldResolutionTestQuery {
   export type Variables = DeepFieldResolutionTestQueryQueryVariables;
   export type Query = DeepFieldResolutionTestQueryQuery;
-  export type Product = (NonNullable<DeepFieldResolutionTestQueryQuery['product']>);
-  export type Variants = NonNullable<(NonNullable<(NonNullable<DeepFieldResolutionTestQueryQuery['product']>)['variants']>)[number]>;
-  export type TaxRateApplied = (NonNullable<NonNullable<(NonNullable<(NonNullable<DeepFieldResolutionTestQueryQuery['product']>)['variants']>)[number]>['taxRateApplied']>);
-  export type CustomerGroup = (NonNullable<(NonNullable<NonNullable<(NonNullable<(NonNullable<DeepFieldResolutionTestQueryQuery['product']>)['variants']>)[number]>['taxRateApplied']>)['customerGroup']>);
-  export type Customers = (NonNullable<(NonNullable<(NonNullable<NonNullable<(NonNullable<(NonNullable<DeepFieldResolutionTestQueryQuery['product']>)['variants']>)[number]>['taxRateApplied']>)['customerGroup']>)['customers']>);
-  export type Items = NonNullable<(NonNullable<(NonNullable<(NonNullable<(NonNullable<NonNullable<(NonNullable<(NonNullable<DeepFieldResolutionTestQueryQuery['product']>)['variants']>)[number]>['taxRateApplied']>)['customerGroup']>)['customers']>)['items']>)[number]>;
+  export type Product = NonNullable<DeepFieldResolutionTestQueryQuery['product']>;
+  export type Variants = NonNullable<
+    NonNullable<NonNullable<DeepFieldResolutionTestQueryQuery['product']>['variants']>[number]
+  >;
+  export type TaxRateApplied = NonNullable<
+    NonNullable<
+      NonNullable<NonNullable<DeepFieldResolutionTestQueryQuery['product']>['variants']>[number]
+    >['taxRateApplied']
+  >;
+  export type CustomerGroup = NonNullable<
+    NonNullable<
+      NonNullable<
+        NonNullable<NonNullable<DeepFieldResolutionTestQueryQuery['product']>['variants']>[number]
+      >['taxRateApplied']
+    >['customerGroup']
+  >;
+  export type Customers = NonNullable<
+    NonNullable<
+      NonNullable<
+        NonNullable<
+          NonNullable<NonNullable<DeepFieldResolutionTestQueryQuery['product']>['variants']>[number]
+        >['taxRateApplied']
+      >['customerGroup']
+    >['customers']
+  >;
+  export type Items = NonNullable<
+    NonNullable<
+      NonNullable<
+        NonNullable<
+          NonNullable<
+            NonNullable<
+              NonNullable<NonNullable<DeepFieldResolutionTestQueryQuery['product']>['variants']>[number]
+            >['taxRateApplied']
+          >['customerGroup']
+        >['customers']
+      >['items']
+    >[number]
+  >;
 }
 
 export namespace Authenticate {
   export type Variables = AuthenticateMutationVariables;
   export type Mutation = AuthenticateMutation;
-  export type Authenticate = (NonNullable<AuthenticateMutation['authenticate']>);
-  export type InvalidCredentialsErrorInlineFragment = (DiscriminateUnion<(NonNullable<AuthenticateMutation['authenticate']>), { __typename?: 'InvalidCredentialsError' }>);
+  export type Authenticate = NonNullable<AuthenticateMutation['authenticate']>;
+  export type InvalidCredentialsErrorInlineFragment = DiscriminateUnion<
+    NonNullable<AuthenticateMutation['authenticate']>,
+    { __typename?: 'InvalidCredentialsError' }
+  >;
 }
 
 export namespace GetCustomers {
   export type Variables = GetCustomersQueryVariables;
   export type Query = GetCustomersQuery;
-  export type Customers = (NonNullable<GetCustomersQuery['customers']>);
-  export type Items = NonNullable<(NonNullable<(NonNullable<GetCustomersQuery['customers']>)['items']>)[number]>;
+  export type Customers = NonNullable<GetCustomersQuery['customers']>;
+  export type Items = NonNullable<NonNullable<NonNullable<GetCustomersQuery['customers']>['items']>[number]>;
 }
 
 export namespace GetCustomerUserAuth {
   export type Variables = GetCustomerUserAuthQueryVariables;
   export type Query = GetCustomerUserAuthQuery;
-  export type Customer = (NonNullable<GetCustomerUserAuthQuery['customer']>);
-  export type User = (NonNullable<(NonNullable<GetCustomerUserAuthQuery['customer']>)['user']>);
-  export type AuthenticationMethods = NonNullable<(NonNullable<(NonNullable<(NonNullable<GetCustomerUserAuthQuery['customer']>)['user']>)['authenticationMethods']>)[number]>;
+  export type Customer = NonNullable<GetCustomerUserAuthQuery['customer']>;
+  export type User = NonNullable<NonNullable<GetCustomerUserAuthQuery['customer']>['user']>;
+  export type AuthenticationMethods = NonNullable<
+    NonNullable<
+      NonNullable<NonNullable<GetCustomerUserAuthQuery['customer']>['user']>['authenticationMethods']
+    >[number]
+  >;
 }
 
 export namespace DeleteChannel {
   export type Variables = DeleteChannelMutationVariables;
   export type Mutation = DeleteChannelMutation;
-  export type DeleteChannel = (NonNullable<DeleteChannelMutation['deleteChannel']>);
+  export type DeleteChannel = NonNullable<DeleteChannelMutation['deleteChannel']>;
 }
 
 export namespace UpdateGlobalLanguages {
   export type Variables = UpdateGlobalLanguagesMutationVariables;
   export type Mutation = UpdateGlobalLanguagesMutation;
-  export type UpdateGlobalSettings = (NonNullable<UpdateGlobalLanguagesMutation['updateGlobalSettings']>);
-  export type GlobalSettingsInlineFragment = (DiscriminateUnion<(NonNullable<UpdateGlobalLanguagesMutation['updateGlobalSettings']>), { __typename?: 'GlobalSettings' }>);
+  export type UpdateGlobalSettings = NonNullable<UpdateGlobalLanguagesMutation['updateGlobalSettings']>;
+  export type GlobalSettingsInlineFragment = DiscriminateUnion<
+    NonNullable<UpdateGlobalLanguagesMutation['updateGlobalSettings']>,
+    { __typename?: 'GlobalSettings' }
+  >;
 }
 
 export namespace GetCollectionsWithAssets {
   export type Variables = GetCollectionsWithAssetsQueryVariables;
   export type Query = GetCollectionsWithAssetsQuery;
-  export type Collections = (NonNullable<GetCollectionsWithAssetsQuery['collections']>);
-  export type Items = NonNullable<(NonNullable<(NonNullable<GetCollectionsWithAssetsQuery['collections']>)['items']>)[number]>;
-  export type Assets = NonNullable<(NonNullable<NonNullable<(NonNullable<(NonNullable<GetCollectionsWithAssetsQuery['collections']>)['items']>)[number]>['assets']>)[number]>;
+  export type Collections = NonNullable<GetCollectionsWithAssetsQuery['collections']>;
+  export type Items = NonNullable<
+    NonNullable<NonNullable<GetCollectionsWithAssetsQuery['collections']>['items']>[number]
+  >;
+  export type Assets = NonNullable<
+    NonNullable<
+      NonNullable<
+        NonNullable<NonNullable<GetCollectionsWithAssetsQuery['collections']>['items']>[number]
+      >['assets']
+    >[number]
+  >;
 }
 
 export namespace GetProductsWithVariantIds {
   export type Variables = GetProductsWithVariantIdsQueryVariables;
   export type Query = GetProductsWithVariantIdsQuery;
-  export type Products = (NonNullable<GetProductsWithVariantIdsQuery['products']>);
-  export type Items = NonNullable<(NonNullable<(NonNullable<GetProductsWithVariantIdsQuery['products']>)['items']>)[number]>;
-  export type Variants = NonNullable<(NonNullable<NonNullable<(NonNullable<(NonNullable<GetProductsWithVariantIdsQuery['products']>)['items']>)[number]>['variants']>)[number]>;
+  export type Products = NonNullable<GetProductsWithVariantIdsQuery['products']>;
+  export type Items = NonNullable<
+    NonNullable<NonNullable<GetProductsWithVariantIdsQuery['products']>['items']>[number]
+  >;
+  export type Variants = NonNullable<
+    NonNullable<
+      NonNullable<
+        NonNullable<NonNullable<GetProductsWithVariantIdsQuery['products']>['items']>[number]
+      >['variants']
+    >[number]
+  >;
 }
 
 export namespace GetCollection {
   export type Variables = GetCollectionQueryVariables;
   export type Query = GetCollectionQuery;
-  export type Collection = (NonNullable<GetCollectionQuery['collection']>);
-  export type ProductVariants = (NonNullable<(NonNullable<GetCollectionQuery['collection']>)['productVariants']>);
-  export type Items = NonNullable<(NonNullable<(NonNullable<(NonNullable<GetCollectionQuery['collection']>)['productVariants']>)['items']>)[number]>;
+  export type Collection = NonNullable<GetCollectionQuery['collection']>;
+  export type ProductVariants = NonNullable<NonNullable<GetCollectionQuery['collection']>['productVariants']>;
+  export type Items = NonNullable<
+    NonNullable<
+      NonNullable<NonNullable<GetCollectionQuery['collection']>['productVariants']>['items']
+    >[number]
+  >;
 }
 
 export namespace GetCollectionListAdmin {
   export type Variables = GetCollectionListAdminQueryVariables;
   export type Query = GetCollectionListAdminQuery;
-  export type Collections = (NonNullable<GetCollectionListAdminQuery['collections']>);
-  export type Items = NonNullable<(NonNullable<(NonNullable<GetCollectionListAdminQuery['collections']>)['items']>)[number]>;
+  export type Collections = NonNullable<GetCollectionListAdminQuery['collections']>;
+  export type Items = NonNullable<
+    NonNullable<NonNullable<GetCollectionListAdminQuery['collections']>['items']>[number]
+  >;
 }
 
 export namespace MoveCollection {
   export type Variables = MoveCollectionMutationVariables;
   export type Mutation = MoveCollectionMutation;
-  export type MoveCollection = (NonNullable<MoveCollectionMutation['moveCollection']>);
+  export type MoveCollection = NonNullable<MoveCollectionMutation['moveCollection']>;
 }
 
 export namespace GetFacetValues {
   export type Variables = GetFacetValuesQueryVariables;
   export type Query = GetFacetValuesQuery;
-  export type Facets = (NonNullable<GetFacetValuesQuery['facets']>);
-  export type Items = NonNullable<(NonNullable<(NonNullable<GetFacetValuesQuery['facets']>)['items']>)[number]>;
-  export type Values = NonNullable<(NonNullable<NonNullable<(NonNullable<(NonNullable<GetFacetValuesQuery['facets']>)['items']>)[number]>['values']>)[number]>;
+  export type Facets = NonNullable<GetFacetValuesQuery['facets']>;
+  export type Items = NonNullable<NonNullable<NonNullable<GetFacetValuesQuery['facets']>['items']>[number]>;
+  export type Values = NonNullable<
+    NonNullable<
+      NonNullable<NonNullable<NonNullable<GetFacetValuesQuery['facets']>['items']>[number]>['values']
+    >[number]
+  >;
 }
 
 export namespace GetCollectionProducts {
   export type Variables = GetCollectionProductsQueryVariables;
   export type Query = GetCollectionProductsQuery;
-  export type Collection = (NonNullable<GetCollectionProductsQuery['collection']>);
-  export type ProductVariants = (NonNullable<(NonNullable<GetCollectionProductsQuery['collection']>)['productVariants']>);
-  export type Items = NonNullable<(NonNullable<(NonNullable<(NonNullable<GetCollectionProductsQuery['collection']>)['productVariants']>)['items']>)[number]>;
-  export type FacetValues = NonNullable<(NonNullable<NonNullable<(NonNullable<(NonNullable<(NonNullable<GetCollectionProductsQuery['collection']>)['productVariants']>)['items']>)[number]>['facetValues']>)[number]>;
+  export type Collection = NonNullable<GetCollectionProductsQuery['collection']>;
+  export type ProductVariants = NonNullable<
+    NonNullable<GetCollectionProductsQuery['collection']>['productVariants']
+  >;
+  export type Items = NonNullable<
+    NonNullable<
+      NonNullable<NonNullable<GetCollectionProductsQuery['collection']>['productVariants']>['items']
+    >[number]
+  >;
+  export type FacetValues = NonNullable<
+    NonNullable<
+      NonNullable<
+        NonNullable<
+          NonNullable<NonNullable<GetCollectionProductsQuery['collection']>['productVariants']>['items']
+        >[number]
+      >['facetValues']
+    >[number]
+  >;
 }
 
 export namespace CreateCollectionSelectVariants {
   export type Variables = CreateCollectionSelectVariantsMutationVariables;
   export type Mutation = CreateCollectionSelectVariantsMutation;
-  export type CreateCollection = (NonNullable<CreateCollectionSelectVariantsMutation['createCollection']>);
-  export type ProductVariants = (NonNullable<(NonNullable<CreateCollectionSelectVariantsMutation['createCollection']>)['productVariants']>);
-  export type Items = NonNullable<(NonNullable<(NonNullable<(NonNullable<CreateCollectionSelectVariantsMutation['createCollection']>)['productVariants']>)['items']>)[number]>;
+  export type CreateCollection = NonNullable<CreateCollectionSelectVariantsMutation['createCollection']>;
+  export type ProductVariants = NonNullable<
+    NonNullable<CreateCollectionSelectVariantsMutation['createCollection']>['productVariants']
+  >;
+  export type Items = NonNullable<
+    NonNullable<
+      NonNullable<
+        NonNullable<CreateCollectionSelectVariantsMutation['createCollection']>['productVariants']
+      >['items']
+    >[number]
+  >;
 }
 
 export namespace GetCollectionBreadcrumbs {
   export type Variables = GetCollectionBreadcrumbsQueryVariables;
   export type Query = GetCollectionBreadcrumbsQuery;
-  export type Collection = (NonNullable<GetCollectionBreadcrumbsQuery['collection']>);
-  export type Breadcrumbs = NonNullable<(NonNullable<(NonNullable<GetCollectionBreadcrumbsQuery['collection']>)['breadcrumbs']>)[number]>;
+  export type Collection = NonNullable<GetCollectionBreadcrumbsQuery['collection']>;
+  export type Breadcrumbs = NonNullable<
+    NonNullable<NonNullable<GetCollectionBreadcrumbsQuery['collection']>['breadcrumbs']>[number]
+  >;
 }
 
 export namespace GetCollectionsForProducts {
   export type Variables = GetCollectionsForProductsQueryVariables;
   export type Query = GetCollectionsForProductsQuery;
-  export type Products = (NonNullable<GetCollectionsForProductsQuery['products']>);
-  export type Items = NonNullable<(NonNullable<(NonNullable<GetCollectionsForProductsQuery['products']>)['items']>)[number]>;
-  export type Collections = NonNullable<(NonNullable<NonNullable<(NonNullable<(NonNullable<GetCollectionsForProductsQuery['products']>)['items']>)[number]>['collections']>)[number]>;
+  export type Products = NonNullable<GetCollectionsForProductsQuery['products']>;
+  export type Items = NonNullable<
+    NonNullable<NonNullable<GetCollectionsForProductsQuery['products']>['items']>[number]
+  >;
+  export type Collections = NonNullable<
+    NonNullable<
+      NonNullable<
+        NonNullable<NonNullable<GetCollectionsForProductsQuery['products']>['items']>[number]
+      >['collections']
+    >[number]
+  >;
 }
 
 export namespace DeleteCollection {
   export type Variables = DeleteCollectionMutationVariables;
   export type Mutation = DeleteCollectionMutation;
-  export type DeleteCollection = (NonNullable<DeleteCollectionMutation['deleteCollection']>);
+  export type DeleteCollection = NonNullable<DeleteCollectionMutation['deleteCollection']>;
 }
 
 export namespace GetProductCollections {
   export type Variables = GetProductCollectionsQueryVariables;
   export type Query = GetProductCollectionsQuery;
-  export type Product = (NonNullable<GetProductCollectionsQuery['product']>);
-  export type Collections = NonNullable<(NonNullable<(NonNullable<GetProductCollectionsQuery['product']>)['collections']>)[number]>;
+  export type Product = NonNullable<GetProductCollectionsQuery['product']>;
+  export type Collections = NonNullable<
+    NonNullable<NonNullable<GetProductCollectionsQuery['product']>['collections']>[number]
+  >;
 }
 
 export namespace GetProductCollectionsWithParent {
   export type Variables = GetProductCollectionsWithParentQueryVariables;
   export type Query = GetProductCollectionsWithParentQuery;
-  export type Product = (NonNullable<GetProductCollectionsWithParentQuery['product']>);
-  export type Collections = NonNullable<(NonNullable<(NonNullable<GetProductCollectionsWithParentQuery['product']>)['collections']>)[number]>;
-  export type Parent = (NonNullable<NonNullable<(NonNullable<(NonNullable<GetProductCollectionsWithParentQuery['product']>)['collections']>)[number]>['parent']>);
+  export type Product = NonNullable<GetProductCollectionsWithParentQuery['product']>;
+  export type Collections = NonNullable<
+    NonNullable<NonNullable<GetProductCollectionsWithParentQuery['product']>['collections']>[number]
+  >;
+  export type Parent = NonNullable<
+    NonNullable<
+      NonNullable<NonNullable<GetProductCollectionsWithParentQuery['product']>['collections']>[number]
+    >['parent']
+  >;
 }
 
 export namespace GetCollectionNestedParents {
   export type Variables = GetCollectionNestedParentsQueryVariables;
   export type Query = GetCollectionNestedParentsQuery;
-  export type Collections = (NonNullable<GetCollectionNestedParentsQuery['collections']>);
-  export type Items = NonNullable<(NonNullable<(NonNullable<GetCollectionNestedParentsQuery['collections']>)['items']>)[number]>;
-  export type Parent = (NonNullable<NonNullable<(NonNullable<(NonNullable<GetCollectionNestedParentsQuery['collections']>)['items']>)[number]>['parent']>);
-  export type _Parent = (NonNullable<(NonNullable<NonNullable<(NonNullable<(NonNullable<GetCollectionNestedParentsQuery['collections']>)['items']>)[number]>['parent']>)['parent']>);
-  export type __Parent = (NonNullable<(NonNullable<(NonNullable<NonNullable<(NonNullable<(NonNullable<GetCollectionNestedParentsQuery['collections']>)['items']>)[number]>['parent']>)['parent']>)['parent']>);
+  export type Collections = NonNullable<GetCollectionNestedParentsQuery['collections']>;
+  export type Items = NonNullable<
+    NonNullable<NonNullable<GetCollectionNestedParentsQuery['collections']>['items']>[number]
+  >;
+  export type Parent = NonNullable<
+    NonNullable<
+      NonNullable<NonNullable<GetCollectionNestedParentsQuery['collections']>['items']>[number]
+    >['parent']
+  >;
+  export type _Parent = NonNullable<
+    NonNullable<
+      NonNullable<
+        NonNullable<NonNullable<GetCollectionNestedParentsQuery['collections']>['items']>[number]
+      >['parent']
+    >['parent']
+  >;
+  export type __Parent = NonNullable<
+    NonNullable<
+      NonNullable<
+        NonNullable<
+          NonNullable<NonNullable<GetCollectionNestedParentsQuery['collections']>['items']>[number]
+        >['parent']
+      >['parent']
+    >['parent']
+  >;
 }
 
 export namespace PreviewCollectionVariants {
   export type Variables = PreviewCollectionVariantsQueryVariables;
   export type Query = PreviewCollectionVariantsQuery;
-  export type PreviewCollectionVariants = (NonNullable<PreviewCollectionVariantsQuery['previewCollectionVariants']>);
-  export type Items = NonNullable<(NonNullable<(NonNullable<PreviewCollectionVariantsQuery['previewCollectionVariants']>)['items']>)[number]>;
+  export type PreviewCollectionVariants = NonNullable<
+    PreviewCollectionVariantsQuery['previewCollectionVariants']
+  >;
+  export type Items = NonNullable<
+    NonNullable<NonNullable<PreviewCollectionVariantsQuery['previewCollectionVariants']>['items']>[number]
+  >;
 }
 
 export namespace AssignCollectionsToChannel {
   export type Variables = AssignCollectionsToChannelMutationVariables;
   export type Mutation = AssignCollectionsToChannelMutation;
-  export type AssignCollectionsToChannel = NonNullable<(NonNullable<AssignCollectionsToChannelMutation['assignCollectionsToChannel']>)[number]>;
+  export type AssignCollectionsToChannel = NonNullable<
+    NonNullable<AssignCollectionsToChannelMutation['assignCollectionsToChannel']>[number]
+  >;
 }
 
 export namespace RemoveCollectionsFromChannel {
   export type Variables = RemoveCollectionsFromChannelMutationVariables;
   export type Mutation = RemoveCollectionsFromChannelMutation;
-  export type RemoveCollectionsFromChannel = NonNullable<(NonNullable<RemoveCollectionsFromChannelMutation['removeCollectionsFromChannel']>)[number]>;
+  export type RemoveCollectionsFromChannel = NonNullable<
+    NonNullable<RemoveCollectionsFromChannelMutation['removeCollectionsFromChannel']>[number]
+  >;
 }
 
 export namespace DeleteCollectionsBulk {
   export type Variables = DeleteCollectionsBulkMutationVariables;
   export type Mutation = DeleteCollectionsBulkMutation;
-  export type DeleteCollections = NonNullable<(NonNullable<DeleteCollectionsBulkMutation['deleteCollections']>)[number]>;
+  export type DeleteCollections = NonNullable<
+    NonNullable<DeleteCollectionsBulkMutation['deleteCollections']>[number]
+  >;
 }
 
 export namespace GetCheckers {
   export type Variables = GetCheckersQueryVariables;
   export type Query = GetCheckersQuery;
-  export type ShippingEligibilityCheckers = NonNullable<(NonNullable<GetCheckersQuery['shippingEligibilityCheckers']>)[number]>;
-  export type Args = NonNullable<(NonNullable<NonNullable<(NonNullable<GetCheckersQuery['shippingEligibilityCheckers']>)[number]>['args']>)[number]>;
+  export type ShippingEligibilityCheckers = NonNullable<
+    NonNullable<GetCheckersQuery['shippingEligibilityCheckers']>[number]
+  >;
+  export type Args = NonNullable<
+    NonNullable<
+      NonNullable<NonNullable<GetCheckersQuery['shippingEligibilityCheckers']>[number]>['args']
+    >[number]
+  >;
 }
 
 export namespace DeleteCountry {
   export type Variables = DeleteCountryMutationVariables;
   export type Mutation = DeleteCountryMutation;
-  export type DeleteCountry = (NonNullable<DeleteCountryMutation['deleteCountry']>);
+  export type DeleteCountry = NonNullable<DeleteCountryMutation['deleteCountry']>;
 }
 
 export namespace GetCountry {
   export type Variables = GetCountryQueryVariables;
   export type Query = GetCountryQuery;
-  export type Country = (NonNullable<GetCountryQuery['country']>);
+  export type Country = NonNullable<GetCountryQuery['country']>;
 }
 
 export namespace CreateCountry {
   export type Variables = CreateCountryMutationVariables;
   export type Mutation = CreateCountryMutation;
-  export type CreateCountry = (NonNullable<CreateCountryMutation['createCountry']>);
+  export type CreateCountry = NonNullable<CreateCountryMutation['createCountry']>;
 }
 
 export namespace DeleteCustomerAddress {
   export type Variables = DeleteCustomerAddressMutationVariables;
   export type Mutation = DeleteCustomerAddressMutation;
-  export type DeleteCustomerAddress = (NonNullable<DeleteCustomerAddressMutation['deleteCustomerAddress']>);
+  export type DeleteCustomerAddress = NonNullable<DeleteCustomerAddressMutation['deleteCustomerAddress']>;
 }
 
 export namespace GetCustomerWithUser {
   export type Variables = GetCustomerWithUserQueryVariables;
   export type Query = GetCustomerWithUserQuery;
-  export type Customer = (NonNullable<GetCustomerWithUserQuery['customer']>);
-  export type User = (NonNullable<(NonNullable<GetCustomerWithUserQuery['customer']>)['user']>);
+  export type Customer = NonNullable<GetCustomerWithUserQuery['customer']>;
+  export type User = NonNullable<NonNullable<GetCustomerWithUserQuery['customer']>['user']>;
 }
 
 export namespace GetCustomerOrders {
   export type Variables = GetCustomerOrdersQueryVariables;
   export type Query = GetCustomerOrdersQuery;
-  export type Customer = (NonNullable<GetCustomerOrdersQuery['customer']>);
-  export type Orders = (NonNullable<(NonNullable<GetCustomerOrdersQuery['customer']>)['orders']>);
-  export type Items = NonNullable<(NonNullable<(NonNullable<(NonNullable<GetCustomerOrdersQuery['customer']>)['orders']>)['items']>)[number]>;
+  export type Customer = NonNullable<GetCustomerOrdersQuery['customer']>;
+  export type Orders = NonNullable<NonNullable<GetCustomerOrdersQuery['customer']>['orders']>;
+  export type Items = NonNullable<
+    NonNullable<NonNullable<NonNullable<GetCustomerOrdersQuery['customer']>['orders']>['items']>[number]
+  >;
 }
 
 export namespace AddNoteToCustomer {
   export type Variables = AddNoteToCustomerMutationVariables;
   export type Mutation = AddNoteToCustomerMutation;
-  export type AddNoteToCustomer = (NonNullable<AddNoteToCustomerMutation['addNoteToCustomer']>);
+  export type AddNoteToCustomer = NonNullable<AddNoteToCustomerMutation['addNoteToCustomer']>;
 }
 
 export namespace Reindex {
   export type Variables = ReindexMutationVariables;
   export type Mutation = ReindexMutation;
-  export type Reindex = (NonNullable<ReindexMutation['reindex']>);
+  export type Reindex = NonNullable<ReindexMutation['reindex']>;
 }
 
 export namespace SearchProductsAdmin {
   export type Variables = SearchProductsAdminQueryVariables;
   export type Query = SearchProductsAdminQuery;
-  export type Search = (NonNullable<SearchProductsAdminQuery['search']>);
-  export type Items = NonNullable<(NonNullable<(NonNullable<SearchProductsAdminQuery['search']>)['items']>)[number]>;
+  export type Search = NonNullable<SearchProductsAdminQuery['search']>;
+  export type Items = NonNullable<
+    NonNullable<NonNullable<SearchProductsAdminQuery['search']>['items']>[number]
+  >;
 }
 
 export namespace SearchFacetValues {
   export type Variables = SearchFacetValuesQueryVariables;
   export type Query = SearchFacetValuesQuery;
-  export type Search = (NonNullable<SearchFacetValuesQuery['search']>);
-  export type FacetValues = NonNullable<(NonNullable<(NonNullable<SearchFacetValuesQuery['search']>)['facetValues']>)[number]>;
-  export type FacetValue = (NonNullable<NonNullable<(NonNullable<(NonNullable<SearchFacetValuesQuery['search']>)['facetValues']>)[number]>['facetValue']>);
+  export type Search = NonNullable<SearchFacetValuesQuery['search']>;
+  export type FacetValues = NonNullable<
+    NonNullable<NonNullable<SearchFacetValuesQuery['search']>['facetValues']>[number]
+  >;
+  export type FacetValue = NonNullable<
+    NonNullable<
+      NonNullable<NonNullable<SearchFacetValuesQuery['search']>['facetValues']>[number]
+    >['facetValue']
+  >;
 }
 
 export namespace SearchCollections {
   export type Variables = SearchCollectionsQueryVariables;
   export type Query = SearchCollectionsQuery;
-  export type Search = (NonNullable<SearchCollectionsQuery['search']>);
-  export type Collections = NonNullable<(NonNullable<(NonNullable<SearchCollectionsQuery['search']>)['collections']>)[number]>;
-  export type Collection = (NonNullable<NonNullable<(NonNullable<(NonNullable<SearchCollectionsQuery['search']>)['collections']>)[number]>['collection']>);
+  export type Search = NonNullable<SearchCollectionsQuery['search']>;
+  export type Collections = NonNullable<
+    NonNullable<NonNullable<SearchCollectionsQuery['search']>['collections']>[number]
+  >;
+  export type Collection = NonNullable<
+    NonNullable<
+      NonNullable<NonNullable<SearchCollectionsQuery['search']>['collections']>[number]
+    >['collection']
+  >;
 }
 
 export namespace SearchGetAssets {
   export type Variables = SearchGetAssetsQueryVariables;
   export type Query = SearchGetAssetsQuery;
-  export type Search = (NonNullable<SearchGetAssetsQuery['search']>);
-  export type Items = NonNullable<(NonNullable<(NonNullable<SearchGetAssetsQuery['search']>)['items']>)[number]>;
-  export type ProductAsset = (NonNullable<NonNullable<(NonNullable<(NonNullable<SearchGetAssetsQuery['search']>)['items']>)[number]>['productAsset']>);
-  export type FocalPoint = (NonNullable<(NonNullable<NonNullable<(NonNullable<(NonNullable<SearchGetAssetsQuery['search']>)['items']>)[number]>['productAsset']>)['focalPoint']>);
-  export type ProductVariantAsset = (NonNullable<NonNullable<(NonNullable<(NonNullable<SearchGetAssetsQuery['search']>)['items']>)[number]>['productVariantAsset']>);
-  export type _FocalPoint = (NonNullable<(NonNullable<NonNullable<(NonNullable<(NonNullable<SearchGetAssetsQuery['search']>)['items']>)[number]>['productVariantAsset']>)['focalPoint']>);
+  export type Search = NonNullable<SearchGetAssetsQuery['search']>;
+  export type Items = NonNullable<NonNullable<NonNullable<SearchGetAssetsQuery['search']>['items']>[number]>;
+  export type ProductAsset = NonNullable<
+    NonNullable<NonNullable<NonNullable<SearchGetAssetsQuery['search']>['items']>[number]>['productAsset']
+  >;
+  export type FocalPoint = NonNullable<
+    NonNullable<
+      NonNullable<NonNullable<NonNullable<SearchGetAssetsQuery['search']>['items']>[number]>['productAsset']
+    >['focalPoint']
+  >;
+  export type ProductVariantAsset = NonNullable<
+    NonNullable<
+      NonNullable<NonNullable<SearchGetAssetsQuery['search']>['items']>[number]
+    >['productVariantAsset']
+  >;
+  export type _FocalPoint = NonNullable<
+    NonNullable<
+      NonNullable<
+        NonNullable<NonNullable<SearchGetAssetsQuery['search']>['items']>[number]
+      >['productVariantAsset']
+    >['focalPoint']
+  >;
 }
 
 export namespace SearchGetPrices {
   export type Variables = SearchGetPricesQueryVariables;
   export type Query = SearchGetPricesQuery;
-  export type Search = (NonNullable<SearchGetPricesQuery['search']>);
-  export type Items = NonNullable<(NonNullable<(NonNullable<SearchGetPricesQuery['search']>)['items']>)[number]>;
-  export type Price = (NonNullable<NonNullable<(NonNullable<(NonNullable<SearchGetPricesQuery['search']>)['items']>)[number]>['price']>);
-  export type PriceRangeInlineFragment = (DiscriminateUnion<(NonNullable<NonNullable<(NonNullable<(NonNullable<SearchGetPricesQuery['search']>)['items']>)[number]>['price']>), { __typename?: 'PriceRange' }>);
-  export type SinglePriceInlineFragment = (DiscriminateUnion<(NonNullable<NonNullable<(NonNullable<(NonNullable<SearchGetPricesQuery['search']>)['items']>)[number]>['price']>), { __typename?: 'SinglePrice' }>);
-  export type PriceWithTax = (NonNullable<NonNullable<(NonNullable<(NonNullable<SearchGetPricesQuery['search']>)['items']>)[number]>['priceWithTax']>);
-  export type _PriceRangeInlineFragment = (DiscriminateUnion<(NonNullable<NonNullable<(NonNullable<(NonNullable<SearchGetPricesQuery['search']>)['items']>)[number]>['priceWithTax']>), { __typename?: 'PriceRange' }>);
-  export type _SinglePriceInlineFragment = (DiscriminateUnion<(NonNullable<NonNullable<(NonNullable<(NonNullable<SearchGetPricesQuery['search']>)['items']>)[number]>['priceWithTax']>), { __typename?: 'SinglePrice' }>);
+  export type Search = NonNullable<SearchGetPricesQuery['search']>;
+  export type Items = NonNullable<NonNullable<NonNullable<SearchGetPricesQuery['search']>['items']>[number]>;
+  export type Price = NonNullable<
+    NonNullable<NonNullable<NonNullable<SearchGetPricesQuery['search']>['items']>[number]>['price']
+  >;
+  export type PriceRangeInlineFragment = DiscriminateUnion<
+    NonNullable<
+      NonNullable<NonNullable<NonNullable<SearchGetPricesQuery['search']>['items']>[number]>['price']
+    >,
+    { __typename?: 'PriceRange' }
+  >;
+  export type SinglePriceInlineFragment = DiscriminateUnion<
+    NonNullable<
+      NonNullable<NonNullable<NonNullable<SearchGetPricesQuery['search']>['items']>[number]>['price']
+    >,
+    { __typename?: 'SinglePrice' }
+  >;
+  export type PriceWithTax = NonNullable<
+    NonNullable<NonNullable<NonNullable<SearchGetPricesQuery['search']>['items']>[number]>['priceWithTax']
+  >;
+  export type _PriceRangeInlineFragment = DiscriminateUnion<
+    NonNullable<
+      NonNullable<NonNullable<NonNullable<SearchGetPricesQuery['search']>['items']>[number]>['priceWithTax']
+    >,
+    { __typename?: 'PriceRange' }
+  >;
+  export type _SinglePriceInlineFragment = DiscriminateUnion<
+    NonNullable<
+      NonNullable<NonNullable<NonNullable<SearchGetPricesQuery['search']>['items']>[number]>['priceWithTax']
+    >,
+    { __typename?: 'SinglePrice' }
+  >;
 }
 
 export namespace CreateDraftOrder {
   export type Variables = CreateDraftOrderMutationVariables;
   export type Mutation = CreateDraftOrderMutation;
-  export type CreateDraftOrder = (NonNullable<CreateDraftOrderMutation['createDraftOrder']>);
+  export type CreateDraftOrder = NonNullable<CreateDraftOrderMutation['createDraftOrder']>;
 }
 
 export namespace AddItemToDraftOrder {
   export type Variables = AddItemToDraftOrderMutationVariables;
   export type Mutation = AddItemToDraftOrderMutation;
-  export type AddItemToDraftOrder = (NonNullable<AddItemToDraftOrderMutation['addItemToDraftOrder']>);
-  export type ErrorResultInlineFragment = (DiscriminateUnion<(NonNullable<AddItemToDraftOrderMutation['addItemToDraftOrder']>), { __typename?: 'ErrorResult' }>);
+  export type AddItemToDraftOrder = NonNullable<AddItemToDraftOrderMutation['addItemToDraftOrder']>;
+  export type ErrorResultInlineFragment = DiscriminateUnion<
+    NonNullable<AddItemToDraftOrderMutation['addItemToDraftOrder']>,
+    { __typename?: 'ErrorResult' }
+  >;
 }
 
 export namespace AdjustDraftOrderLine {
   export type Variables = AdjustDraftOrderLineMutationVariables;
   export type Mutation = AdjustDraftOrderLineMutation;
-  export type AdjustDraftOrderLine = (NonNullable<AdjustDraftOrderLineMutation['adjustDraftOrderLine']>);
-  export type ErrorResultInlineFragment = (DiscriminateUnion<(NonNullable<AdjustDraftOrderLineMutation['adjustDraftOrderLine']>), { __typename?: 'ErrorResult' }>);
+  export type AdjustDraftOrderLine = NonNullable<AdjustDraftOrderLineMutation['adjustDraftOrderLine']>;
+  export type ErrorResultInlineFragment = DiscriminateUnion<
+    NonNullable<AdjustDraftOrderLineMutation['adjustDraftOrderLine']>,
+    { __typename?: 'ErrorResult' }
+  >;
 }
 
 export namespace RemoveDraftOrderLine {
   export type Variables = RemoveDraftOrderLineMutationVariables;
   export type Mutation = RemoveDraftOrderLineMutation;
-  export type RemoveDraftOrderLine = (NonNullable<RemoveDraftOrderLineMutation['removeDraftOrderLine']>);
-  export type ErrorResultInlineFragment = (DiscriminateUnion<(NonNullable<RemoveDraftOrderLineMutation['removeDraftOrderLine']>), { __typename?: 'ErrorResult' }>);
+  export type RemoveDraftOrderLine = NonNullable<RemoveDraftOrderLineMutation['removeDraftOrderLine']>;
+  export type ErrorResultInlineFragment = DiscriminateUnion<
+    NonNullable<RemoveDraftOrderLineMutation['removeDraftOrderLine']>,
+    { __typename?: 'ErrorResult' }
+  >;
 }
 
 export namespace SetCustomerForDraftOrder {
   export type Variables = SetCustomerForDraftOrderMutationVariables;
   export type Mutation = SetCustomerForDraftOrderMutation;
-  export type SetCustomerForDraftOrder = (NonNullable<SetCustomerForDraftOrderMutation['setCustomerForDraftOrder']>);
-  export type ErrorResultInlineFragment = (DiscriminateUnion<(NonNullable<SetCustomerForDraftOrderMutation['setCustomerForDraftOrder']>), { __typename?: 'ErrorResult' }>);
+  export type SetCustomerForDraftOrder = NonNullable<
+    SetCustomerForDraftOrderMutation['setCustomerForDraftOrder']
+  >;
+  export type ErrorResultInlineFragment = DiscriminateUnion<
+    NonNullable<SetCustomerForDraftOrderMutation['setCustomerForDraftOrder']>,
+    { __typename?: 'ErrorResult' }
+  >;
 }
 
 export namespace SetDraftOrderShippingAddress {
   export type Variables = SetDraftOrderShippingAddressMutationVariables;
   export type Mutation = SetDraftOrderShippingAddressMutation;
-  export type SetDraftOrderShippingAddress = (NonNullable<SetDraftOrderShippingAddressMutation['setDraftOrderShippingAddress']>);
+  export type SetDraftOrderShippingAddress = NonNullable<
+    SetDraftOrderShippingAddressMutation['setDraftOrderShippingAddress']
+  >;
 }
 
 export namespace SetDraftOrderBillingAddress {
   export type Variables = SetDraftOrderBillingAddressMutationVariables;
   export type Mutation = SetDraftOrderBillingAddressMutation;
-  export type SetDraftOrderBillingAddress = (NonNullable<SetDraftOrderBillingAddressMutation['setDraftOrderBillingAddress']>);
-  export type BillingAddress = (NonNullable<(NonNullable<SetDraftOrderBillingAddressMutation['setDraftOrderBillingAddress']>)['billingAddress']>);
+  export type SetDraftOrderBillingAddress = NonNullable<
+    SetDraftOrderBillingAddressMutation['setDraftOrderBillingAddress']
+  >;
+  export type BillingAddress = NonNullable<
+    NonNullable<SetDraftOrderBillingAddressMutation['setDraftOrderBillingAddress']>['billingAddress']
+  >;
 }
 
 export namespace ApplyCouponCodeToDraftOrder {
   export type Variables = ApplyCouponCodeToDraftOrderMutationVariables;
   export type Mutation = ApplyCouponCodeToDraftOrderMutation;
-  export type ApplyCouponCodeToDraftOrder = (NonNullable<ApplyCouponCodeToDraftOrderMutation['applyCouponCodeToDraftOrder']>);
-  export type OrderInlineFragment = (DiscriminateUnion<(NonNullable<ApplyCouponCodeToDraftOrderMutation['applyCouponCodeToDraftOrder']>), { __typename?: 'Order' }>);
-  export type ErrorResultInlineFragment = (DiscriminateUnion<(NonNullable<ApplyCouponCodeToDraftOrderMutation['applyCouponCodeToDraftOrder']>), { __typename?: 'ErrorResult' }>);
+  export type ApplyCouponCodeToDraftOrder = NonNullable<
+    ApplyCouponCodeToDraftOrderMutation['applyCouponCodeToDraftOrder']
+  >;
+  export type OrderInlineFragment = DiscriminateUnion<
+    NonNullable<ApplyCouponCodeToDraftOrderMutation['applyCouponCodeToDraftOrder']>,
+    { __typename?: 'Order' }
+  >;
+  export type ErrorResultInlineFragment = DiscriminateUnion<
+    NonNullable<ApplyCouponCodeToDraftOrderMutation['applyCouponCodeToDraftOrder']>,
+    { __typename?: 'ErrorResult' }
+  >;
 }
 
 export namespace RemoveCouponCodeFromDraftOrder {
   export type Variables = RemoveCouponCodeFromDraftOrderMutationVariables;
   export type Mutation = RemoveCouponCodeFromDraftOrderMutation;
-  export type RemoveCouponCodeFromDraftOrder = (NonNullable<RemoveCouponCodeFromDraftOrderMutation['removeCouponCodeFromDraftOrder']>);
-  export type OrderInlineFragment = ({ __typename: 'Order' } & Pick<(NonNullable<RemoveCouponCodeFromDraftOrderMutation['removeCouponCodeFromDraftOrder']>), 'couponCodes'>);
+  export type RemoveCouponCodeFromDraftOrder = NonNullable<
+    RemoveCouponCodeFromDraftOrderMutation['removeCouponCodeFromDraftOrder']
+  >;
+  export type OrderInlineFragment = { __typename: 'Order' } & Pick<
+    NonNullable<RemoveCouponCodeFromDraftOrderMutation['removeCouponCodeFromDraftOrder']>,
+    'couponCodes'
+  >;
 }
 
 export namespace DraftOrderEligibleShippingMethods {
   export type Variables = DraftOrderEligibleShippingMethodsQueryVariables;
   export type Query = DraftOrderEligibleShippingMethodsQuery;
-  export type EligibleShippingMethodsForDraftOrder = NonNullable<(NonNullable<DraftOrderEligibleShippingMethodsQuery['eligibleShippingMethodsForDraftOrder']>)[number]>;
+  export type EligibleShippingMethodsForDraftOrder = NonNullable<
+    NonNullable<DraftOrderEligibleShippingMethodsQuery['eligibleShippingMethodsForDraftOrder']>[number]
+  >;
 }
 
 export namespace SetDraftOrderShippingMethod {
   export type Variables = SetDraftOrderShippingMethodMutationVariables;
   export type Mutation = SetDraftOrderShippingMethodMutation;
-  export type SetDraftOrderShippingMethod = (NonNullable<SetDraftOrderShippingMethodMutation['setDraftOrderShippingMethod']>);
-  export type ErrorResultInlineFragment = (DiscriminateUnion<(NonNullable<SetDraftOrderShippingMethodMutation['setDraftOrderShippingMethod']>), { __typename?: 'ErrorResult' }>);
+  export type SetDraftOrderShippingMethod = NonNullable<
+    SetDraftOrderShippingMethodMutation['setDraftOrderShippingMethod']
+  >;
+  export type ErrorResultInlineFragment = DiscriminateUnion<
+    NonNullable<SetDraftOrderShippingMethodMutation['setDraftOrderShippingMethod']>,
+    { __typename?: 'ErrorResult' }
+  >;
 }
 
 export namespace IdTest1 {
   export type Variables = IdTest1QueryVariables;
   export type Query = IdTest1Query;
-  export type Products = (NonNullable<IdTest1Query['products']>);
-  export type Items = NonNullable<(NonNullable<(NonNullable<IdTest1Query['products']>)['items']>)[number]>;
+  export type Products = NonNullable<IdTest1Query['products']>;
+  export type Items = NonNullable<NonNullable<NonNullable<IdTest1Query['products']>['items']>[number]>;
 }
 
 export namespace IdTest2 {
   export type Variables = IdTest2QueryVariables;
   export type Query = IdTest2Query;
-  export type Products = (NonNullable<IdTest2Query['products']>);
-  export type Items = NonNullable<(NonNullable<(NonNullable<IdTest2Query['products']>)['items']>)[number]>;
-  export type Variants = NonNullable<(NonNullable<NonNullable<(NonNullable<(NonNullable<IdTest2Query['products']>)['items']>)[number]>['variants']>)[number]>;
-  export type Options = NonNullable<(NonNullable<NonNullable<(NonNullable<NonNullable<(NonNullable<(NonNullable<IdTest2Query['products']>)['items']>)[number]>['variants']>)[number]>['options']>)[number]>;
+  export type Products = NonNullable<IdTest2Query['products']>;
+  export type Items = NonNullable<NonNullable<NonNullable<IdTest2Query['products']>['items']>[number]>;
+  export type Variants = NonNullable<
+    NonNullable<
+      NonNullable<NonNullable<NonNullable<IdTest2Query['products']>['items']>[number]>['variants']
+    >[number]
+  >;
+  export type Options = NonNullable<
+    NonNullable<
+      NonNullable<
+        NonNullable<
+          NonNullable<NonNullable<NonNullable<IdTest2Query['products']>['items']>[number]>['variants']
+        >[number]
+      >['options']
+    >[number]
+  >;
 }
 
 export namespace IdTest3 {
   export type Variables = IdTest3QueryVariables;
   export type Query = IdTest3Query;
-  export type Product = (NonNullable<IdTest3Query['product']>);
+  export type Product = NonNullable<IdTest3Query['product']>;
 }
 
 export namespace IdTest4 {
   export type Variables = IdTest4MutationVariables;
   export type Mutation = IdTest4Mutation;
-  export type UpdateProduct = (NonNullable<IdTest4Mutation['updateProduct']>);
-  export type FeaturedAsset = (NonNullable<(NonNullable<IdTest4Mutation['updateProduct']>)['featuredAsset']>);
+  export type UpdateProduct = NonNullable<IdTest4Mutation['updateProduct']>;
+  export type FeaturedAsset = NonNullable<NonNullable<IdTest4Mutation['updateProduct']>['featuredAsset']>;
 }
 
 export namespace IdTest5 {
   export type Variables = IdTest5MutationVariables;
   export type Mutation = IdTest5Mutation;
-  export type UpdateProduct = (NonNullable<IdTest5Mutation['updateProduct']>);
+  export type UpdateProduct = NonNullable<IdTest5Mutation['updateProduct']>;
 }
 
 export namespace IdTest6 {
   export type Variables = IdTest6QueryVariables;
   export type Query = IdTest6Query;
-  export type Product = (NonNullable<IdTest6Query['product']>);
+  export type Product = NonNullable<IdTest6Query['product']>;
 }
 
 export namespace IdTest7 {
   export type Variables = IdTest7MutationVariables;
   export type Mutation = IdTest7Mutation;
-  export type UpdateProduct = (NonNullable<IdTest7Mutation['updateProduct']>);
-  export type FeaturedAsset = (NonNullable<(NonNullable<IdTest7Mutation['updateProduct']>)['featuredAsset']>);
+  export type UpdateProduct = NonNullable<IdTest7Mutation['updateProduct']>;
+  export type FeaturedAsset = NonNullable<NonNullable<IdTest7Mutation['updateProduct']>['featuredAsset']>;
 }
 
 export namespace IdTest8 {
   export type Variables = IdTest8MutationVariables;
   export type Mutation = IdTest8Mutation;
-  export type UpdateProduct = (NonNullable<IdTest8Mutation['updateProduct']>);
+  export type UpdateProduct = NonNullable<IdTest8Mutation['updateProduct']>;
 }
 
 export namespace IdTest9 {
   export type Variables = IdTest9QueryVariables;
   export type Query = IdTest9Query;
-  export type Products = (NonNullable<IdTest9Query['products']>);
-  export type Items = NonNullable<(NonNullable<(NonNullable<IdTest9Query['products']>)['items']>)[number]>;
+  export type Products = NonNullable<IdTest9Query['products']>;
+  export type Items = NonNullable<NonNullable<NonNullable<IdTest9Query['products']>['items']>[number]>;
 }
 
 export namespace ProdFragment {
   export type Fragment = ProdFragmentFragment;
-  export type FeaturedAsset = (NonNullable<ProdFragmentFragment['featuredAsset']>);
+  export type FeaturedAsset = NonNullable<ProdFragmentFragment['featuredAsset']>;
 }
 
 export namespace IdTest10 {
   export type Variables = IdTest10QueryVariables;
   export type Query = IdTest10Query;
-  export type Products = (NonNullable<IdTest10Query['products']>);
-  export type Items = NonNullable<(NonNullable<(NonNullable<IdTest10Query['products']>)['items']>)[number]>;
+  export type Products = NonNullable<IdTest10Query['products']>;
+  export type Items = NonNullable<NonNullable<NonNullable<IdTest10Query['products']>['items']>[number]>;
 }
 
 export namespace ProdFragment1 {
@@ -8212,14 +9091,14 @@ export namespace ProdFragment1 {
 
 export namespace ProdFragment2 {
   export type Fragment = ProdFragment2Fragment;
-  export type FeaturedAsset = (NonNullable<ProdFragment2Fragment['featuredAsset']>);
+  export type FeaturedAsset = NonNullable<ProdFragment2Fragment['featuredAsset']>;
 }
 
 export namespace IdTest11 {
   export type Variables = IdTest11QueryVariables;
   export type Query = IdTest11Query;
-  export type Products = (NonNullable<IdTest11Query['products']>);
-  export type Items = NonNullable<(NonNullable<(NonNullable<IdTest11Query['products']>)['items']>)[number]>;
+  export type Products = NonNullable<IdTest11Query['products']>;
+  export type Items = NonNullable<NonNullable<NonNullable<IdTest11Query['products']>['items']>[number]>;
 }
 
 export namespace ProdFragment1_1 {
@@ -8232,80 +9111,114 @@ export namespace ProdFragment2_1 {
 
 export namespace ProdFragment3_1 {
   export type Fragment = ProdFragment3_1Fragment;
-  export type FeaturedAsset = (NonNullable<ProdFragment3_1Fragment['featuredAsset']>);
+  export type FeaturedAsset = NonNullable<ProdFragment3_1Fragment['featuredAsset']>;
 }
 
 export namespace GetFacetWithValues {
   export type Variables = GetFacetWithValuesQueryVariables;
   export type Query = GetFacetWithValuesQuery;
-  export type Facet = (NonNullable<GetFacetWithValuesQuery['facet']>);
+  export type Facet = NonNullable<GetFacetWithValuesQuery['facet']>;
 }
 
 export namespace DeleteFacetValues {
   export type Variables = DeleteFacetValuesMutationVariables;
   export type Mutation = DeleteFacetValuesMutation;
-  export type DeleteFacetValues = NonNullable<(NonNullable<DeleteFacetValuesMutation['deleteFacetValues']>)[number]>;
+  export type DeleteFacetValues = NonNullable<
+    NonNullable<DeleteFacetValuesMutation['deleteFacetValues']>[number]
+  >;
 }
 
 export namespace DeleteFacet {
   export type Variables = DeleteFacetMutationVariables;
   export type Mutation = DeleteFacetMutation;
-  export type DeleteFacet = (NonNullable<DeleteFacetMutation['deleteFacet']>);
+  export type DeleteFacet = NonNullable<DeleteFacetMutation['deleteFacet']>;
 }
 
 export namespace GetProductWithFacetValues {
   export type Variables = GetProductWithFacetValuesQueryVariables;
   export type Query = GetProductWithFacetValuesQuery;
-  export type Product = (NonNullable<GetProductWithFacetValuesQuery['product']>);
-  export type FacetValues = NonNullable<(NonNullable<(NonNullable<GetProductWithFacetValuesQuery['product']>)['facetValues']>)[number]>;
-  export type Variants = NonNullable<(NonNullable<(NonNullable<GetProductWithFacetValuesQuery['product']>)['variants']>)[number]>;
-  export type _FacetValues = NonNullable<(NonNullable<NonNullable<(NonNullable<(NonNullable<GetProductWithFacetValuesQuery['product']>)['variants']>)[number]>['facetValues']>)[number]>;
+  export type Product = NonNullable<GetProductWithFacetValuesQuery['product']>;
+  export type FacetValues = NonNullable<
+    NonNullable<NonNullable<GetProductWithFacetValuesQuery['product']>['facetValues']>[number]
+  >;
+  export type Variants = NonNullable<
+    NonNullable<NonNullable<GetProductWithFacetValuesQuery['product']>['variants']>[number]
+  >;
+  export type _FacetValues = NonNullable<
+    NonNullable<
+      NonNullable<
+        NonNullable<NonNullable<GetProductWithFacetValuesQuery['product']>['variants']>[number]
+      >['facetValues']
+    >[number]
+  >;
 }
 
 export namespace GetProductListWithVariants {
   export type Variables = GetProductListWithVariantsQueryVariables;
   export type Query = GetProductListWithVariantsQuery;
-  export type Products = (NonNullable<GetProductListWithVariantsQuery['products']>);
-  export type Items = NonNullable<(NonNullable<(NonNullable<GetProductListWithVariantsQuery['products']>)['items']>)[number]>;
-  export type Variants = NonNullable<(NonNullable<NonNullable<(NonNullable<(NonNullable<GetProductListWithVariantsQuery['products']>)['items']>)[number]>['variants']>)[number]>;
+  export type Products = NonNullable<GetProductListWithVariantsQuery['products']>;
+  export type Items = NonNullable<
+    NonNullable<NonNullable<GetProductListWithVariantsQuery['products']>['items']>[number]
+  >;
+  export type Variants = NonNullable<
+    NonNullable<
+      NonNullable<
+        NonNullable<NonNullable<GetProductListWithVariantsQuery['products']>['items']>[number]
+      >['variants']
+    >[number]
+  >;
 }
 
 export namespace CreateFacetValues {
   export type Variables = CreateFacetValuesMutationVariables;
   export type Mutation = CreateFacetValuesMutation;
-  export type CreateFacetValues = NonNullable<(NonNullable<CreateFacetValuesMutation['createFacetValues']>)[number]>;
+  export type CreateFacetValues = NonNullable<
+    NonNullable<CreateFacetValuesMutation['createFacetValues']>[number]
+  >;
 }
 
 export namespace UpdateFacetValues {
   export type Variables = UpdateFacetValuesMutationVariables;
   export type Mutation = UpdateFacetValuesMutation;
-  export type UpdateFacetValues = NonNullable<(NonNullable<UpdateFacetValuesMutation['updateFacetValues']>)[number]>;
+  export type UpdateFacetValues = NonNullable<
+    NonNullable<UpdateFacetValuesMutation['updateFacetValues']>[number]
+  >;
 }
 
 export namespace AssignFacetsToChannel {
   export type Variables = AssignFacetsToChannelMutationVariables;
   export type Mutation = AssignFacetsToChannelMutation;
-  export type AssignFacetsToChannel = NonNullable<(NonNullable<AssignFacetsToChannelMutation['assignFacetsToChannel']>)[number]>;
+  export type AssignFacetsToChannel = NonNullable<
+    NonNullable<AssignFacetsToChannelMutation['assignFacetsToChannel']>[number]
+  >;
 }
 
 export namespace RemoveFacetsFromChannel {
   export type Variables = RemoveFacetsFromChannelMutationVariables;
   export type Mutation = RemoveFacetsFromChannelMutation;
-  export type RemoveFacetsFromChannel = NonNullable<(NonNullable<RemoveFacetsFromChannelMutation['removeFacetsFromChannel']>)[number]>;
-  export type FacetInlineFragment = (DiscriminateUnion<NonNullable<(NonNullable<RemoveFacetsFromChannelMutation['removeFacetsFromChannel']>)[number]>, { __typename?: 'Facet' }>);
-  export type FacetInUseErrorInlineFragment = (DiscriminateUnion<NonNullable<(NonNullable<RemoveFacetsFromChannelMutation['removeFacetsFromChannel']>)[number]>, { __typename?: 'FacetInUseError' }>);
+  export type RemoveFacetsFromChannel = NonNullable<
+    NonNullable<RemoveFacetsFromChannelMutation['removeFacetsFromChannel']>[number]
+  >;
+  export type FacetInlineFragment = DiscriminateUnion<
+    NonNullable<NonNullable<RemoveFacetsFromChannelMutation['removeFacetsFromChannel']>[number]>,
+    { __typename?: 'Facet' }
+  >;
+  export type FacetInUseErrorInlineFragment = DiscriminateUnion<
+    NonNullable<NonNullable<RemoveFacetsFromChannelMutation['removeFacetsFromChannel']>[number]>,
+    { __typename?: 'FacetInUseError' }
+  >;
 }
 
 export namespace GetGlobalSettings {
   export type Variables = GetGlobalSettingsQueryVariables;
   export type Query = GetGlobalSettingsQuery;
-  export type GlobalSettings = (NonNullable<GetGlobalSettingsQuery['globalSettings']>);
+  export type GlobalSettings = NonNullable<GetGlobalSettingsQuery['globalSettings']>;
 }
 
 export namespace Administrator {
   export type Fragment = AdministratorFragment;
-  export type User = (NonNullable<AdministratorFragment['user']>);
-  export type Roles = NonNullable<(NonNullable<(NonNullable<AdministratorFragment['user']>)['roles']>)[number]>;
+  export type User = NonNullable<AdministratorFragment['user']>;
+  export type Roles = NonNullable<NonNullable<NonNullable<AdministratorFragment['user']>['roles']>[number]>;
 }
 
 export namespace Asset {
@@ -8314,75 +9227,79 @@ export namespace Asset {
 
 export namespace ProductVariant {
   export type Fragment = ProductVariantFragment;
-  export type TaxRateApplied = (NonNullable<ProductVariantFragment['taxRateApplied']>);
-  export type TaxCategory = (NonNullable<ProductVariantFragment['taxCategory']>);
-  export type Options = NonNullable<(NonNullable<ProductVariantFragment['options']>)[number]>;
-  export type FacetValues = NonNullable<(NonNullable<ProductVariantFragment['facetValues']>)[number]>;
-  export type Facet = (NonNullable<NonNullable<(NonNullable<ProductVariantFragment['facetValues']>)[number]>['facet']>);
-  export type FeaturedAsset = (NonNullable<ProductVariantFragment['featuredAsset']>);
-  export type Assets = NonNullable<(NonNullable<ProductVariantFragment['assets']>)[number]>;
-  export type Translations = NonNullable<(NonNullable<ProductVariantFragment['translations']>)[number]>;
-  export type Channels = NonNullable<(NonNullable<ProductVariantFragment['channels']>)[number]>;
+  export type TaxRateApplied = NonNullable<ProductVariantFragment['taxRateApplied']>;
+  export type TaxCategory = NonNullable<ProductVariantFragment['taxCategory']>;
+  export type Options = NonNullable<NonNullable<ProductVariantFragment['options']>[number]>;
+  export type FacetValues = NonNullable<NonNullable<ProductVariantFragment['facetValues']>[number]>;
+  export type Facet = NonNullable<
+    NonNullable<NonNullable<ProductVariantFragment['facetValues']>[number]>['facet']
+  >;
+  export type FeaturedAsset = NonNullable<ProductVariantFragment['featuredAsset']>;
+  export type Assets = NonNullable<NonNullable<ProductVariantFragment['assets']>[number]>;
+  export type Translations = NonNullable<NonNullable<ProductVariantFragment['translations']>[number]>;
+  export type Channels = NonNullable<NonNullable<ProductVariantFragment['channels']>[number]>;
 }
 
 export namespace ProductWithVariants {
   export type Fragment = ProductWithVariantsFragment;
-  export type FeaturedAsset = (NonNullable<ProductWithVariantsFragment['featuredAsset']>);
-  export type Assets = NonNullable<(NonNullable<ProductWithVariantsFragment['assets']>)[number]>;
-  export type Translations = NonNullable<(NonNullable<ProductWithVariantsFragment['translations']>)[number]>;
-  export type OptionGroups = NonNullable<(NonNullable<ProductWithVariantsFragment['optionGroups']>)[number]>;
-  export type Variants = NonNullable<(NonNullable<ProductWithVariantsFragment['variants']>)[number]>;
-  export type FacetValues = NonNullable<(NonNullable<ProductWithVariantsFragment['facetValues']>)[number]>;
-  export type Facet = (NonNullable<NonNullable<(NonNullable<ProductWithVariantsFragment['facetValues']>)[number]>['facet']>);
-  export type Channels = NonNullable<(NonNullable<ProductWithVariantsFragment['channels']>)[number]>;
+  export type FeaturedAsset = NonNullable<ProductWithVariantsFragment['featuredAsset']>;
+  export type Assets = NonNullable<NonNullable<ProductWithVariantsFragment['assets']>[number]>;
+  export type Translations = NonNullable<NonNullable<ProductWithVariantsFragment['translations']>[number]>;
+  export type OptionGroups = NonNullable<NonNullable<ProductWithVariantsFragment['optionGroups']>[number]>;
+  export type Variants = NonNullable<NonNullable<ProductWithVariantsFragment['variants']>[number]>;
+  export type FacetValues = NonNullable<NonNullable<ProductWithVariantsFragment['facetValues']>[number]>;
+  export type Facet = NonNullable<
+    NonNullable<NonNullable<ProductWithVariantsFragment['facetValues']>[number]>['facet']
+  >;
+  export type Channels = NonNullable<NonNullable<ProductWithVariantsFragment['channels']>[number]>;
 }
 
 export namespace Role {
   export type Fragment = RoleFragment;
-  export type Channels = NonNullable<(NonNullable<RoleFragment['channels']>)[number]>;
+  export type Channels = NonNullable<NonNullable<RoleFragment['channels']>[number]>;
 }
 
 export namespace ConfigurableOperation {
   export type Fragment = ConfigurableOperationFragment;
-  export type Args = NonNullable<(NonNullable<ConfigurableOperationFragment['args']>)[number]>;
+  export type Args = NonNullable<NonNullable<ConfigurableOperationFragment['args']>[number]>;
 }
 
 export namespace Collection {
   export type Fragment = CollectionFragment;
-  export type FeaturedAsset = (NonNullable<CollectionFragment['featuredAsset']>);
-  export type Assets = NonNullable<(NonNullable<CollectionFragment['assets']>)[number]>;
-  export type Filters = NonNullable<(NonNullable<CollectionFragment['filters']>)[number]>;
-  export type Translations = NonNullable<(NonNullable<CollectionFragment['translations']>)[number]>;
-  export type Parent = (NonNullable<CollectionFragment['parent']>);
-  export type Children = NonNullable<(NonNullable<CollectionFragment['children']>)[number]>;
+  export type FeaturedAsset = NonNullable<CollectionFragment['featuredAsset']>;
+  export type Assets = NonNullable<NonNullable<CollectionFragment['assets']>[number]>;
+  export type Filters = NonNullable<NonNullable<CollectionFragment['filters']>[number]>;
+  export type Translations = NonNullable<NonNullable<CollectionFragment['translations']>[number]>;
+  export type Parent = NonNullable<CollectionFragment['parent']>;
+  export type Children = NonNullable<NonNullable<CollectionFragment['children']>[number]>;
 }
 
 export namespace FacetValue {
   export type Fragment = FacetValueFragment;
-  export type Translations = NonNullable<(NonNullable<FacetValueFragment['translations']>)[number]>;
-  export type Facet = (NonNullable<FacetValueFragment['facet']>);
+  export type Translations = NonNullable<NonNullable<FacetValueFragment['translations']>[number]>;
+  export type Facet = NonNullable<FacetValueFragment['facet']>;
 }
 
 export namespace FacetWithValues {
   export type Fragment = FacetWithValuesFragment;
-  export type Translations = NonNullable<(NonNullable<FacetWithValuesFragment['translations']>)[number]>;
-  export type Values = NonNullable<(NonNullable<FacetWithValuesFragment['values']>)[number]>;
+  export type Translations = NonNullable<NonNullable<FacetWithValuesFragment['translations']>[number]>;
+  export type Values = NonNullable<NonNullable<FacetWithValuesFragment['values']>[number]>;
 }
 
 export namespace Country {
   export type Fragment = CountryFragment;
-  export type Translations = NonNullable<(NonNullable<CountryFragment['translations']>)[number]>;
+  export type Translations = NonNullable<NonNullable<CountryFragment['translations']>[number]>;
 }
 
 export namespace Address {
   export type Fragment = AddressFragment;
-  export type Country = (NonNullable<AddressFragment['country']>);
+  export type Country = NonNullable<AddressFragment['country']>;
 }
 
 export namespace Customer {
   export type Fragment = CustomerFragment;
-  export type User = (NonNullable<CustomerFragment['user']>);
-  export type Addresses = NonNullable<(NonNullable<CustomerFragment['addresses']>)[number]>;
+  export type User = NonNullable<CustomerFragment['user']>;
+  export type Addresses = NonNullable<NonNullable<CustomerFragment['addresses']>[number]>;
 }
 
 export namespace Adjustment {
@@ -8395,575 +9312,763 @@ export namespace ShippingAddress {
 
 export namespace Order {
   export type Fragment = OrderFragment;
-  export type Customer = (NonNullable<OrderFragment['customer']>);
+  export type Customer = NonNullable<OrderFragment['customer']>;
 }
 
 export namespace OrderItem {
   export type Fragment = OrderItemFragment;
-  export type Fulfillment = (NonNullable<OrderItemFragment['fulfillment']>);
+  export type Fulfillment = NonNullable<OrderItemFragment['fulfillment']>;
 }
 
 export namespace Payment {
   export type Fragment = PaymentFragment;
-  export type Refunds = NonNullable<(NonNullable<PaymentFragment['refunds']>)[number]>;
+  export type Refunds = NonNullable<NonNullable<PaymentFragment['refunds']>[number]>;
 }
 
 export namespace OrderWithLines {
   export type Fragment = OrderWithLinesFragment;
-  export type Customer = (NonNullable<OrderWithLinesFragment['customer']>);
-  export type Lines = NonNullable<(NonNullable<OrderWithLinesFragment['lines']>)[number]>;
-  export type FeaturedAsset = (NonNullable<NonNullable<(NonNullable<OrderWithLinesFragment['lines']>)[number]>['featuredAsset']>);
-  export type ProductVariant = (NonNullable<NonNullable<(NonNullable<OrderWithLinesFragment['lines']>)[number]>['productVariant']>);
-  export type Items = NonNullable<(NonNullable<NonNullable<(NonNullable<OrderWithLinesFragment['lines']>)[number]>['items']>)[number]>;
-  export type Surcharges = NonNullable<(NonNullable<OrderWithLinesFragment['surcharges']>)[number]>;
-  export type ShippingLines = NonNullable<(NonNullable<OrderWithLinesFragment['shippingLines']>)[number]>;
-  export type ShippingMethod = (NonNullable<NonNullable<(NonNullable<OrderWithLinesFragment['shippingLines']>)[number]>['shippingMethod']>);
-  export type ShippingAddress = (NonNullable<OrderWithLinesFragment['shippingAddress']>);
-  export type Payments = NonNullable<(NonNullable<OrderWithLinesFragment['payments']>)[number]>;
+  export type Customer = NonNullable<OrderWithLinesFragment['customer']>;
+  export type Lines = NonNullable<NonNullable<OrderWithLinesFragment['lines']>[number]>;
+  export type FeaturedAsset = NonNullable<
+    NonNullable<NonNullable<OrderWithLinesFragment['lines']>[number]>['featuredAsset']
+  >;
+  export type ProductVariant = NonNullable<
+    NonNullable<NonNullable<OrderWithLinesFragment['lines']>[number]>['productVariant']
+  >;
+  export type Items = NonNullable<
+    NonNullable<NonNullable<NonNullable<OrderWithLinesFragment['lines']>[number]>['items']>[number]
+  >;
+  export type Surcharges = NonNullable<NonNullable<OrderWithLinesFragment['surcharges']>[number]>;
+  export type ShippingLines = NonNullable<NonNullable<OrderWithLinesFragment['shippingLines']>[number]>;
+  export type ShippingMethod = NonNullable<
+    NonNullable<NonNullable<OrderWithLinesFragment['shippingLines']>[number]>['shippingMethod']
+  >;
+  export type ShippingAddress = NonNullable<OrderWithLinesFragment['shippingAddress']>;
+  export type Payments = NonNullable<NonNullable<OrderWithLinesFragment['payments']>[number]>;
 }
 
 export namespace Promotion {
   export type Fragment = PromotionFragment;
-  export type Conditions = NonNullable<(NonNullable<PromotionFragment['conditions']>)[number]>;
-  export type Actions = NonNullable<(NonNullable<PromotionFragment['actions']>)[number]>;
+  export type Conditions = NonNullable<NonNullable<PromotionFragment['conditions']>[number]>;
+  export type Actions = NonNullable<NonNullable<PromotionFragment['actions']>[number]>;
 }
 
 export namespace Zone {
   export type Fragment = ZoneFragment;
-  export type Members = NonNullable<(NonNullable<ZoneFragment['members']>)[number]>;
+  export type Members = NonNullable<NonNullable<ZoneFragment['members']>[number]>;
 }
 
 export namespace TaxRate {
   export type Fragment = TaxRateFragment;
-  export type Category = (NonNullable<TaxRateFragment['category']>);
-  export type Zone = (NonNullable<TaxRateFragment['zone']>);
-  export type CustomerGroup = (NonNullable<TaxRateFragment['customerGroup']>);
+  export type Category = NonNullable<TaxRateFragment['category']>;
+  export type Zone = NonNullable<TaxRateFragment['zone']>;
+  export type CustomerGroup = NonNullable<TaxRateFragment['customerGroup']>;
 }
 
 export namespace CurrentUser {
   export type Fragment = CurrentUserFragment;
-  export type Channels = NonNullable<(NonNullable<CurrentUserFragment['channels']>)[number]>;
+  export type Channels = NonNullable<NonNullable<CurrentUserFragment['channels']>[number]>;
 }
 
 export namespace VariantWithStock {
   export type Fragment = VariantWithStockFragment;
-  export type StockMovements = (NonNullable<VariantWithStockFragment['stockMovements']>);
-  export type Items = NonNullable<(NonNullable<(NonNullable<VariantWithStockFragment['stockMovements']>)['items']>)[number]>;
-  export type StockMovementInlineFragment = (DiscriminateUnion<NonNullable<(NonNullable<(NonNullable<VariantWithStockFragment['stockMovements']>)['items']>)[number]>, { __typename?: 'StockMovement' }>);
+  export type StockMovements = NonNullable<VariantWithStockFragment['stockMovements']>;
+  export type Items = NonNullable<
+    NonNullable<NonNullable<VariantWithStockFragment['stockMovements']>['items']>[number]
+  >;
+  export type StockMovementInlineFragment = DiscriminateUnion<
+    NonNullable<NonNullable<NonNullable<VariantWithStockFragment['stockMovements']>['items']>[number]>,
+    { __typename?: 'StockMovement' }
+  >;
 }
 
 export namespace Fulfillment {
   export type Fragment = FulfillmentFragment;
-  export type OrderItems = NonNullable<(NonNullable<FulfillmentFragment['orderItems']>)[number]>;
+  export type OrderItems = NonNullable<NonNullable<FulfillmentFragment['orderItems']>[number]>;
 }
 
 export namespace Channel {
   export type Fragment = ChannelFragment;
-  export type DefaultShippingZone = (NonNullable<ChannelFragment['defaultShippingZone']>);
-  export type DefaultTaxZone = (NonNullable<ChannelFragment['defaultTaxZone']>);
+  export type DefaultShippingZone = NonNullable<ChannelFragment['defaultShippingZone']>;
+  export type DefaultTaxZone = NonNullable<ChannelFragment['defaultTaxZone']>;
 }
 
 export namespace GlobalSettings {
   export type Fragment = GlobalSettingsFragment;
-  export type ServerConfig = (NonNullable<GlobalSettingsFragment['serverConfig']>);
-  export type OrderProcess = NonNullable<(NonNullable<(NonNullable<GlobalSettingsFragment['serverConfig']>)['orderProcess']>)[number]>;
-  export type Permissions = NonNullable<(NonNullable<(NonNullable<GlobalSettingsFragment['serverConfig']>)['permissions']>)[number]>;
-  export type CustomFieldConfig = (NonNullable<(NonNullable<GlobalSettingsFragment['serverConfig']>)['customFieldConfig']>);
-  export type Customer = NonNullable<(NonNullable<(NonNullable<(NonNullable<GlobalSettingsFragment['serverConfig']>)['customFieldConfig']>)['Customer']>)[number]>;
-  export type CustomFieldInlineFragment = (DiscriminateUnion<NonNullable<(NonNullable<(NonNullable<(NonNullable<GlobalSettingsFragment['serverConfig']>)['customFieldConfig']>)['Customer']>)[number]>, { __typename?: 'CustomField' }>);
+  export type ServerConfig = NonNullable<GlobalSettingsFragment['serverConfig']>;
+  export type OrderProcess = NonNullable<
+    NonNullable<NonNullable<GlobalSettingsFragment['serverConfig']>['orderProcess']>[number]
+  >;
+  export type Permissions = NonNullable<
+    NonNullable<NonNullable<GlobalSettingsFragment['serverConfig']>['permissions']>[number]
+  >;
+  export type CustomFieldConfig = NonNullable<
+    NonNullable<GlobalSettingsFragment['serverConfig']>['customFieldConfig']
+  >;
+  export type Customer = NonNullable<
+    NonNullable<
+      NonNullable<NonNullable<GlobalSettingsFragment['serverConfig']>['customFieldConfig']>['Customer']
+    >[number]
+  >;
+  export type CustomFieldInlineFragment = DiscriminateUnion<
+    NonNullable<
+      NonNullable<
+        NonNullable<NonNullable<GlobalSettingsFragment['serverConfig']>['customFieldConfig']>['Customer']
+      >[number]
+    >,
+    { __typename?: 'CustomField' }
+  >;
 }
 
 export namespace CustomerGroup {
   export type Fragment = CustomerGroupFragment;
-  export type Customers = (NonNullable<CustomerGroupFragment['customers']>);
-  export type Items = NonNullable<(NonNullable<(NonNullable<CustomerGroupFragment['customers']>)['items']>)[number]>;
+  export type Customers = NonNullable<CustomerGroupFragment['customers']>;
+  export type Items = NonNullable<
+    NonNullable<NonNullable<CustomerGroupFragment['customers']>['items']>[number]
+  >;
 }
 
 export namespace ProductOptionGroup {
   export type Fragment = ProductOptionGroupFragment;
-  export type Options = NonNullable<(NonNullable<ProductOptionGroupFragment['options']>)[number]>;
-  export type Translations = NonNullable<(NonNullable<ProductOptionGroupFragment['translations']>)[number]>;
+  export type Options = NonNullable<NonNullable<ProductOptionGroupFragment['options']>[number]>;
+  export type Translations = NonNullable<NonNullable<ProductOptionGroupFragment['translations']>[number]>;
 }
 
 export namespace ProductWithOptions {
   export type Fragment = ProductWithOptionsFragment;
-  export type OptionGroups = NonNullable<(NonNullable<ProductWithOptionsFragment['optionGroups']>)[number]>;
-  export type Options = NonNullable<(NonNullable<NonNullable<(NonNullable<ProductWithOptionsFragment['optionGroups']>)[number]>['options']>)[number]>;
+  export type OptionGroups = NonNullable<NonNullable<ProductWithOptionsFragment['optionGroups']>[number]>;
+  export type Options = NonNullable<
+    NonNullable<
+      NonNullable<NonNullable<ProductWithOptionsFragment['optionGroups']>[number]>['options']
+    >[number]
+  >;
 }
 
 export namespace ShippingMethod {
   export type Fragment = ShippingMethodFragment;
-  export type Calculator = (NonNullable<ShippingMethodFragment['calculator']>);
-  export type Args = NonNullable<(NonNullable<(NonNullable<ShippingMethodFragment['calculator']>)['args']>)[number]>;
-  export type Checker = (NonNullable<ShippingMethodFragment['checker']>);
-  export type _Args = NonNullable<(NonNullable<(NonNullable<ShippingMethodFragment['checker']>)['args']>)[number]>;
+  export type Calculator = NonNullable<ShippingMethodFragment['calculator']>;
+  export type Args = NonNullable<
+    NonNullable<NonNullable<ShippingMethodFragment['calculator']>['args']>[number]
+  >;
+  export type Checker = NonNullable<ShippingMethodFragment['checker']>;
+  export type _Args = NonNullable<
+    NonNullable<NonNullable<ShippingMethodFragment['checker']>['args']>[number]
+  >;
 }
 
 export namespace CreateAdministrator {
   export type Variables = CreateAdministratorMutationVariables;
   export type Mutation = CreateAdministratorMutation;
-  export type CreateAdministrator = (NonNullable<CreateAdministratorMutation['createAdministrator']>);
+  export type CreateAdministrator = NonNullable<CreateAdministratorMutation['createAdministrator']>;
 }
 
 export namespace UpdateProduct {
   export type Variables = UpdateProductMutationVariables;
   export type Mutation = UpdateProductMutation;
-  export type UpdateProduct = (NonNullable<UpdateProductMutation['updateProduct']>);
+  export type UpdateProduct = NonNullable<UpdateProductMutation['updateProduct']>;
 }
 
 export namespace CreateProduct {
   export type Variables = CreateProductMutationVariables;
   export type Mutation = CreateProductMutation;
-  export type CreateProduct = (NonNullable<CreateProductMutation['createProduct']>);
+  export type CreateProduct = NonNullable<CreateProductMutation['createProduct']>;
 }
 
 export namespace GetProductWithVariants {
   export type Variables = GetProductWithVariantsQueryVariables;
   export type Query = GetProductWithVariantsQuery;
-  export type Product = (NonNullable<GetProductWithVariantsQuery['product']>);
+  export type Product = NonNullable<GetProductWithVariantsQuery['product']>;
 }
 
 export namespace GetProductList {
   export type Variables = GetProductListQueryVariables;
   export type Query = GetProductListQuery;
-  export type Products = (NonNullable<GetProductListQuery['products']>);
-  export type Items = NonNullable<(NonNullable<(NonNullable<GetProductListQuery['products']>)['items']>)[number]>;
-  export type FeaturedAsset = (NonNullable<NonNullable<(NonNullable<(NonNullable<GetProductListQuery['products']>)['items']>)[number]>['featuredAsset']>);
+  export type Products = NonNullable<GetProductListQuery['products']>;
+  export type Items = NonNullable<NonNullable<NonNullable<GetProductListQuery['products']>['items']>[number]>;
+  export type FeaturedAsset = NonNullable<
+    NonNullable<NonNullable<NonNullable<GetProductListQuery['products']>['items']>[number]>['featuredAsset']
+  >;
 }
 
 export namespace CreateProductVariants {
   export type Variables = CreateProductVariantsMutationVariables;
   export type Mutation = CreateProductVariantsMutation;
-  export type CreateProductVariants = NonNullable<(NonNullable<CreateProductVariantsMutation['createProductVariants']>)[number]>;
+  export type CreateProductVariants = NonNullable<
+    NonNullable<CreateProductVariantsMutation['createProductVariants']>[number]
+  >;
 }
 
 export namespace UpdateProductVariants {
   export type Variables = UpdateProductVariantsMutationVariables;
   export type Mutation = UpdateProductVariantsMutation;
-  export type UpdateProductVariants = NonNullable<(NonNullable<UpdateProductVariantsMutation['updateProductVariants']>)[number]>;
+  export type UpdateProductVariants = NonNullable<
+    NonNullable<UpdateProductVariantsMutation['updateProductVariants']>[number]
+  >;
 }
 
 export namespace UpdateTaxRate {
   export type Variables = UpdateTaxRateMutationVariables;
   export type Mutation = UpdateTaxRateMutation;
-  export type UpdateTaxRate = (NonNullable<UpdateTaxRateMutation['updateTaxRate']>);
+  export type UpdateTaxRate = NonNullable<UpdateTaxRateMutation['updateTaxRate']>;
 }
 
 export namespace CreateFacet {
   export type Variables = CreateFacetMutationVariables;
   export type Mutation = CreateFacetMutation;
-  export type CreateFacet = (NonNullable<CreateFacetMutation['createFacet']>);
+  export type CreateFacet = NonNullable<CreateFacetMutation['createFacet']>;
 }
 
 export namespace UpdateFacet {
   export type Variables = UpdateFacetMutationVariables;
   export type Mutation = UpdateFacetMutation;
-  export type UpdateFacet = (NonNullable<UpdateFacetMutation['updateFacet']>);
+  export type UpdateFacet = NonNullable<UpdateFacetMutation['updateFacet']>;
 }
 
 export namespace GetCustomerList {
   export type Variables = GetCustomerListQueryVariables;
   export type Query = GetCustomerListQuery;
-  export type Customers = (NonNullable<GetCustomerListQuery['customers']>);
-  export type Items = NonNullable<(NonNullable<(NonNullable<GetCustomerListQuery['customers']>)['items']>)[number]>;
-  export type User = (NonNullable<NonNullable<(NonNullable<(NonNullable<GetCustomerListQuery['customers']>)['items']>)[number]>['user']>);
+  export type Customers = NonNullable<GetCustomerListQuery['customers']>;
+  export type Items = NonNullable<
+    NonNullable<NonNullable<GetCustomerListQuery['customers']>['items']>[number]
+  >;
+  export type User = NonNullable<
+    NonNullable<NonNullable<NonNullable<GetCustomerListQuery['customers']>['items']>[number]>['user']
+  >;
 }
 
 export namespace GetAssetList {
   export type Variables = GetAssetListQueryVariables;
   export type Query = GetAssetListQuery;
-  export type Assets = (NonNullable<GetAssetListQuery['assets']>);
-  export type Items = NonNullable<(NonNullable<(NonNullable<GetAssetListQuery['assets']>)['items']>)[number]>;
+  export type Assets = NonNullable<GetAssetListQuery['assets']>;
+  export type Items = NonNullable<NonNullable<NonNullable<GetAssetListQuery['assets']>['items']>[number]>;
 }
 
 export namespace CreateRole {
   export type Variables = CreateRoleMutationVariables;
   export type Mutation = CreateRoleMutation;
-  export type CreateRole = (NonNullable<CreateRoleMutation['createRole']>);
+  export type CreateRole = NonNullable<CreateRoleMutation['createRole']>;
 }
 
 export namespace CreateCollection {
   export type Variables = CreateCollectionMutationVariables;
   export type Mutation = CreateCollectionMutation;
-  export type CreateCollection = (NonNullable<CreateCollectionMutation['createCollection']>);
+  export type CreateCollection = NonNullable<CreateCollectionMutation['createCollection']>;
 }
 
 export namespace UpdateCollection {
   export type Variables = UpdateCollectionMutationVariables;
   export type Mutation = UpdateCollectionMutation;
-  export type UpdateCollection = (NonNullable<UpdateCollectionMutation['updateCollection']>);
+  export type UpdateCollection = NonNullable<UpdateCollectionMutation['updateCollection']>;
 }
 
 export namespace GetCustomer {
   export type Variables = GetCustomerQueryVariables;
   export type Query = GetCustomerQuery;
-  export type Customer = (NonNullable<GetCustomerQuery['customer']>);
-  export type Orders = (NonNullable<(NonNullable<GetCustomerQuery['customer']>)['orders']>);
-  export type Items = NonNullable<(NonNullable<(NonNullable<(NonNullable<GetCustomerQuery['customer']>)['orders']>)['items']>)[number]>;
+  export type Customer = NonNullable<GetCustomerQuery['customer']>;
+  export type Orders = NonNullable<NonNullable<GetCustomerQuery['customer']>['orders']>;
+  export type Items = NonNullable<
+    NonNullable<NonNullable<NonNullable<GetCustomerQuery['customer']>['orders']>['items']>[number]
+  >;
 }
 
 export namespace AttemptLogin {
   export type Variables = AttemptLoginMutationVariables;
   export type Mutation = AttemptLoginMutation;
-  export type Login = (NonNullable<AttemptLoginMutation['login']>);
+  export type Login = NonNullable<AttemptLoginMutation['login']>;
+  export type ErrorResultInlineFragment = DiscriminateUnion<
+    NonNullable<AttemptLoginMutation['login']>,
+    { __typename?: 'ErrorResult' }
+  >;
 }
 
 export namespace GetCountryList {
   export type Variables = GetCountryListQueryVariables;
   export type Query = GetCountryListQuery;
-  export type Countries = (NonNullable<GetCountryListQuery['countries']>);
-  export type Items = NonNullable<(NonNullable<(NonNullable<GetCountryListQuery['countries']>)['items']>)[number]>;
+  export type Countries = NonNullable<GetCountryListQuery['countries']>;
+  export type Items = NonNullable<
+    NonNullable<NonNullable<GetCountryListQuery['countries']>['items']>[number]
+  >;
 }
 
 export namespace UpdateCountry {
   export type Variables = UpdateCountryMutationVariables;
   export type Mutation = UpdateCountryMutation;
-  export type UpdateCountry = (NonNullable<UpdateCountryMutation['updateCountry']>);
+  export type UpdateCountry = NonNullable<UpdateCountryMutation['updateCountry']>;
 }
 
 export namespace GetFacetList {
   export type Variables = GetFacetListQueryVariables;
   export type Query = GetFacetListQuery;
-  export type Facets = (NonNullable<GetFacetListQuery['facets']>);
-  export type Items = NonNullable<(NonNullable<(NonNullable<GetFacetListQuery['facets']>)['items']>)[number]>;
+  export type Facets = NonNullable<GetFacetListQuery['facets']>;
+  export type Items = NonNullable<NonNullable<NonNullable<GetFacetListQuery['facets']>['items']>[number]>;
 }
 
 export namespace GetFacetListSimple {
   export type Variables = GetFacetListSimpleQueryVariables;
   export type Query = GetFacetListSimpleQuery;
-  export type Facets = (NonNullable<GetFacetListSimpleQuery['facets']>);
-  export type Items = NonNullable<(NonNullable<(NonNullable<GetFacetListSimpleQuery['facets']>)['items']>)[number]>;
+  export type Facets = NonNullable<GetFacetListSimpleQuery['facets']>;
+  export type Items = NonNullable<
+    NonNullable<NonNullable<GetFacetListSimpleQuery['facets']>['items']>[number]
+  >;
 }
 
 export namespace DeleteProduct {
   export type Variables = DeleteProductMutationVariables;
   export type Mutation = DeleteProductMutation;
-  export type DeleteProduct = (NonNullable<DeleteProductMutation['deleteProduct']>);
+  export type DeleteProduct = NonNullable<DeleteProductMutation['deleteProduct']>;
 }
 
 export namespace GetProductSimple {
   export type Variables = GetProductSimpleQueryVariables;
   export type Query = GetProductSimpleQuery;
-  export type Product = (NonNullable<GetProductSimpleQuery['product']>);
+  export type Product = NonNullable<GetProductSimpleQuery['product']>;
 }
 
 export namespace GetStockMovement {
   export type Variables = GetStockMovementQueryVariables;
   export type Query = GetStockMovementQuery;
-  export type Product = (NonNullable<GetStockMovementQuery['product']>);
-  export type Variants = NonNullable<(NonNullable<(NonNullable<GetStockMovementQuery['product']>)['variants']>)[number]>;
+  export type Product = NonNullable<GetStockMovementQuery['product']>;
+  export type Variants = NonNullable<
+    NonNullable<NonNullable<GetStockMovementQuery['product']>['variants']>[number]
+  >;
 }
 
 export namespace GetRunningJobs {
   export type Variables = GetRunningJobsQueryVariables;
   export type Query = GetRunningJobsQuery;
-  export type Jobs = (NonNullable<GetRunningJobsQuery['jobs']>);
-  export type Items = NonNullable<(NonNullable<(NonNullable<GetRunningJobsQuery['jobs']>)['items']>)[number]>;
+  export type Jobs = NonNullable<GetRunningJobsQuery['jobs']>;
+  export type Items = NonNullable<NonNullable<NonNullable<GetRunningJobsQuery['jobs']>['items']>[number]>;
 }
 
 export namespace CreatePromotion {
   export type Variables = CreatePromotionMutationVariables;
   export type Mutation = CreatePromotionMutation;
-  export type CreatePromotion = (NonNullable<CreatePromotionMutation['createPromotion']>);
-  export type ErrorResultInlineFragment = (DiscriminateUnion<(NonNullable<CreatePromotionMutation['createPromotion']>), { __typename?: 'ErrorResult' }>);
+  export type CreatePromotion = NonNullable<CreatePromotionMutation['createPromotion']>;
+  export type ErrorResultInlineFragment = DiscriminateUnion<
+    NonNullable<CreatePromotionMutation['createPromotion']>,
+    { __typename?: 'ErrorResult' }
+  >;
 }
 
 export namespace Me {
   export type Variables = MeQueryVariables;
   export type Query = MeQuery;
-  export type Me = (NonNullable<MeQuery['me']>);
+  export type Me = NonNullable<MeQuery['me']>;
 }
 
 export namespace CreateChannel {
   export type Variables = CreateChannelMutationVariables;
   export type Mutation = CreateChannelMutation;
-  export type CreateChannel = (NonNullable<CreateChannelMutation['createChannel']>);
-  export type LanguageNotAvailableErrorInlineFragment = (DiscriminateUnion<(NonNullable<CreateChannelMutation['createChannel']>), { __typename?: 'LanguageNotAvailableError' }>);
+  export type CreateChannel = NonNullable<CreateChannelMutation['createChannel']>;
+  export type LanguageNotAvailableErrorInlineFragment = DiscriminateUnion<
+    NonNullable<CreateChannelMutation['createChannel']>,
+    { __typename?: 'LanguageNotAvailableError' }
+  >;
 }
 
 export namespace DeleteProductVariant {
   export type Variables = DeleteProductVariantMutationVariables;
   export type Mutation = DeleteProductVariantMutation;
-  export type DeleteProductVariant = (NonNullable<DeleteProductVariantMutation['deleteProductVariant']>);
+  export type DeleteProductVariant = NonNullable<DeleteProductVariantMutation['deleteProductVariant']>;
 }
 
 export namespace AssignProductsToChannel {
   export type Variables = AssignProductsToChannelMutationVariables;
   export type Mutation = AssignProductsToChannelMutation;
-  export type AssignProductsToChannel = NonNullable<(NonNullable<AssignProductsToChannelMutation['assignProductsToChannel']>)[number]>;
+  export type AssignProductsToChannel = NonNullable<
+    NonNullable<AssignProductsToChannelMutation['assignProductsToChannel']>[number]
+  >;
 }
 
 export namespace RemoveProductsFromChannel {
   export type Variables = RemoveProductsFromChannelMutationVariables;
   export type Mutation = RemoveProductsFromChannelMutation;
-  export type RemoveProductsFromChannel = NonNullable<(NonNullable<RemoveProductsFromChannelMutation['removeProductsFromChannel']>)[number]>;
+  export type RemoveProductsFromChannel = NonNullable<
+    NonNullable<RemoveProductsFromChannelMutation['removeProductsFromChannel']>[number]
+  >;
 }
 
 export namespace AssignProductVariantsToChannel {
   export type Variables = AssignProductVariantsToChannelMutationVariables;
   export type Mutation = AssignProductVariantsToChannelMutation;
-  export type AssignProductVariantsToChannel = NonNullable<(NonNullable<AssignProductVariantsToChannelMutation['assignProductVariantsToChannel']>)[number]>;
+  export type AssignProductVariantsToChannel = NonNullable<
+    NonNullable<AssignProductVariantsToChannelMutation['assignProductVariantsToChannel']>[number]
+  >;
 }
 
 export namespace RemoveProductVariantsFromChannel {
   export type Variables = RemoveProductVariantsFromChannelMutationVariables;
   export type Mutation = RemoveProductVariantsFromChannelMutation;
-  export type RemoveProductVariantsFromChannel = NonNullable<(NonNullable<RemoveProductVariantsFromChannelMutation['removeProductVariantsFromChannel']>)[number]>;
+  export type RemoveProductVariantsFromChannel = NonNullable<
+    NonNullable<RemoveProductVariantsFromChannelMutation['removeProductVariantsFromChannel']>[number]
+  >;
 }
 
 export namespace UpdateAsset {
   export type Variables = UpdateAssetMutationVariables;
   export type Mutation = UpdateAssetMutation;
-  export type UpdateAsset = (NonNullable<UpdateAssetMutation['updateAsset']>);
-  export type AssetInlineFragment = ({ __typename: 'Asset' } & Pick<(NonNullable<UpdateAssetMutation['updateAsset']>), 'tags' | 'focalPoint'>);
-  export type Tags = NonNullable<(NonNullable<({ __typename: 'Asset' } & Pick<(NonNullable<UpdateAssetMutation['updateAsset']>), 'tags' | 'focalPoint'>)['tags']>)[number]>;
-  export type FocalPoint = (NonNullable<({ __typename: 'Asset' } & Pick<(NonNullable<UpdateAssetMutation['updateAsset']>), 'tags' | 'focalPoint'>)['focalPoint']>);
+  export type UpdateAsset = NonNullable<UpdateAssetMutation['updateAsset']>;
+  export type AssetInlineFragment = { __typename: 'Asset' } & Pick<
+    NonNullable<UpdateAssetMutation['updateAsset']>,
+    'tags' | 'focalPoint'
+  >;
+  export type Tags = NonNullable<
+    NonNullable<
+      ({ __typename: 'Asset' } & Pick<
+        NonNullable<UpdateAssetMutation['updateAsset']>,
+        'tags' | 'focalPoint'
+      >)['tags']
+    >[number]
+  >;
+  export type FocalPoint = NonNullable<
+    ({ __typename: 'Asset' } & Pick<
+      NonNullable<UpdateAssetMutation['updateAsset']>,
+      'tags' | 'focalPoint'
+    >)['focalPoint']
+  >;
 }
 
 export namespace DeleteAsset {
   export type Variables = DeleteAssetMutationVariables;
   export type Mutation = DeleteAssetMutation;
-  export type DeleteAsset = (NonNullable<DeleteAssetMutation['deleteAsset']>);
+  export type DeleteAsset = NonNullable<DeleteAssetMutation['deleteAsset']>;
 }
 
 export namespace UpdateChannel {
   export type Variables = UpdateChannelMutationVariables;
   export type Mutation = UpdateChannelMutation;
-  export type UpdateChannel = (NonNullable<UpdateChannelMutation['updateChannel']>);
-  export type LanguageNotAvailableErrorInlineFragment = (DiscriminateUnion<(NonNullable<UpdateChannelMutation['updateChannel']>), { __typename?: 'LanguageNotAvailableError' }>);
+  export type UpdateChannel = NonNullable<UpdateChannelMutation['updateChannel']>;
+  export type LanguageNotAvailableErrorInlineFragment = DiscriminateUnion<
+    NonNullable<UpdateChannelMutation['updateChannel']>,
+    { __typename?: 'LanguageNotAvailableError' }
+  >;
 }
 
 export namespace GetCustomerHistory {
   export type Variables = GetCustomerHistoryQueryVariables;
   export type Query = GetCustomerHistoryQuery;
-  export type Customer = (NonNullable<GetCustomerHistoryQuery['customer']>);
-  export type History = (NonNullable<(NonNullable<GetCustomerHistoryQuery['customer']>)['history']>);
-  export type Items = NonNullable<(NonNullable<(NonNullable<(NonNullable<GetCustomerHistoryQuery['customer']>)['history']>)['items']>)[number]>;
-  export type Administrator = (NonNullable<NonNullable<(NonNullable<(NonNullable<(NonNullable<GetCustomerHistoryQuery['customer']>)['history']>)['items']>)[number]>['administrator']>);
+  export type Customer = NonNullable<GetCustomerHistoryQuery['customer']>;
+  export type History = NonNullable<NonNullable<GetCustomerHistoryQuery['customer']>['history']>;
+  export type Items = NonNullable<
+    NonNullable<NonNullable<NonNullable<GetCustomerHistoryQuery['customer']>['history']>['items']>[number]
+  >;
+  export type Administrator = NonNullable<
+    NonNullable<
+      NonNullable<NonNullable<NonNullable<GetCustomerHistoryQuery['customer']>['history']>['items']>[number]
+    >['administrator']
+  >;
 }
 
 export namespace GetOrder {
   export type Variables = GetOrderQueryVariables;
   export type Query = GetOrderQuery;
-  export type Order = (NonNullable<GetOrderQuery['order']>);
+  export type Order = NonNullable<GetOrderQuery['order']>;
 }
 
 export namespace CreateCustomerGroup {
   export type Variables = CreateCustomerGroupMutationVariables;
   export type Mutation = CreateCustomerGroupMutation;
-  export type CreateCustomerGroup = (NonNullable<CreateCustomerGroupMutation['createCustomerGroup']>);
+  export type CreateCustomerGroup = NonNullable<CreateCustomerGroupMutation['createCustomerGroup']>;
 }
 
 export namespace RemoveCustomersFromGroup {
   export type Variables = RemoveCustomersFromGroupMutationVariables;
   export type Mutation = RemoveCustomersFromGroupMutation;
-  export type RemoveCustomersFromGroup = (NonNullable<RemoveCustomersFromGroupMutation['removeCustomersFromGroup']>);
+  export type RemoveCustomersFromGroup = NonNullable<
+    RemoveCustomersFromGroupMutation['removeCustomersFromGroup']
+  >;
 }
 
 export namespace CreateFulfillment {
   export type Variables = CreateFulfillmentMutationVariables;
   export type Mutation = CreateFulfillmentMutation;
-  export type AddFulfillmentToOrder = (NonNullable<CreateFulfillmentMutation['addFulfillmentToOrder']>);
-  export type ErrorResultInlineFragment = (DiscriminateUnion<(NonNullable<CreateFulfillmentMutation['addFulfillmentToOrder']>), { __typename?: 'ErrorResult' }>);
-  export type CreateFulfillmentErrorInlineFragment = (DiscriminateUnion<(NonNullable<CreateFulfillmentMutation['addFulfillmentToOrder']>), { __typename?: 'CreateFulfillmentError' }>);
+  export type AddFulfillmentToOrder = NonNullable<CreateFulfillmentMutation['addFulfillmentToOrder']>;
+  export type ErrorResultInlineFragment = DiscriminateUnion<
+    NonNullable<CreateFulfillmentMutation['addFulfillmentToOrder']>,
+    { __typename?: 'ErrorResult' }
+  >;
+  export type CreateFulfillmentErrorInlineFragment = DiscriminateUnion<
+    NonNullable<CreateFulfillmentMutation['addFulfillmentToOrder']>,
+    { __typename?: 'CreateFulfillmentError' }
+  >;
 }
 
 export namespace TransitFulfillment {
   export type Variables = TransitFulfillmentMutationVariables;
   export type Mutation = TransitFulfillmentMutation;
-  export type TransitionFulfillmentToState = (NonNullable<TransitFulfillmentMutation['transitionFulfillmentToState']>);
-  export type FulfillmentStateTransitionErrorInlineFragment = (DiscriminateUnion<(NonNullable<TransitFulfillmentMutation['transitionFulfillmentToState']>), { __typename?: 'FulfillmentStateTransitionError' }>);
+  export type TransitionFulfillmentToState = NonNullable<
+    TransitFulfillmentMutation['transitionFulfillmentToState']
+  >;
+  export type FulfillmentStateTransitionErrorInlineFragment = DiscriminateUnion<
+    NonNullable<TransitFulfillmentMutation['transitionFulfillmentToState']>,
+    { __typename?: 'FulfillmentStateTransitionError' }
+  >;
 }
 
 export namespace GetOrderFulfillments {
   export type Variables = GetOrderFulfillmentsQueryVariables;
   export type Query = GetOrderFulfillmentsQuery;
-  export type Order = (NonNullable<GetOrderFulfillmentsQuery['order']>);
-  export type Fulfillments = NonNullable<(NonNullable<(NonNullable<GetOrderFulfillmentsQuery['order']>)['fulfillments']>)[number]>;
-  export type Summary = NonNullable<(NonNullable<NonNullable<(NonNullable<(NonNullable<GetOrderFulfillmentsQuery['order']>)['fulfillments']>)[number]>['summary']>)[number]>;
-  export type OrderLine = (NonNullable<NonNullable<(NonNullable<NonNullable<(NonNullable<(NonNullable<GetOrderFulfillmentsQuery['order']>)['fulfillments']>)[number]>['summary']>)[number]>['orderLine']>);
+  export type Order = NonNullable<GetOrderFulfillmentsQuery['order']>;
+  export type Fulfillments = NonNullable<
+    NonNullable<NonNullable<GetOrderFulfillmentsQuery['order']>['fulfillments']>[number]
+  >;
+  export type Summary = NonNullable<
+    NonNullable<
+      NonNullable<
+        NonNullable<NonNullable<GetOrderFulfillmentsQuery['order']>['fulfillments']>[number]
+      >['summary']
+    >[number]
+  >;
+  export type OrderLine = NonNullable<
+    NonNullable<
+      NonNullable<
+        NonNullable<
+          NonNullable<NonNullable<GetOrderFulfillmentsQuery['order']>['fulfillments']>[number]
+        >['summary']
+      >[number]
+    >['orderLine']
+  >;
 }
 
 export namespace GetOrderList {
   export type Variables = GetOrderListQueryVariables;
   export type Query = GetOrderListQuery;
-  export type Orders = (NonNullable<GetOrderListQuery['orders']>);
-  export type Items = NonNullable<(NonNullable<(NonNullable<GetOrderListQuery['orders']>)['items']>)[number]>;
+  export type Orders = NonNullable<GetOrderListQuery['orders']>;
+  export type Items = NonNullable<NonNullable<NonNullable<GetOrderListQuery['orders']>['items']>[number]>;
 }
 
 export namespace CreateAddress {
   export type Variables = CreateAddressMutationVariables;
   export type Mutation = CreateAddressMutation;
-  export type CreateCustomerAddress = (NonNullable<CreateAddressMutation['createCustomerAddress']>);
-  export type Country = (NonNullable<(NonNullable<CreateAddressMutation['createCustomerAddress']>)['country']>);
+  export type CreateCustomerAddress = NonNullable<CreateAddressMutation['createCustomerAddress']>;
+  export type Country = NonNullable<NonNullable<CreateAddressMutation['createCustomerAddress']>['country']>;
 }
 
 export namespace UpdateAddress {
   export type Variables = UpdateAddressMutationVariables;
   export type Mutation = UpdateAddressMutation;
-  export type UpdateCustomerAddress = (NonNullable<UpdateAddressMutation['updateCustomerAddress']>);
-  export type Country = (NonNullable<(NonNullable<UpdateAddressMutation['updateCustomerAddress']>)['country']>);
+  export type UpdateCustomerAddress = NonNullable<UpdateAddressMutation['updateCustomerAddress']>;
+  export type Country = NonNullable<NonNullable<UpdateAddressMutation['updateCustomerAddress']>['country']>;
 }
 
 export namespace CreateCustomer {
   export type Variables = CreateCustomerMutationVariables;
   export type Mutation = CreateCustomerMutation;
-  export type CreateCustomer = (NonNullable<CreateCustomerMutation['createCustomer']>);
-  export type ErrorResultInlineFragment = (DiscriminateUnion<(NonNullable<CreateCustomerMutation['createCustomer']>), { __typename?: 'ErrorResult' }>);
+  export type CreateCustomer = NonNullable<CreateCustomerMutation['createCustomer']>;
+  export type ErrorResultInlineFragment = DiscriminateUnion<
+    NonNullable<CreateCustomerMutation['createCustomer']>,
+    { __typename?: 'ErrorResult' }
+  >;
 }
 
 export namespace UpdateCustomer {
   export type Variables = UpdateCustomerMutationVariables;
   export type Mutation = UpdateCustomerMutation;
-  export type UpdateCustomer = (NonNullable<UpdateCustomerMutation['updateCustomer']>);
-  export type ErrorResultInlineFragment = (DiscriminateUnion<(NonNullable<UpdateCustomerMutation['updateCustomer']>), { __typename?: 'ErrorResult' }>);
+  export type UpdateCustomer = NonNullable<UpdateCustomerMutation['updateCustomer']>;
+  export type ErrorResultInlineFragment = DiscriminateUnion<
+    NonNullable<UpdateCustomerMutation['updateCustomer']>,
+    { __typename?: 'ErrorResult' }
+  >;
 }
 
 export namespace DeleteCustomer {
   export type Variables = DeleteCustomerMutationVariables;
   export type Mutation = DeleteCustomerMutation;
-  export type DeleteCustomer = (NonNullable<DeleteCustomerMutation['deleteCustomer']>);
+  export type DeleteCustomer = NonNullable<DeleteCustomerMutation['deleteCustomer']>;
 }
 
 export namespace UpdateCustomerNote {
   export type Variables = UpdateCustomerNoteMutationVariables;
   export type Mutation = UpdateCustomerNoteMutation;
-  export type UpdateCustomerNote = (NonNullable<UpdateCustomerNoteMutation['updateCustomerNote']>);
+  export type UpdateCustomerNote = NonNullable<UpdateCustomerNoteMutation['updateCustomerNote']>;
 }
 
 export namespace DeleteCustomerNote {
   export type Variables = DeleteCustomerNoteMutationVariables;
   export type Mutation = DeleteCustomerNoteMutation;
-  export type DeleteCustomerNote = (NonNullable<DeleteCustomerNoteMutation['deleteCustomerNote']>);
+  export type DeleteCustomerNote = NonNullable<DeleteCustomerNoteMutation['deleteCustomerNote']>;
 }
 
 export namespace UpdateCustomerGroup {
   export type Variables = UpdateCustomerGroupMutationVariables;
   export type Mutation = UpdateCustomerGroupMutation;
-  export type UpdateCustomerGroup = (NonNullable<UpdateCustomerGroupMutation['updateCustomerGroup']>);
+  export type UpdateCustomerGroup = NonNullable<UpdateCustomerGroupMutation['updateCustomerGroup']>;
 }
 
 export namespace DeleteCustomerGroup {
   export type Variables = DeleteCustomerGroupMutationVariables;
   export type Mutation = DeleteCustomerGroupMutation;
-  export type DeleteCustomerGroup = (NonNullable<DeleteCustomerGroupMutation['deleteCustomerGroup']>);
+  export type DeleteCustomerGroup = NonNullable<DeleteCustomerGroupMutation['deleteCustomerGroup']>;
 }
 
 export namespace GetCustomerGroups {
   export type Variables = GetCustomerGroupsQueryVariables;
   export type Query = GetCustomerGroupsQuery;
-  export type CustomerGroups = (NonNullable<GetCustomerGroupsQuery['customerGroups']>);
-  export type Items = NonNullable<(NonNullable<(NonNullable<GetCustomerGroupsQuery['customerGroups']>)['items']>)[number]>;
+  export type CustomerGroups = NonNullable<GetCustomerGroupsQuery['customerGroups']>;
+  export type Items = NonNullable<
+    NonNullable<NonNullable<GetCustomerGroupsQuery['customerGroups']>['items']>[number]
+  >;
 }
 
 export namespace GetCustomerGroup {
   export type Variables = GetCustomerGroupQueryVariables;
   export type Query = GetCustomerGroupQuery;
-  export type CustomerGroup = (NonNullable<GetCustomerGroupQuery['customerGroup']>);
-  export type Customers = (NonNullable<(NonNullable<GetCustomerGroupQuery['customerGroup']>)['customers']>);
-  export type Items = NonNullable<(NonNullable<(NonNullable<(NonNullable<GetCustomerGroupQuery['customerGroup']>)['customers']>)['items']>)[number]>;
+  export type CustomerGroup = NonNullable<GetCustomerGroupQuery['customerGroup']>;
+  export type Customers = NonNullable<NonNullable<GetCustomerGroupQuery['customerGroup']>['customers']>;
+  export type Items = NonNullable<
+    NonNullable<
+      NonNullable<NonNullable<GetCustomerGroupQuery['customerGroup']>['customers']>['items']
+    >[number]
+  >;
 }
 
 export namespace AddCustomersToGroup {
   export type Variables = AddCustomersToGroupMutationVariables;
   export type Mutation = AddCustomersToGroupMutation;
-  export type AddCustomersToGroup = (NonNullable<AddCustomersToGroupMutation['addCustomersToGroup']>);
+  export type AddCustomersToGroup = NonNullable<AddCustomersToGroupMutation['addCustomersToGroup']>;
 }
 
 export namespace GetCustomerWithGroups {
   export type Variables = GetCustomerWithGroupsQueryVariables;
   export type Query = GetCustomerWithGroupsQuery;
-  export type Customer = (NonNullable<GetCustomerWithGroupsQuery['customer']>);
-  export type Groups = NonNullable<(NonNullable<(NonNullable<GetCustomerWithGroupsQuery['customer']>)['groups']>)[number]>;
+  export type Customer = NonNullable<GetCustomerWithGroupsQuery['customer']>;
+  export type Groups = NonNullable<
+    NonNullable<NonNullable<GetCustomerWithGroupsQuery['customer']>['groups']>[number]
+  >;
 }
 
 export namespace AdminTransition {
   export type Variables = AdminTransitionMutationVariables;
   export type Mutation = AdminTransitionMutation;
-  export type TransitionOrderToState = (NonNullable<AdminTransitionMutation['transitionOrderToState']>);
-  export type OrderStateTransitionErrorInlineFragment = (DiscriminateUnion<(NonNullable<AdminTransitionMutation['transitionOrderToState']>), { __typename?: 'OrderStateTransitionError' }>);
+  export type TransitionOrderToState = NonNullable<AdminTransitionMutation['transitionOrderToState']>;
+  export type OrderStateTransitionErrorInlineFragment = DiscriminateUnion<
+    NonNullable<AdminTransitionMutation['transitionOrderToState']>,
+    { __typename?: 'OrderStateTransitionError' }
+  >;
 }
 
 export namespace CancelOrder {
   export type Variables = CancelOrderMutationVariables;
   export type Mutation = CancelOrderMutation;
-  export type CancelOrder = (NonNullable<CancelOrderMutation['cancelOrder']>);
-  export type ErrorResultInlineFragment = (DiscriminateUnion<(NonNullable<CancelOrderMutation['cancelOrder']>), { __typename?: 'ErrorResult' }>);
+  export type CancelOrder = NonNullable<CancelOrderMutation['cancelOrder']>;
+  export type ErrorResultInlineFragment = DiscriminateUnion<
+    NonNullable<CancelOrderMutation['cancelOrder']>,
+    { __typename?: 'ErrorResult' }
+  >;
 }
 
 export namespace CanceledOrder {
   export type Fragment = CanceledOrderFragment;
-  export type Lines = NonNullable<(NonNullable<CanceledOrderFragment['lines']>)[number]>;
-  export type Items = NonNullable<(NonNullable<NonNullable<(NonNullable<CanceledOrderFragment['lines']>)[number]>['items']>)[number]>;
+  export type Lines = NonNullable<NonNullable<CanceledOrderFragment['lines']>[number]>;
+  export type Items = NonNullable<
+    NonNullable<NonNullable<NonNullable<CanceledOrderFragment['lines']>[number]>['items']>[number]
+  >;
 }
 
 export namespace UpdateGlobalSettings {
   export type Variables = UpdateGlobalSettingsMutationVariables;
   export type Mutation = UpdateGlobalSettingsMutation;
-  export type UpdateGlobalSettings = (NonNullable<UpdateGlobalSettingsMutation['updateGlobalSettings']>);
-  export type ErrorResultInlineFragment = (DiscriminateUnion<(NonNullable<UpdateGlobalSettingsMutation['updateGlobalSettings']>), { __typename?: 'ErrorResult' }>);
+  export type UpdateGlobalSettings = NonNullable<UpdateGlobalSettingsMutation['updateGlobalSettings']>;
+  export type ErrorResultInlineFragment = DiscriminateUnion<
+    NonNullable<UpdateGlobalSettingsMutation['updateGlobalSettings']>,
+    { __typename?: 'ErrorResult' }
+  >;
 }
 
 export namespace UpdateRole {
   export type Variables = UpdateRoleMutationVariables;
   export type Mutation = UpdateRoleMutation;
-  export type UpdateRole = (NonNullable<UpdateRoleMutation['updateRole']>);
+  export type UpdateRole = NonNullable<UpdateRoleMutation['updateRole']>;
 }
 
 export namespace GetProductsWithVariantPrices {
   export type Variables = GetProductsWithVariantPricesQueryVariables;
   export type Query = GetProductsWithVariantPricesQuery;
-  export type Products = (NonNullable<GetProductsWithVariantPricesQuery['products']>);
-  export type Items = NonNullable<(NonNullable<(NonNullable<GetProductsWithVariantPricesQuery['products']>)['items']>)[number]>;
-  export type Variants = NonNullable<(NonNullable<NonNullable<(NonNullable<(NonNullable<GetProductsWithVariantPricesQuery['products']>)['items']>)[number]>['variants']>)[number]>;
-  export type FacetValues = NonNullable<(NonNullable<NonNullable<(NonNullable<NonNullable<(NonNullable<(NonNullable<GetProductsWithVariantPricesQuery['products']>)['items']>)[number]>['variants']>)[number]>['facetValues']>)[number]>;
+  export type Products = NonNullable<GetProductsWithVariantPricesQuery['products']>;
+  export type Items = NonNullable<
+    NonNullable<NonNullable<GetProductsWithVariantPricesQuery['products']>['items']>[number]
+  >;
+  export type Variants = NonNullable<
+    NonNullable<
+      NonNullable<
+        NonNullable<NonNullable<GetProductsWithVariantPricesQuery['products']>['items']>[number]
+      >['variants']
+    >[number]
+  >;
+  export type FacetValues = NonNullable<
+    NonNullable<
+      NonNullable<
+        NonNullable<
+          NonNullable<
+            NonNullable<NonNullable<GetProductsWithVariantPricesQuery['products']>['items']>[number]
+          >['variants']
+        >[number]
+      >['facetValues']
+    >[number]
+  >;
 }
 
 export namespace CreateProductOptionGroup {
   export type Variables = CreateProductOptionGroupMutationVariables;
   export type Mutation = CreateProductOptionGroupMutation;
-  export type CreateProductOptionGroup = (NonNullable<CreateProductOptionGroupMutation['createProductOptionGroup']>);
+  export type CreateProductOptionGroup = NonNullable<
+    CreateProductOptionGroupMutation['createProductOptionGroup']
+  >;
 }
 
 export namespace AddOptionGroupToProduct {
   export type Variables = AddOptionGroupToProductMutationVariables;
   export type Mutation = AddOptionGroupToProductMutation;
-  export type AddOptionGroupToProduct = (NonNullable<AddOptionGroupToProductMutation['addOptionGroupToProduct']>);
+  export type AddOptionGroupToProduct = NonNullable<
+    AddOptionGroupToProductMutation['addOptionGroupToProduct']
+  >;
 }
 
 export namespace CreateShippingMethod {
   export type Variables = CreateShippingMethodMutationVariables;
   export type Mutation = CreateShippingMethodMutation;
-  export type CreateShippingMethod = (NonNullable<CreateShippingMethodMutation['createShippingMethod']>);
+  export type CreateShippingMethod = NonNullable<CreateShippingMethodMutation['createShippingMethod']>;
 }
 
 export namespace SettlePayment {
   export type Variables = SettlePaymentMutationVariables;
   export type Mutation = SettlePaymentMutation;
-  export type SettlePayment = (NonNullable<SettlePaymentMutation['settlePayment']>);
-  export type ErrorResultInlineFragment = (DiscriminateUnion<(NonNullable<SettlePaymentMutation['settlePayment']>), { __typename?: 'ErrorResult' }>);
-  export type SettlePaymentErrorInlineFragment = (DiscriminateUnion<(NonNullable<SettlePaymentMutation['settlePayment']>), { __typename?: 'SettlePaymentError' }>);
+  export type SettlePayment = NonNullable<SettlePaymentMutation['settlePayment']>;
+  export type ErrorResultInlineFragment = DiscriminateUnion<
+    NonNullable<SettlePaymentMutation['settlePayment']>,
+    { __typename?: 'ErrorResult' }
+  >;
+  export type SettlePaymentErrorInlineFragment = DiscriminateUnion<
+    NonNullable<SettlePaymentMutation['settlePayment']>,
+    { __typename?: 'SettlePaymentError' }
+  >;
 }
 
 export namespace GetOrderHistory {
   export type Variables = GetOrderHistoryQueryVariables;
   export type Query = GetOrderHistoryQuery;
-  export type Order = (NonNullable<GetOrderHistoryQuery['order']>);
-  export type History = (NonNullable<(NonNullable<GetOrderHistoryQuery['order']>)['history']>);
-  export type Items = NonNullable<(NonNullable<(NonNullable<(NonNullable<GetOrderHistoryQuery['order']>)['history']>)['items']>)[number]>;
-  export type Administrator = (NonNullable<NonNullable<(NonNullable<(NonNullable<(NonNullable<GetOrderHistoryQuery['order']>)['history']>)['items']>)[number]>['administrator']>);
+  export type Order = NonNullable<GetOrderHistoryQuery['order']>;
+  export type History = NonNullable<NonNullable<GetOrderHistoryQuery['order']>['history']>;
+  export type Items = NonNullable<
+    NonNullable<NonNullable<NonNullable<GetOrderHistoryQuery['order']>['history']>['items']>[number]
+  >;
+  export type Administrator = NonNullable<
+    NonNullable<
+      NonNullable<NonNullable<NonNullable<GetOrderHistoryQuery['order']>['history']>['items']>[number]
+    >['administrator']
+  >;
 }
 
 export namespace UpdateShippingMethod {
   export type Variables = UpdateShippingMethodMutationVariables;
   export type Mutation = UpdateShippingMethodMutation;
-  export type UpdateShippingMethod = (NonNullable<UpdateShippingMethodMutation['updateShippingMethod']>);
+  export type UpdateShippingMethod = NonNullable<UpdateShippingMethodMutation['updateShippingMethod']>;
 }
 
 export namespace GetAsset {
   export type Variables = GetAssetQueryVariables;
   export type Query = GetAssetQuery;
-  export type Asset = (NonNullable<GetAssetQuery['asset']>);
+  export type Asset = NonNullable<GetAssetQuery['asset']>;
 }
 
 export namespace AssetFragFirst {
@@ -8973,186 +10078,278 @@ export namespace AssetFragFirst {
 export namespace GetAssetFragmentFirst {
   export type Variables = GetAssetFragmentFirstQueryVariables;
   export type Query = GetAssetFragmentFirstQuery;
-  export type Asset = (NonNullable<GetAssetFragmentFirstQuery['asset']>);
+  export type Asset = NonNullable<GetAssetFragmentFirstQuery['asset']>;
 }
 
 export namespace CreateAssets {
   export type Variables = CreateAssetsMutationVariables;
   export type Mutation = CreateAssetsMutation;
-  export type CreateAssets = NonNullable<(NonNullable<CreateAssetsMutation['createAssets']>)[number]>;
-  export type AssetInlineFragment = (DiscriminateUnion<NonNullable<(NonNullable<CreateAssetsMutation['createAssets']>)[number]>, { __typename?: 'Asset' }>);
-  export type FocalPoint = (NonNullable<(DiscriminateUnion<NonNullable<(NonNullable<CreateAssetsMutation['createAssets']>)[number]>, { __typename?: 'Asset' }>)['focalPoint']>);
-  export type Tags = NonNullable<(NonNullable<(DiscriminateUnion<NonNullable<(NonNullable<CreateAssetsMutation['createAssets']>)[number]>, { __typename?: 'Asset' }>)['tags']>)[number]>;
-  export type MimeTypeErrorInlineFragment = (DiscriminateUnion<NonNullable<(NonNullable<CreateAssetsMutation['createAssets']>)[number]>, { __typename?: 'MimeTypeError' }>);
+  export type CreateAssets = NonNullable<NonNullable<CreateAssetsMutation['createAssets']>[number]>;
+  export type AssetInlineFragment = DiscriminateUnion<
+    NonNullable<NonNullable<CreateAssetsMutation['createAssets']>[number]>,
+    { __typename?: 'Asset' }
+  >;
+  export type FocalPoint = NonNullable<
+    DiscriminateUnion<
+      NonNullable<NonNullable<CreateAssetsMutation['createAssets']>[number]>,
+      { __typename?: 'Asset' }
+    >['focalPoint']
+  >;
+  export type Tags = NonNullable<
+    NonNullable<
+      DiscriminateUnion<
+        NonNullable<NonNullable<CreateAssetsMutation['createAssets']>[number]>,
+        { __typename?: 'Asset' }
+      >['tags']
+    >[number]
+  >;
+  export type MimeTypeErrorInlineFragment = DiscriminateUnion<
+    NonNullable<NonNullable<CreateAssetsMutation['createAssets']>[number]>,
+    { __typename?: 'MimeTypeError' }
+  >;
 }
 
 export namespace DeleteShippingMethod {
   export type Variables = DeleteShippingMethodMutationVariables;
   export type Mutation = DeleteShippingMethodMutation;
-  export type DeleteShippingMethod = (NonNullable<DeleteShippingMethodMutation['deleteShippingMethod']>);
+  export type DeleteShippingMethod = NonNullable<DeleteShippingMethodMutation['deleteShippingMethod']>;
 }
 
 export namespace AssignPromotionToChannel {
   export type Variables = AssignPromotionToChannelMutationVariables;
   export type Mutation = AssignPromotionToChannelMutation;
-  export type AssignPromotionsToChannel = NonNullable<(NonNullable<AssignPromotionToChannelMutation['assignPromotionsToChannel']>)[number]>;
+  export type AssignPromotionsToChannel = NonNullable<
+    NonNullable<AssignPromotionToChannelMutation['assignPromotionsToChannel']>[number]
+  >;
 }
 
 export namespace RemovePromotionFromChannel {
   export type Variables = RemovePromotionFromChannelMutationVariables;
   export type Mutation = RemovePromotionFromChannelMutation;
-  export type RemovePromotionsFromChannel = NonNullable<(NonNullable<RemovePromotionFromChannelMutation['removePromotionsFromChannel']>)[number]>;
+  export type RemovePromotionsFromChannel = NonNullable<
+    NonNullable<RemovePromotionFromChannelMutation['removePromotionsFromChannel']>[number]
+  >;
 }
 
 export namespace GetTaxRates {
   export type Variables = GetTaxRatesQueryVariables;
   export type Query = GetTaxRatesQuery;
-  export type TaxRates = (NonNullable<GetTaxRatesQuery['taxRates']>);
-  export type Items = NonNullable<(NonNullable<(NonNullable<GetTaxRatesQuery['taxRates']>)['items']>)[number]>;
+  export type TaxRates = NonNullable<GetTaxRatesQuery['taxRates']>;
+  export type Items = NonNullable<NonNullable<NonNullable<GetTaxRatesQuery['taxRates']>['items']>[number]>;
 }
 
 export namespace GetShippingMethodList {
   export type Variables = GetShippingMethodListQueryVariables;
   export type Query = GetShippingMethodListQuery;
-  export type ShippingMethods = (NonNullable<GetShippingMethodListQuery['shippingMethods']>);
-  export type Items = NonNullable<(NonNullable<(NonNullable<GetShippingMethodListQuery['shippingMethods']>)['items']>)[number]>;
+  export type ShippingMethods = NonNullable<GetShippingMethodListQuery['shippingMethods']>;
+  export type Items = NonNullable<
+    NonNullable<NonNullable<GetShippingMethodListQuery['shippingMethods']>['items']>[number]
+  >;
 }
 
 export namespace GetCollections {
   export type Variables = GetCollectionsQueryVariables;
   export type Query = GetCollectionsQuery;
-  export type Collections = (NonNullable<GetCollectionsQuery['collections']>);
-  export type Items = NonNullable<(NonNullable<(NonNullable<GetCollectionsQuery['collections']>)['items']>)[number]>;
-  export type Parent = (NonNullable<NonNullable<(NonNullable<(NonNullable<GetCollectionsQuery['collections']>)['items']>)[number]>['parent']>);
+  export type Collections = NonNullable<GetCollectionsQuery['collections']>;
+  export type Items = NonNullable<
+    NonNullable<NonNullable<GetCollectionsQuery['collections']>['items']>[number]
+  >;
+  export type Parent = NonNullable<
+    NonNullable<NonNullable<NonNullable<GetCollectionsQuery['collections']>['items']>[number]>['parent']
+  >;
 }
 
 export namespace TransitionPaymentToState {
   export type Variables = TransitionPaymentToStateMutationVariables;
   export type Mutation = TransitionPaymentToStateMutation;
-  export type TransitionPaymentToState = (NonNullable<TransitionPaymentToStateMutation['transitionPaymentToState']>);
-  export type ErrorResultInlineFragment = (DiscriminateUnion<(NonNullable<TransitionPaymentToStateMutation['transitionPaymentToState']>), { __typename?: 'ErrorResult' }>);
-  export type PaymentStateTransitionErrorInlineFragment = (DiscriminateUnion<(NonNullable<TransitionPaymentToStateMutation['transitionPaymentToState']>), { __typename?: 'PaymentStateTransitionError' }>);
+  export type TransitionPaymentToState = NonNullable<
+    TransitionPaymentToStateMutation['transitionPaymentToState']
+  >;
+  export type ErrorResultInlineFragment = DiscriminateUnion<
+    NonNullable<TransitionPaymentToStateMutation['transitionPaymentToState']>,
+    { __typename?: 'ErrorResult' }
+  >;
+  export type PaymentStateTransitionErrorInlineFragment = DiscriminateUnion<
+    NonNullable<TransitionPaymentToStateMutation['transitionPaymentToState']>,
+    { __typename?: 'PaymentStateTransitionError' }
+  >;
 }
 
 export namespace GetProductVariantList {
   export type Variables = GetProductVariantListQueryVariables;
   export type Query = GetProductVariantListQuery;
-  export type ProductVariants = (NonNullable<GetProductVariantListQuery['productVariants']>);
-  export type Items = NonNullable<(NonNullable<(NonNullable<GetProductVariantListQuery['productVariants']>)['items']>)[number]>;
+  export type ProductVariants = NonNullable<GetProductVariantListQuery['productVariants']>;
+  export type Items = NonNullable<
+    NonNullable<NonNullable<GetProductVariantListQuery['productVariants']>['items']>[number]
+  >;
 }
 
 export namespace DeletePromotion {
   export type Variables = DeletePromotionMutationVariables;
   export type Mutation = DeletePromotionMutation;
-  export type DeletePromotion = (NonNullable<DeletePromotionMutation['deletePromotion']>);
+  export type DeletePromotion = NonNullable<DeletePromotionMutation['deletePromotion']>;
 }
 
 export namespace GetChannels {
   export type Variables = GetChannelsQueryVariables;
   export type Query = GetChannelsQuery;
-  export type Channels = NonNullable<(NonNullable<GetChannelsQuery['channels']>)[number]>;
+  export type Channels = NonNullable<NonNullable<GetChannelsQuery['channels']>[number]>;
 }
 
 export namespace UpdateAdministrator {
   export type Variables = UpdateAdministratorMutationVariables;
   export type Mutation = UpdateAdministratorMutation;
-  export type UpdateAdministrator = (NonNullable<UpdateAdministratorMutation['updateAdministrator']>);
+  export type UpdateAdministrator = NonNullable<UpdateAdministratorMutation['updateAdministrator']>;
 }
 
 export namespace CancelJob {
   export type Variables = CancelJobMutationVariables;
   export type Mutation = CancelJobMutation;
-  export type CancelJob = (NonNullable<CancelJobMutation['cancelJob']>);
+  export type CancelJob = NonNullable<CancelJobMutation['cancelJob']>;
 }
 
 export namespace UpdateOptionGroup {
   export type Variables = UpdateOptionGroupMutationVariables;
   export type Mutation = UpdateOptionGroupMutation;
-  export type UpdateProductOptionGroup = (NonNullable<UpdateOptionGroupMutation['updateProductOptionGroup']>);
+  export type UpdateProductOptionGroup = NonNullable<UpdateOptionGroupMutation['updateProductOptionGroup']>;
 }
 
 export namespace GetFulfillmentHandlers {
   export type Variables = GetFulfillmentHandlersQueryVariables;
   export type Query = GetFulfillmentHandlersQuery;
-  export type FulfillmentHandlers = NonNullable<(NonNullable<GetFulfillmentHandlersQuery['fulfillmentHandlers']>)[number]>;
-  export type Args = NonNullable<(NonNullable<NonNullable<(NonNullable<GetFulfillmentHandlersQuery['fulfillmentHandlers']>)[number]>['args']>)[number]>;
+  export type FulfillmentHandlers = NonNullable<
+    NonNullable<GetFulfillmentHandlersQuery['fulfillmentHandlers']>[number]
+  >;
+  export type Args = NonNullable<
+    NonNullable<
+      NonNullable<NonNullable<GetFulfillmentHandlersQuery['fulfillmentHandlers']>[number]>['args']
+    >[number]
+  >;
 }
 
 export namespace OrderWithModifications {
   export type Fragment = OrderWithModificationsFragment;
-  export type Lines = NonNullable<(NonNullable<OrderWithModificationsFragment['lines']>)[number]>;
-  export type Discounts = NonNullable<(NonNullable<NonNullable<(NonNullable<OrderWithModificationsFragment['lines']>)[number]>['discounts']>)[number]>;
-  export type ProductVariant = (NonNullable<NonNullable<(NonNullable<OrderWithModificationsFragment['lines']>)[number]>['productVariant']>);
-  export type Items = NonNullable<(NonNullable<NonNullable<(NonNullable<OrderWithModificationsFragment['lines']>)[number]>['items']>)[number]>;
-  export type Surcharges = NonNullable<(NonNullable<OrderWithModificationsFragment['surcharges']>)[number]>;
-  export type Payments = NonNullable<(NonNullable<OrderWithModificationsFragment['payments']>)[number]>;
-  export type Refunds = NonNullable<(NonNullable<NonNullable<(NonNullable<OrderWithModificationsFragment['payments']>)[number]>['refunds']>)[number]>;
-  export type Modifications = NonNullable<(NonNullable<OrderWithModificationsFragment['modifications']>)[number]>;
-  export type OrderItems = NonNullable<(NonNullable<NonNullable<(NonNullable<OrderWithModificationsFragment['modifications']>)[number]>['orderItems']>)[number]>;
-  export type _Surcharges = NonNullable<(NonNullable<NonNullable<(NonNullable<OrderWithModificationsFragment['modifications']>)[number]>['surcharges']>)[number]>;
-  export type Payment = (NonNullable<NonNullable<(NonNullable<OrderWithModificationsFragment['modifications']>)[number]>['payment']>);
-  export type Refund = (NonNullable<NonNullable<(NonNullable<OrderWithModificationsFragment['modifications']>)[number]>['refund']>);
-  export type Promotions = NonNullable<(NonNullable<OrderWithModificationsFragment['promotions']>)[number]>;
-  export type _Discounts = NonNullable<(NonNullable<OrderWithModificationsFragment['discounts']>)[number]>;
-  export type ShippingAddress = (NonNullable<OrderWithModificationsFragment['shippingAddress']>);
-  export type BillingAddress = (NonNullable<OrderWithModificationsFragment['billingAddress']>);
+  export type Lines = NonNullable<NonNullable<OrderWithModificationsFragment['lines']>[number]>;
+  export type Discounts = NonNullable<
+    NonNullable<
+      NonNullable<NonNullable<OrderWithModificationsFragment['lines']>[number]>['discounts']
+    >[number]
+  >;
+  export type ProductVariant = NonNullable<
+    NonNullable<NonNullable<OrderWithModificationsFragment['lines']>[number]>['productVariant']
+  >;
+  export type Items = NonNullable<
+    NonNullable<NonNullable<NonNullable<OrderWithModificationsFragment['lines']>[number]>['items']>[number]
+  >;
+  export type Surcharges = NonNullable<NonNullable<OrderWithModificationsFragment['surcharges']>[number]>;
+  export type Payments = NonNullable<NonNullable<OrderWithModificationsFragment['payments']>[number]>;
+  export type Refunds = NonNullable<
+    NonNullable<
+      NonNullable<NonNullable<OrderWithModificationsFragment['payments']>[number]>['refunds']
+    >[number]
+  >;
+  export type Modifications = NonNullable<
+    NonNullable<OrderWithModificationsFragment['modifications']>[number]
+  >;
+  export type OrderItems = NonNullable<
+    NonNullable<
+      NonNullable<NonNullable<OrderWithModificationsFragment['modifications']>[number]>['orderItems']
+    >[number]
+  >;
+  export type _Surcharges = NonNullable<
+    NonNullable<
+      NonNullable<NonNullable<OrderWithModificationsFragment['modifications']>[number]>['surcharges']
+    >[number]
+  >;
+  export type Payment = NonNullable<
+    NonNullable<NonNullable<OrderWithModificationsFragment['modifications']>[number]>['payment']
+  >;
+  export type Refund = NonNullable<
+    NonNullable<NonNullable<OrderWithModificationsFragment['modifications']>[number]>['refund']
+  >;
+  export type Promotions = NonNullable<NonNullable<OrderWithModificationsFragment['promotions']>[number]>;
+  export type _Discounts = NonNullable<NonNullable<OrderWithModificationsFragment['discounts']>[number]>;
+  export type ShippingAddress = NonNullable<OrderWithModificationsFragment['shippingAddress']>;
+  export type BillingAddress = NonNullable<OrderWithModificationsFragment['billingAddress']>;
 }
 
 export namespace GetOrderWithModifications {
   export type Variables = GetOrderWithModificationsQueryVariables;
   export type Query = GetOrderWithModificationsQuery;
-  export type Order = (NonNullable<GetOrderWithModificationsQuery['order']>);
+  export type Order = NonNullable<GetOrderWithModificationsQuery['order']>;
 }
 
 export namespace ModifyOrder {
   export type Variables = ModifyOrderMutationVariables;
   export type Mutation = ModifyOrderMutation;
-  export type ModifyOrder = (NonNullable<ModifyOrderMutation['modifyOrder']>);
-  export type ErrorResultInlineFragment = (DiscriminateUnion<(NonNullable<ModifyOrderMutation['modifyOrder']>), { __typename?: 'ErrorResult' }>);
+  export type ModifyOrder = NonNullable<ModifyOrderMutation['modifyOrder']>;
+  export type ErrorResultInlineFragment = DiscriminateUnion<
+    NonNullable<ModifyOrderMutation['modifyOrder']>,
+    { __typename?: 'ErrorResult' }
+  >;
 }
 
 export namespace AddManualPayment {
   export type Variables = AddManualPaymentMutationVariables;
   export type Mutation = AddManualPaymentMutation;
-  export type AddManualPaymentToOrder = (NonNullable<AddManualPaymentMutation['addManualPaymentToOrder']>);
-  export type ErrorResultInlineFragment = (DiscriminateUnion<(NonNullable<AddManualPaymentMutation['addManualPaymentToOrder']>), { __typename?: 'ErrorResult' }>);
+  export type AddManualPaymentToOrder = NonNullable<AddManualPaymentMutation['addManualPaymentToOrder']>;
+  export type ErrorResultInlineFragment = DiscriminateUnion<
+    NonNullable<AddManualPaymentMutation['addManualPaymentToOrder']>,
+    { __typename?: 'ErrorResult' }
+  >;
 }
 
 export namespace DeletePromotionAdHoc1 {
   export type Variables = DeletePromotionAdHoc1MutationVariables;
   export type Mutation = DeletePromotionAdHoc1Mutation;
-  export type DeletePromotion = (NonNullable<DeletePromotionAdHoc1Mutation['deletePromotion']>);
+  export type DeletePromotion = NonNullable<DeletePromotionAdHoc1Mutation['deletePromotion']>;
 }
 
 export namespace GetTaxRateList {
   export type Variables = GetTaxRateListQueryVariables;
   export type Query = GetTaxRateListQuery;
-  export type TaxRates = (NonNullable<GetTaxRateListQuery['taxRates']>);
-  export type Items = NonNullable<(NonNullable<(NonNullable<GetTaxRateListQuery['taxRates']>)['items']>)[number]>;
-  export type Category = (NonNullable<NonNullable<(NonNullable<(NonNullable<GetTaxRateListQuery['taxRates']>)['items']>)[number]>['category']>);
-  export type Zone = (NonNullable<NonNullable<(NonNullable<(NonNullable<GetTaxRateListQuery['taxRates']>)['items']>)[number]>['zone']>);
+  export type TaxRates = NonNullable<GetTaxRateListQuery['taxRates']>;
+  export type Items = NonNullable<NonNullable<NonNullable<GetTaxRateListQuery['taxRates']>['items']>[number]>;
+  export type Category = NonNullable<
+    NonNullable<NonNullable<NonNullable<GetTaxRateListQuery['taxRates']>['items']>[number]>['category']
+  >;
+  export type Zone = NonNullable<
+    NonNullable<NonNullable<NonNullable<GetTaxRateListQuery['taxRates']>['items']>[number]>['zone']
+  >;
 }
 
 export namespace GetOrderWithLineCalculatedProps {
   export type Variables = GetOrderWithLineCalculatedPropsQueryVariables;
   export type Query = GetOrderWithLineCalculatedPropsQuery;
-  export type Order = (NonNullable<GetOrderWithLineCalculatedPropsQuery['order']>);
-  export type Lines = NonNullable<(NonNullable<(NonNullable<GetOrderWithLineCalculatedPropsQuery['order']>)['lines']>)[number]>;
+  export type Order = NonNullable<GetOrderWithLineCalculatedPropsQuery['order']>;
+  export type Lines = NonNullable<
+    NonNullable<NonNullable<GetOrderWithLineCalculatedPropsQuery['order']>['lines']>[number]
+  >;
 }
 
 export namespace GetOrderListFulfillments {
   export type Variables = GetOrderListFulfillmentsQueryVariables;
   export type Query = GetOrderListFulfillmentsQuery;
-  export type Orders = (NonNullable<GetOrderListFulfillmentsQuery['orders']>);
-  export type Items = NonNullable<(NonNullable<(NonNullable<GetOrderListFulfillmentsQuery['orders']>)['items']>)[number]>;
-  export type Fulfillments = NonNullable<(NonNullable<NonNullable<(NonNullable<(NonNullable<GetOrderListFulfillmentsQuery['orders']>)['items']>)[number]>['fulfillments']>)[number]>;
+  export type Orders = NonNullable<GetOrderListFulfillmentsQuery['orders']>;
+  export type Items = NonNullable<
+    NonNullable<NonNullable<GetOrderListFulfillmentsQuery['orders']>['items']>[number]
+  >;
+  export type Fulfillments = NonNullable<
+    NonNullable<
+      NonNullable<
+        NonNullable<NonNullable<GetOrderListFulfillmentsQuery['orders']>['items']>[number]
+      >['fulfillments']
+    >[number]
+  >;
 }
 
 export namespace GetOrderFulfillmentItems {
   export type Variables = GetOrderFulfillmentItemsQueryVariables;
   export type Query = GetOrderFulfillmentItemsQuery;
-  export type Order = (NonNullable<GetOrderFulfillmentItemsQuery['order']>);
-  export type Fulfillments = NonNullable<(NonNullable<(NonNullable<GetOrderFulfillmentItemsQuery['order']>)['fulfillments']>)[number]>;
+  export type Order = NonNullable<GetOrderFulfillmentItemsQuery['order']>;
+  export type Fulfillments = NonNullable<
+    NonNullable<NonNullable<GetOrderFulfillmentItemsQuery['order']>['fulfillments']>[number]
+  >;
 }
 
 export namespace Refund {
@@ -9162,511 +10359,679 @@ export namespace Refund {
 export namespace RefundOrder {
   export type Variables = RefundOrderMutationVariables;
   export type Mutation = RefundOrderMutation;
-  export type RefundOrder = (NonNullable<RefundOrderMutation['refundOrder']>);
-  export type ErrorResultInlineFragment = (DiscriminateUnion<(NonNullable<RefundOrderMutation['refundOrder']>), { __typename?: 'ErrorResult' }>);
+  export type RefundOrder = NonNullable<RefundOrderMutation['refundOrder']>;
+  export type ErrorResultInlineFragment = DiscriminateUnion<
+    NonNullable<RefundOrderMutation['refundOrder']>,
+    { __typename?: 'ErrorResult' }
+  >;
 }
 
 export namespace SettleRefund {
   export type Variables = SettleRefundMutationVariables;
   export type Mutation = SettleRefundMutation;
-  export type SettleRefund = (NonNullable<SettleRefundMutation['settleRefund']>);
-  export type ErrorResultInlineFragment = (DiscriminateUnion<(NonNullable<SettleRefundMutation['settleRefund']>), { __typename?: 'ErrorResult' }>);
+  export type SettleRefund = NonNullable<SettleRefundMutation['settleRefund']>;
+  export type ErrorResultInlineFragment = DiscriminateUnion<
+    NonNullable<SettleRefundMutation['settleRefund']>,
+    { __typename?: 'ErrorResult' }
+  >;
 }
 
 export namespace AddNoteToOrder {
   export type Variables = AddNoteToOrderMutationVariables;
   export type Mutation = AddNoteToOrderMutation;
-  export type AddNoteToOrder = (NonNullable<AddNoteToOrderMutation['addNoteToOrder']>);
+  export type AddNoteToOrder = NonNullable<AddNoteToOrderMutation['addNoteToOrder']>;
 }
 
 export namespace UpdateOrderNote {
   export type Variables = UpdateOrderNoteMutationVariables;
   export type Mutation = UpdateOrderNoteMutation;
-  export type UpdateOrderNote = (NonNullable<UpdateOrderNoteMutation['updateOrderNote']>);
+  export type UpdateOrderNote = NonNullable<UpdateOrderNoteMutation['updateOrderNote']>;
 }
 
 export namespace DeleteOrderNote {
   export type Variables = DeleteOrderNoteMutationVariables;
   export type Mutation = DeleteOrderNoteMutation;
-  export type DeleteOrderNote = (NonNullable<DeleteOrderNoteMutation['deleteOrderNote']>);
+  export type DeleteOrderNote = NonNullable<DeleteOrderNoteMutation['deleteOrderNote']>;
 }
 
 export namespace GetOrderWithPayments {
   export type Variables = GetOrderWithPaymentsQueryVariables;
   export type Query = GetOrderWithPaymentsQuery;
-  export type Order = (NonNullable<GetOrderWithPaymentsQuery['order']>);
-  export type Payments = NonNullable<(NonNullable<(NonNullable<GetOrderWithPaymentsQuery['order']>)['payments']>)[number]>;
-  export type Refunds = NonNullable<(NonNullable<NonNullable<(NonNullable<(NonNullable<GetOrderWithPaymentsQuery['order']>)['payments']>)[number]>['refunds']>)[number]>;
+  export type Order = NonNullable<GetOrderWithPaymentsQuery['order']>;
+  export type Payments = NonNullable<
+    NonNullable<NonNullable<GetOrderWithPaymentsQuery['order']>['payments']>[number]
+  >;
+  export type Refunds = NonNullable<
+    NonNullable<
+      NonNullable<NonNullable<NonNullable<GetOrderWithPaymentsQuery['order']>['payments']>[number]>['refunds']
+    >[number]
+  >;
 }
 
 export namespace GetOrderLineFulfillments {
   export type Variables = GetOrderLineFulfillmentsQueryVariables;
   export type Query = GetOrderLineFulfillmentsQuery;
-  export type Order = (NonNullable<GetOrderLineFulfillmentsQuery['order']>);
-  export type Lines = NonNullable<(NonNullable<(NonNullable<GetOrderLineFulfillmentsQuery['order']>)['lines']>)[number]>;
-  export type Fulfillments = NonNullable<(NonNullable<NonNullable<(NonNullable<(NonNullable<GetOrderLineFulfillmentsQuery['order']>)['lines']>)[number]>['fulfillments']>)[number]>;
-  export type Summary = NonNullable<(NonNullable<NonNullable<(NonNullable<NonNullable<(NonNullable<(NonNullable<GetOrderLineFulfillmentsQuery['order']>)['lines']>)[number]>['fulfillments']>)[number]>['summary']>)[number]>;
-  export type OrderLine = (NonNullable<NonNullable<(NonNullable<NonNullable<(NonNullable<NonNullable<(NonNullable<(NonNullable<GetOrderLineFulfillmentsQuery['order']>)['lines']>)[number]>['fulfillments']>)[number]>['summary']>)[number]>['orderLine']>);
+  export type Order = NonNullable<GetOrderLineFulfillmentsQuery['order']>;
+  export type Lines = NonNullable<
+    NonNullable<NonNullable<GetOrderLineFulfillmentsQuery['order']>['lines']>[number]
+  >;
+  export type Fulfillments = NonNullable<
+    NonNullable<
+      NonNullable<
+        NonNullable<NonNullable<GetOrderLineFulfillmentsQuery['order']>['lines']>[number]
+      >['fulfillments']
+    >[number]
+  >;
+  export type Summary = NonNullable<
+    NonNullable<
+      NonNullable<
+        NonNullable<
+          NonNullable<
+            NonNullable<NonNullable<GetOrderLineFulfillmentsQuery['order']>['lines']>[number]
+          >['fulfillments']
+        >[number]
+      >['summary']
+    >[number]
+  >;
+  export type OrderLine = NonNullable<
+    NonNullable<
+      NonNullable<
+        NonNullable<
+          NonNullable<
+            NonNullable<
+              NonNullable<NonNullable<GetOrderLineFulfillmentsQuery['order']>['lines']>[number]
+            >['fulfillments']
+          >[number]
+        >['summary']
+      >[number]
+    >['orderLine']
+  >;
 }
 
 export namespace GetOrderListWithQty {
   export type Variables = GetOrderListWithQtyQueryVariables;
   export type Query = GetOrderListWithQtyQuery;
-  export type Orders = (NonNullable<GetOrderListWithQtyQuery['orders']>);
-  export type Items = NonNullable<(NonNullable<(NonNullable<GetOrderListWithQtyQuery['orders']>)['items']>)[number]>;
-  export type Lines = NonNullable<(NonNullable<NonNullable<(NonNullable<(NonNullable<GetOrderListWithQtyQuery['orders']>)['items']>)[number]>['lines']>)[number]>;
+  export type Orders = NonNullable<GetOrderListWithQtyQuery['orders']>;
+  export type Items = NonNullable<
+    NonNullable<NonNullable<GetOrderListWithQtyQuery['orders']>['items']>[number]
+  >;
+  export type Lines = NonNullable<
+    NonNullable<
+      NonNullable<NonNullable<NonNullable<GetOrderListWithQtyQuery['orders']>['items']>[number]>['lines']
+    >[number]
+  >;
 }
 
 export namespace CancelPayment {
   export type Variables = CancelPaymentMutationVariables;
   export type Mutation = CancelPaymentMutation;
-  export type CancelPayment = (NonNullable<CancelPaymentMutation['cancelPayment']>);
-  export type ErrorResultInlineFragment = (DiscriminateUnion<(NonNullable<CancelPaymentMutation['cancelPayment']>), { __typename?: 'ErrorResult' }>);
-  export type PaymentStateTransitionErrorInlineFragment = (DiscriminateUnion<(NonNullable<CancelPaymentMutation['cancelPayment']>), { __typename?: 'PaymentStateTransitionError' }>);
-  export type CancelPaymentErrorInlineFragment = (DiscriminateUnion<(NonNullable<CancelPaymentMutation['cancelPayment']>), { __typename?: 'CancelPaymentError' }>);
+  export type CancelPayment = NonNullable<CancelPaymentMutation['cancelPayment']>;
+  export type ErrorResultInlineFragment = DiscriminateUnion<
+    NonNullable<CancelPaymentMutation['cancelPayment']>,
+    { __typename?: 'ErrorResult' }
+  >;
+  export type PaymentStateTransitionErrorInlineFragment = DiscriminateUnion<
+    NonNullable<CancelPaymentMutation['cancelPayment']>,
+    { __typename?: 'PaymentStateTransitionError' }
+  >;
+  export type CancelPaymentErrorInlineFragment = DiscriminateUnion<
+    NonNullable<CancelPaymentMutation['cancelPayment']>,
+    { __typename?: 'CancelPaymentError' }
+  >;
 }
 
 export namespace PaymentMethod {
   export type Fragment = PaymentMethodFragment;
-  export type Checker = (NonNullable<PaymentMethodFragment['checker']>);
-  export type Args = NonNullable<(NonNullable<(NonNullable<PaymentMethodFragment['checker']>)['args']>)[number]>;
-  export type Handler = (NonNullable<PaymentMethodFragment['handler']>);
-  export type _Args = NonNullable<(NonNullable<(NonNullable<PaymentMethodFragment['handler']>)['args']>)[number]>;
+  export type Checker = NonNullable<PaymentMethodFragment['checker']>;
+  export type Args = NonNullable<NonNullable<NonNullable<PaymentMethodFragment['checker']>['args']>[number]>;
+  export type Handler = NonNullable<PaymentMethodFragment['handler']>;
+  export type _Args = NonNullable<NonNullable<NonNullable<PaymentMethodFragment['handler']>['args']>[number]>;
 }
 
 export namespace CreatePaymentMethod {
   export type Variables = CreatePaymentMethodMutationVariables;
   export type Mutation = CreatePaymentMethodMutation;
-  export type CreatePaymentMethod = (NonNullable<CreatePaymentMethodMutation['createPaymentMethod']>);
+  export type CreatePaymentMethod = NonNullable<CreatePaymentMethodMutation['createPaymentMethod']>;
 }
 
 export namespace UpdatePaymentMethod {
   export type Variables = UpdatePaymentMethodMutationVariables;
   export type Mutation = UpdatePaymentMethodMutation;
-  export type UpdatePaymentMethod = (NonNullable<UpdatePaymentMethodMutation['updatePaymentMethod']>);
+  export type UpdatePaymentMethod = NonNullable<UpdatePaymentMethodMutation['updatePaymentMethod']>;
 }
 
 export namespace GetPaymentMethodHandlers {
   export type Variables = GetPaymentMethodHandlersQueryVariables;
   export type Query = GetPaymentMethodHandlersQuery;
-  export type PaymentMethodHandlers = NonNullable<(NonNullable<GetPaymentMethodHandlersQuery['paymentMethodHandlers']>)[number]>;
-  export type Args = NonNullable<(NonNullable<NonNullable<(NonNullable<GetPaymentMethodHandlersQuery['paymentMethodHandlers']>)[number]>['args']>)[number]>;
+  export type PaymentMethodHandlers = NonNullable<
+    NonNullable<GetPaymentMethodHandlersQuery['paymentMethodHandlers']>[number]
+  >;
+  export type Args = NonNullable<
+    NonNullable<
+      NonNullable<NonNullable<GetPaymentMethodHandlersQuery['paymentMethodHandlers']>[number]>['args']
+    >[number]
+  >;
 }
 
 export namespace GetPaymentMethodCheckers {
   export type Variables = GetPaymentMethodCheckersQueryVariables;
   export type Query = GetPaymentMethodCheckersQuery;
-  export type PaymentMethodEligibilityCheckers = NonNullable<(NonNullable<GetPaymentMethodCheckersQuery['paymentMethodEligibilityCheckers']>)[number]>;
-  export type Args = NonNullable<(NonNullable<NonNullable<(NonNullable<GetPaymentMethodCheckersQuery['paymentMethodEligibilityCheckers']>)[number]>['args']>)[number]>;
+  export type PaymentMethodEligibilityCheckers = NonNullable<
+    NonNullable<GetPaymentMethodCheckersQuery['paymentMethodEligibilityCheckers']>[number]
+  >;
+  export type Args = NonNullable<
+    NonNullable<
+      NonNullable<
+        NonNullable<GetPaymentMethodCheckersQuery['paymentMethodEligibilityCheckers']>[number]
+      >['args']
+    >[number]
+  >;
 }
 
 export namespace GetPaymentMethod {
   export type Variables = GetPaymentMethodQueryVariables;
   export type Query = GetPaymentMethodQuery;
-  export type PaymentMethod = (NonNullable<GetPaymentMethodQuery['paymentMethod']>);
+  export type PaymentMethod = NonNullable<GetPaymentMethodQuery['paymentMethod']>;
 }
 
 export namespace GetPaymentMethodList {
   export type Variables = GetPaymentMethodListQueryVariables;
   export type Query = GetPaymentMethodListQuery;
-  export type PaymentMethods = (NonNullable<GetPaymentMethodListQuery['paymentMethods']>);
-  export type Items = NonNullable<(NonNullable<(NonNullable<GetPaymentMethodListQuery['paymentMethods']>)['items']>)[number]>;
+  export type PaymentMethods = NonNullable<GetPaymentMethodListQuery['paymentMethods']>;
+  export type Items = NonNullable<
+    NonNullable<NonNullable<GetPaymentMethodListQuery['paymentMethods']>['items']>[number]
+  >;
 }
 
 export namespace DeletePaymentMethod {
   export type Variables = DeletePaymentMethodMutationVariables;
   export type Mutation = DeletePaymentMethodMutation;
-  export type DeletePaymentMethod = (NonNullable<DeletePaymentMethodMutation['deletePaymentMethod']>);
+  export type DeletePaymentMethod = NonNullable<DeletePaymentMethodMutation['deletePaymentMethod']>;
 }
 
 export namespace AddManualPayment2 {
   export type Variables = AddManualPayment2MutationVariables;
   export type Mutation = AddManualPayment2Mutation;
-  export type AddManualPaymentToOrder = (NonNullable<AddManualPayment2Mutation['addManualPaymentToOrder']>);
-  export type ErrorResultInlineFragment = (DiscriminateUnion<(NonNullable<AddManualPayment2Mutation['addManualPaymentToOrder']>), { __typename?: 'ErrorResult' }>);
+  export type AddManualPaymentToOrder = NonNullable<AddManualPayment2Mutation['addManualPaymentToOrder']>;
+  export type ErrorResultInlineFragment = DiscriminateUnion<
+    NonNullable<AddManualPayment2Mutation['addManualPaymentToOrder']>,
+    { __typename?: 'ErrorResult' }
+  >;
 }
 
 export namespace GetProductOptionGroup {
   export type Variables = GetProductOptionGroupQueryVariables;
   export type Query = GetProductOptionGroupQuery;
-  export type ProductOptionGroup = (NonNullable<GetProductOptionGroupQuery['productOptionGroup']>);
-  export type Options = NonNullable<(NonNullable<(NonNullable<GetProductOptionGroupQuery['productOptionGroup']>)['options']>)[number]>;
+  export type ProductOptionGroup = NonNullable<GetProductOptionGroupQuery['productOptionGroup']>;
+  export type Options = NonNullable<
+    NonNullable<NonNullable<GetProductOptionGroupQuery['productOptionGroup']>['options']>[number]
+  >;
 }
 
 export namespace UpdateProductOptionGroup {
   export type Variables = UpdateProductOptionGroupMutationVariables;
   export type Mutation = UpdateProductOptionGroupMutation;
-  export type UpdateProductOptionGroup = (NonNullable<UpdateProductOptionGroupMutation['updateProductOptionGroup']>);
+  export type UpdateProductOptionGroup = NonNullable<
+    UpdateProductOptionGroupMutation['updateProductOptionGroup']
+  >;
 }
 
 export namespace CreateProductOption {
   export type Variables = CreateProductOptionMutationVariables;
   export type Mutation = CreateProductOptionMutation;
-  export type CreateProductOption = (NonNullable<CreateProductOptionMutation['createProductOption']>);
-  export type Translations = NonNullable<(NonNullable<(NonNullable<CreateProductOptionMutation['createProductOption']>)['translations']>)[number]>;
+  export type CreateProductOption = NonNullable<CreateProductOptionMutation['createProductOption']>;
+  export type Translations = NonNullable<
+    NonNullable<NonNullable<CreateProductOptionMutation['createProductOption']>['translations']>[number]
+  >;
 }
 
 export namespace UpdateProductOption {
   export type Variables = UpdateProductOptionMutationVariables;
   export type Mutation = UpdateProductOptionMutation;
-  export type UpdateProductOption = (NonNullable<UpdateProductOptionMutation['updateProductOption']>);
+  export type UpdateProductOption = NonNullable<UpdateProductOptionMutation['updateProductOption']>;
 }
 
 export namespace DeleteProductOption {
   export type Variables = DeleteProductOptionMutationVariables;
   export type Mutation = DeleteProductOptionMutation;
-  export type DeleteProductOption = (NonNullable<DeleteProductOptionMutation['deleteProductOption']>);
+  export type DeleteProductOption = NonNullable<DeleteProductOptionMutation['deleteProductOption']>;
 }
 
 export namespace RemoveOptionGroupFromProduct {
   export type Variables = RemoveOptionGroupFromProductMutationVariables;
   export type Mutation = RemoveOptionGroupFromProductMutation;
-  export type RemoveOptionGroupFromProduct = (NonNullable<RemoveOptionGroupFromProductMutation['removeOptionGroupFromProduct']>);
-  export type ProductOptionInUseErrorInlineFragment = (DiscriminateUnion<(NonNullable<RemoveOptionGroupFromProductMutation['removeOptionGroupFromProduct']>), { __typename?: 'ProductOptionInUseError' }>);
+  export type RemoveOptionGroupFromProduct = NonNullable<
+    RemoveOptionGroupFromProductMutation['removeOptionGroupFromProduct']
+  >;
+  export type ProductOptionInUseErrorInlineFragment = DiscriminateUnion<
+    NonNullable<RemoveOptionGroupFromProductMutation['removeOptionGroupFromProduct']>,
+    { __typename?: 'ProductOptionInUseError' }
+  >;
 }
 
 export namespace GetOptionGroup {
   export type Variables = GetOptionGroupQueryVariables;
   export type Query = GetOptionGroupQuery;
-  export type ProductOptionGroup = (NonNullable<GetOptionGroupQuery['productOptionGroup']>);
-  export type Options = NonNullable<(NonNullable<(NonNullable<GetOptionGroupQuery['productOptionGroup']>)['options']>)[number]>;
+  export type ProductOptionGroup = NonNullable<GetOptionGroupQuery['productOptionGroup']>;
+  export type Options = NonNullable<
+    NonNullable<NonNullable<GetOptionGroupQuery['productOptionGroup']>['options']>[number]
+  >;
 }
 
 export namespace GetProductVariant {
   export type Variables = GetProductVariantQueryVariables;
   export type Query = GetProductVariantQuery;
-  export type ProductVariant = (NonNullable<GetProductVariantQuery['productVariant']>);
+  export type ProductVariant = NonNullable<GetProductVariantQuery['productVariant']>;
 }
 
 export namespace GetProductWithVariantList {
   export type Variables = GetProductWithVariantListQueryVariables;
   export type Query = GetProductWithVariantListQuery;
-  export type Product = (NonNullable<GetProductWithVariantListQuery['product']>);
-  export type VariantList = (NonNullable<(NonNullable<GetProductWithVariantListQuery['product']>)['variantList']>);
-  export type Items = NonNullable<(NonNullable<(NonNullable<(NonNullable<GetProductWithVariantListQuery['product']>)['variantList']>)['items']>)[number]>;
+  export type Product = NonNullable<GetProductWithVariantListQuery['product']>;
+  export type VariantList = NonNullable<
+    NonNullable<GetProductWithVariantListQuery['product']>['variantList']
+  >;
+  export type Items = NonNullable<
+    NonNullable<
+      NonNullable<NonNullable<GetProductWithVariantListQuery['product']>['variantList']>['items']
+    >[number]
+  >;
 }
 
 export namespace GetPromotionList {
   export type Variables = GetPromotionListQueryVariables;
   export type Query = GetPromotionListQuery;
-  export type Promotions = (NonNullable<GetPromotionListQuery['promotions']>);
-  export type Items = NonNullable<(NonNullable<(NonNullable<GetPromotionListQuery['promotions']>)['items']>)[number]>;
+  export type Promotions = NonNullable<GetPromotionListQuery['promotions']>;
+  export type Items = NonNullable<
+    NonNullable<NonNullable<GetPromotionListQuery['promotions']>['items']>[number]
+  >;
 }
 
 export namespace GetPromotion {
   export type Variables = GetPromotionQueryVariables;
   export type Query = GetPromotionQuery;
-  export type Promotion = (NonNullable<GetPromotionQuery['promotion']>);
+  export type Promotion = NonNullable<GetPromotionQuery['promotion']>;
 }
 
 export namespace UpdatePromotion {
   export type Variables = UpdatePromotionMutationVariables;
   export type Mutation = UpdatePromotionMutation;
-  export type UpdatePromotion = (NonNullable<UpdatePromotionMutation['updatePromotion']>);
-  export type ErrorResultInlineFragment = (DiscriminateUnion<(NonNullable<UpdatePromotionMutation['updatePromotion']>), { __typename?: 'ErrorResult' }>);
+  export type UpdatePromotion = NonNullable<UpdatePromotionMutation['updatePromotion']>;
+  export type ErrorResultInlineFragment = DiscriminateUnion<
+    NonNullable<UpdatePromotionMutation['updatePromotion']>,
+    { __typename?: 'ErrorResult' }
+  >;
 }
 
 export namespace ConfigurableOperationDef {
   export type Fragment = ConfigurableOperationDefFragment;
-  export type Args = NonNullable<(NonNullable<ConfigurableOperationDefFragment['args']>)[number]>;
+  export type Args = NonNullable<NonNullable<ConfigurableOperationDefFragment['args']>[number]>;
 }
 
 export namespace GetAdjustmentOperations {
   export type Variables = GetAdjustmentOperationsQueryVariables;
   export type Query = GetAdjustmentOperationsQuery;
-  export type PromotionActions = NonNullable<(NonNullable<GetAdjustmentOperationsQuery['promotionActions']>)[number]>;
-  export type PromotionConditions = NonNullable<(NonNullable<GetAdjustmentOperationsQuery['promotionConditions']>)[number]>;
+  export type PromotionActions = NonNullable<
+    NonNullable<GetAdjustmentOperationsQuery['promotionActions']>[number]
+  >;
+  export type PromotionConditions = NonNullable<
+    NonNullable<GetAdjustmentOperationsQuery['promotionConditions']>[number]
+  >;
 }
 
 export namespace GetRoles {
   export type Variables = GetRolesQueryVariables;
   export type Query = GetRolesQuery;
-  export type Roles = (NonNullable<GetRolesQuery['roles']>);
-  export type Items = NonNullable<(NonNullable<(NonNullable<GetRolesQuery['roles']>)['items']>)[number]>;
+  export type Roles = NonNullable<GetRolesQuery['roles']>;
+  export type Items = NonNullable<NonNullable<NonNullable<GetRolesQuery['roles']>['items']>[number]>;
 }
 
 export namespace GetRole {
   export type Variables = GetRoleQueryVariables;
   export type Query = GetRoleQuery;
-  export type Role = (NonNullable<GetRoleQuery['role']>);
+  export type Role = NonNullable<GetRoleQuery['role']>;
 }
 
 export namespace DeleteRole {
   export type Variables = DeleteRoleMutationVariables;
   export type Mutation = DeleteRoleMutation;
-  export type DeleteRole = (NonNullable<DeleteRoleMutation['deleteRole']>);
+  export type DeleteRole = NonNullable<DeleteRoleMutation['deleteRole']>;
 }
 
 export namespace Logout {
   export type Variables = LogoutMutationVariables;
   export type Mutation = LogoutMutation;
-  export type Logout = (NonNullable<LogoutMutation['logout']>);
+  export type Logout = NonNullable<LogoutMutation['logout']>;
 }
 
 export namespace GetShippingMethod {
   export type Variables = GetShippingMethodQueryVariables;
   export type Query = GetShippingMethodQuery;
-  export type ShippingMethod = (NonNullable<GetShippingMethodQuery['shippingMethod']>);
+  export type ShippingMethod = NonNullable<GetShippingMethodQuery['shippingMethod']>;
 }
 
 export namespace GetEligibilityCheckers {
   export type Variables = GetEligibilityCheckersQueryVariables;
   export type Query = GetEligibilityCheckersQuery;
-  export type ShippingEligibilityCheckers = NonNullable<(NonNullable<GetEligibilityCheckersQuery['shippingEligibilityCheckers']>)[number]>;
-  export type Args = NonNullable<(NonNullable<NonNullable<(NonNullable<GetEligibilityCheckersQuery['shippingEligibilityCheckers']>)[number]>['args']>)[number]>;
+  export type ShippingEligibilityCheckers = NonNullable<
+    NonNullable<GetEligibilityCheckersQuery['shippingEligibilityCheckers']>[number]
+  >;
+  export type Args = NonNullable<
+    NonNullable<
+      NonNullable<NonNullable<GetEligibilityCheckersQuery['shippingEligibilityCheckers']>[number]>['args']
+    >[number]
+  >;
 }
 
 export namespace GetCalculators {
   export type Variables = GetCalculatorsQueryVariables;
   export type Query = GetCalculatorsQuery;
-  export type ShippingCalculators = NonNullable<(NonNullable<GetCalculatorsQuery['shippingCalculators']>)[number]>;
-  export type Args = NonNullable<(NonNullable<NonNullable<(NonNullable<GetCalculatorsQuery['shippingCalculators']>)[number]>['args']>)[number]>;
+  export type ShippingCalculators = NonNullable<
+    NonNullable<GetCalculatorsQuery['shippingCalculators']>[number]
+  >;
+  export type Args = NonNullable<
+    NonNullable<NonNullable<NonNullable<GetCalculatorsQuery['shippingCalculators']>[number]>['args']>[number]
+  >;
 }
 
 export namespace TestShippingMethod {
   export type Variables = TestShippingMethodQueryVariables;
   export type Query = TestShippingMethodQuery;
-  export type TestShippingMethod = (NonNullable<TestShippingMethodQuery['testShippingMethod']>);
-  export type Quote = (NonNullable<(NonNullable<TestShippingMethodQuery['testShippingMethod']>)['quote']>);
+  export type TestShippingMethod = NonNullable<TestShippingMethodQuery['testShippingMethod']>;
+  export type Quote = NonNullable<NonNullable<TestShippingMethodQuery['testShippingMethod']>['quote']>;
 }
 
 export namespace TestEligibleMethods {
   export type Variables = TestEligibleMethodsQueryVariables;
   export type Query = TestEligibleMethodsQuery;
-  export type TestEligibleShippingMethods = NonNullable<(NonNullable<TestEligibleMethodsQuery['testEligibleShippingMethods']>)[number]>;
+  export type TestEligibleShippingMethods = NonNullable<
+    NonNullable<TestEligibleMethodsQuery['testEligibleShippingMethods']>[number]
+  >;
 }
 
 export namespace GetMe {
   export type Variables = GetMeQueryVariables;
   export type Query = GetMeQuery;
-  export type Me = (NonNullable<GetMeQuery['me']>);
+  export type Me = NonNullable<GetMeQuery['me']>;
 }
 
 export namespace GetProductsTake3 {
   export type Variables = GetProductsTake3QueryVariables;
   export type Query = GetProductsTake3Query;
-  export type Products = (NonNullable<GetProductsTake3Query['products']>);
-  export type Items = NonNullable<(NonNullable<(NonNullable<GetProductsTake3Query['products']>)['items']>)[number]>;
+  export type Products = NonNullable<GetProductsTake3Query['products']>;
+  export type Items = NonNullable<
+    NonNullable<NonNullable<GetProductsTake3Query['products']>['items']>[number]
+  >;
 }
 
 export namespace GetProduct1 {
   export type Variables = GetProduct1QueryVariables;
   export type Query = GetProduct1Query;
-  export type Product = (NonNullable<GetProduct1Query['product']>);
+  export type Product = NonNullable<GetProduct1Query['product']>;
 }
 
 export namespace GetProduct2Variants {
   export type Variables = GetProduct2VariantsQueryVariables;
   export type Query = GetProduct2VariantsQuery;
-  export type Product = (NonNullable<GetProduct2VariantsQuery['product']>);
-  export type Variants = NonNullable<(NonNullable<(NonNullable<GetProduct2VariantsQuery['product']>)['variants']>)[number]>;
+  export type Product = NonNullable<GetProduct2VariantsQuery['product']>;
+  export type Variants = NonNullable<
+    NonNullable<NonNullable<GetProduct2VariantsQuery['product']>['variants']>[number]
+  >;
 }
 
 export namespace GetProductCollection {
   export type Variables = GetProductCollectionQueryVariables;
   export type Query = GetProductCollectionQuery;
-  export type Product = (NonNullable<GetProductCollectionQuery['product']>);
-  export type Collections = NonNullable<(NonNullable<(NonNullable<GetProductCollectionQuery['product']>)['collections']>)[number]>;
+  export type Product = NonNullable<GetProductCollectionQuery['product']>;
+  export type Collections = NonNullable<
+    NonNullable<NonNullable<GetProductCollectionQuery['product']>['collections']>[number]
+  >;
 }
 
 export namespace GetCollectionShop {
   export type Variables = GetCollectionShopQueryVariables;
   export type Query = GetCollectionShopQuery;
-  export type Collection = (NonNullable<GetCollectionShopQuery['collection']>);
-  export type Parent = (NonNullable<(NonNullable<GetCollectionShopQuery['collection']>)['parent']>);
-  export type Children = NonNullable<(NonNullable<(NonNullable<GetCollectionShopQuery['collection']>)['children']>)[number]>;
+  export type Collection = NonNullable<GetCollectionShopQuery['collection']>;
+  export type Parent = NonNullable<NonNullable<GetCollectionShopQuery['collection']>['parent']>;
+  export type Children = NonNullable<
+    NonNullable<NonNullable<GetCollectionShopQuery['collection']>['children']>[number]
+  >;
 }
 
 export namespace DisableProduct {
   export type Variables = DisableProductMutationVariables;
   export type Mutation = DisableProductMutation;
-  export type UpdateProduct = (NonNullable<DisableProductMutation['updateProduct']>);
+  export type UpdateProduct = NonNullable<DisableProductMutation['updateProduct']>;
 }
 
 export namespace GetCollectionVariants {
   export type Variables = GetCollectionVariantsQueryVariables;
   export type Query = GetCollectionVariantsQuery;
-  export type Collection = (NonNullable<GetCollectionVariantsQuery['collection']>);
-  export type ProductVariants = (NonNullable<(NonNullable<GetCollectionVariantsQuery['collection']>)['productVariants']>);
-  export type Items = NonNullable<(NonNullable<(NonNullable<(NonNullable<GetCollectionVariantsQuery['collection']>)['productVariants']>)['items']>)[number]>;
+  export type Collection = NonNullable<GetCollectionVariantsQuery['collection']>;
+  export type ProductVariants = NonNullable<
+    NonNullable<GetCollectionVariantsQuery['collection']>['productVariants']
+  >;
+  export type Items = NonNullable<
+    NonNullable<
+      NonNullable<NonNullable<GetCollectionVariantsQuery['collection']>['productVariants']>['items']
+    >[number]
+  >;
 }
 
 export namespace GetCollectionList {
   export type Variables = GetCollectionListQueryVariables;
   export type Query = GetCollectionListQuery;
-  export type Collections = (NonNullable<GetCollectionListQuery['collections']>);
-  export type Items = NonNullable<(NonNullable<(NonNullable<GetCollectionListQuery['collections']>)['items']>)[number]>;
+  export type Collections = NonNullable<GetCollectionListQuery['collections']>;
+  export type Items = NonNullable<
+    NonNullable<NonNullable<GetCollectionListQuery['collections']>['items']>[number]
+  >;
 }
 
 export namespace GetProductFacetValues {
   export type Variables = GetProductFacetValuesQueryVariables;
   export type Query = GetProductFacetValuesQuery;
-  export type Product = (NonNullable<GetProductFacetValuesQuery['product']>);
-  export type FacetValues = NonNullable<(NonNullable<(NonNullable<GetProductFacetValuesQuery['product']>)['facetValues']>)[number]>;
+  export type Product = NonNullable<GetProductFacetValuesQuery['product']>;
+  export type FacetValues = NonNullable<
+    NonNullable<NonNullable<GetProductFacetValuesQuery['product']>['facetValues']>[number]
+  >;
 }
 
 export namespace GetVariantFacetValues {
   export type Variables = GetVariantFacetValuesQueryVariables;
   export type Query = GetVariantFacetValuesQuery;
-  export type Product = (NonNullable<GetVariantFacetValuesQuery['product']>);
-  export type Variants = NonNullable<(NonNullable<(NonNullable<GetVariantFacetValuesQuery['product']>)['variants']>)[number]>;
-  export type FacetValues = NonNullable<(NonNullable<NonNullable<(NonNullable<(NonNullable<GetVariantFacetValuesQuery['product']>)['variants']>)[number]>['facetValues']>)[number]>;
+  export type Product = NonNullable<GetVariantFacetValuesQuery['product']>;
+  export type Variants = NonNullable<
+    NonNullable<NonNullable<GetVariantFacetValuesQuery['product']>['variants']>[number]
+  >;
+  export type FacetValues = NonNullable<
+    NonNullable<
+      NonNullable<
+        NonNullable<NonNullable<GetVariantFacetValuesQuery['product']>['variants']>[number]
+      >['facetValues']
+    >[number]
+  >;
 }
 
 export namespace GetCustomerIds {
   export type Variables = GetCustomerIdsQueryVariables;
   export type Query = GetCustomerIdsQuery;
-  export type Customers = (NonNullable<GetCustomerIdsQuery['customers']>);
-  export type Items = NonNullable<(NonNullable<(NonNullable<GetCustomerIdsQuery['customers']>)['items']>)[number]>;
+  export type Customers = NonNullable<GetCustomerIdsQuery['customers']>;
+  export type Items = NonNullable<
+    NonNullable<NonNullable<GetCustomerIdsQuery['customers']>['items']>[number]
+  >;
 }
 
 export namespace UpdateStock {
   export type Variables = UpdateStockMutationVariables;
   export type Mutation = UpdateStockMutation;
-  export type UpdateProductVariants = NonNullable<(NonNullable<UpdateStockMutation['updateProductVariants']>)[number]>;
+  export type UpdateProductVariants = NonNullable<
+    NonNullable<UpdateStockMutation['updateProductVariants']>[number]
+  >;
 }
 
 export namespace TransitionFulfillmentToState {
   export type Variables = TransitionFulfillmentToStateMutationVariables;
   export type Mutation = TransitionFulfillmentToStateMutation;
-  export type TransitionFulfillmentToState = (NonNullable<TransitionFulfillmentToStateMutation['transitionFulfillmentToState']>);
-  export type FulfillmentInlineFragment = (DiscriminateUnion<(NonNullable<TransitionFulfillmentToStateMutation['transitionFulfillmentToState']>), { __typename?: 'Fulfillment' }>);
-  export type ErrorResultInlineFragment = (DiscriminateUnion<(NonNullable<TransitionFulfillmentToStateMutation['transitionFulfillmentToState']>), { __typename?: 'ErrorResult' }>);
-  export type FulfillmentStateTransitionErrorInlineFragment = (DiscriminateUnion<(NonNullable<TransitionFulfillmentToStateMutation['transitionFulfillmentToState']>), { __typename?: 'FulfillmentStateTransitionError' }>);
+  export type TransitionFulfillmentToState = NonNullable<
+    TransitionFulfillmentToStateMutation['transitionFulfillmentToState']
+  >;
+  export type FulfillmentInlineFragment = DiscriminateUnion<
+    NonNullable<TransitionFulfillmentToStateMutation['transitionFulfillmentToState']>,
+    { __typename?: 'Fulfillment' }
+  >;
+  export type ErrorResultInlineFragment = DiscriminateUnion<
+    NonNullable<TransitionFulfillmentToStateMutation['transitionFulfillmentToState']>,
+    { __typename?: 'ErrorResult' }
+  >;
+  export type FulfillmentStateTransitionErrorInlineFragment = DiscriminateUnion<
+    NonNullable<TransitionFulfillmentToStateMutation['transitionFulfillmentToState']>,
+    { __typename?: 'FulfillmentStateTransitionError' }
+  >;
 }
 
 export namespace UpdateOrderCustomFields {
   export type Variables = UpdateOrderCustomFieldsMutationVariables;
   export type Mutation = UpdateOrderCustomFieldsMutation;
-  export type SetOrderCustomFields = (NonNullable<UpdateOrderCustomFieldsMutation['setOrderCustomFields']>);
-  export type OrderInlineFragment = ({ __typename: 'Order' } & Pick<(NonNullable<UpdateOrderCustomFieldsMutation['setOrderCustomFields']>), 'id'>);
+  export type SetOrderCustomFields = NonNullable<UpdateOrderCustomFieldsMutation['setOrderCustomFields']>;
+  export type OrderInlineFragment = { __typename: 'Order' } & Pick<
+    NonNullable<UpdateOrderCustomFieldsMutation['setOrderCustomFields']>,
+    'id'
+  >;
 }
 
 export namespace GetTagList {
   export type Variables = GetTagListQueryVariables;
   export type Query = GetTagListQuery;
-  export type Tags = (NonNullable<GetTagListQuery['tags']>);
-  export type Items = NonNullable<(NonNullable<(NonNullable<GetTagListQuery['tags']>)['items']>)[number]>;
+  export type Tags = NonNullable<GetTagListQuery['tags']>;
+  export type Items = NonNullable<NonNullable<NonNullable<GetTagListQuery['tags']>['items']>[number]>;
 }
 
 export namespace GetTag {
   export type Variables = GetTagQueryVariables;
   export type Query = GetTagQuery;
-  export type Tag = (NonNullable<GetTagQuery['tag']>);
+  export type Tag = NonNullable<GetTagQuery['tag']>;
 }
 
 export namespace CreateTag {
   export type Variables = CreateTagMutationVariables;
   export type Mutation = CreateTagMutation;
-  export type CreateTag = (NonNullable<CreateTagMutation['createTag']>);
+  export type CreateTag = NonNullable<CreateTagMutation['createTag']>;
 }
 
 export namespace UpdateTag {
   export type Variables = UpdateTagMutationVariables;
   export type Mutation = UpdateTagMutation;
-  export type UpdateTag = (NonNullable<UpdateTagMutation['updateTag']>);
+  export type UpdateTag = NonNullable<UpdateTagMutation['updateTag']>;
 }
 
 export namespace DeleteTag {
   export type Variables = DeleteTagMutationVariables;
   export type Mutation = DeleteTagMutation;
-  export type DeleteTag = (NonNullable<DeleteTagMutation['deleteTag']>);
+  export type DeleteTag = NonNullable<DeleteTagMutation['deleteTag']>;
 }
 
 export namespace GetTaxCategoryList {
   export type Variables = GetTaxCategoryListQueryVariables;
   export type Query = GetTaxCategoryListQuery;
-  export type TaxCategories = NonNullable<(NonNullable<GetTaxCategoryListQuery['taxCategories']>)[number]>;
+  export type TaxCategories = NonNullable<NonNullable<GetTaxCategoryListQuery['taxCategories']>[number]>;
 }
 
 export namespace GetTaxCategory {
   export type Variables = GetTaxCategoryQueryVariables;
   export type Query = GetTaxCategoryQuery;
-  export type TaxCategory = (NonNullable<GetTaxCategoryQuery['taxCategory']>);
+  export type TaxCategory = NonNullable<GetTaxCategoryQuery['taxCategory']>;
 }
 
 export namespace CreateTaxCategory {
   export type Variables = CreateTaxCategoryMutationVariables;
   export type Mutation = CreateTaxCategoryMutation;
-  export type CreateTaxCategory = (NonNullable<CreateTaxCategoryMutation['createTaxCategory']>);
+  export type CreateTaxCategory = NonNullable<CreateTaxCategoryMutation['createTaxCategory']>;
 }
 
 export namespace UpdateTaxCategory {
   export type Variables = UpdateTaxCategoryMutationVariables;
   export type Mutation = UpdateTaxCategoryMutation;
-  export type UpdateTaxCategory = (NonNullable<UpdateTaxCategoryMutation['updateTaxCategory']>);
+  export type UpdateTaxCategory = NonNullable<UpdateTaxCategoryMutation['updateTaxCategory']>;
 }
 
 export namespace DeleteTaxCategory {
   export type Variables = DeleteTaxCategoryMutationVariables;
   export type Mutation = DeleteTaxCategoryMutation;
-  export type DeleteTaxCategory = (NonNullable<DeleteTaxCategoryMutation['deleteTaxCategory']>);
+  export type DeleteTaxCategory = NonNullable<DeleteTaxCategoryMutation['deleteTaxCategory']>;
 }
 
 export namespace GetTaxRate {
   export type Variables = GetTaxRateQueryVariables;
   export type Query = GetTaxRateQuery;
-  export type TaxRate = (NonNullable<GetTaxRateQuery['taxRate']>);
+  export type TaxRate = NonNullable<GetTaxRateQuery['taxRate']>;
 }
 
 export namespace CreateTaxRate {
   export type Variables = CreateTaxRateMutationVariables;
   export type Mutation = CreateTaxRateMutation;
-  export type CreateTaxRate = (NonNullable<CreateTaxRateMutation['createTaxRate']>);
+  export type CreateTaxRate = NonNullable<CreateTaxRateMutation['createTaxRate']>;
 }
 
 export namespace DeleteTaxRate {
   export type Variables = DeleteTaxRateMutationVariables;
   export type Mutation = DeleteTaxRateMutation;
-  export type DeleteTaxRate = (NonNullable<DeleteTaxRateMutation['deleteTaxRate']>);
+  export type DeleteTaxRate = NonNullable<DeleteTaxRateMutation['deleteTaxRate']>;
 }
 
 export namespace DeleteZone {
   export type Variables = DeleteZoneMutationVariables;
   export type Mutation = DeleteZoneMutation;
-  export type DeleteZone = (NonNullable<DeleteZoneMutation['deleteZone']>);
+  export type DeleteZone = NonNullable<DeleteZoneMutation['deleteZone']>;
 }
 
 export namespace GetZones {
   export type Variables = GetZonesQueryVariables;
   export type Query = GetZonesQuery;
-  export type Zones = NonNullable<(NonNullable<GetZonesQuery['zones']>)[number]>;
+  export type Zones = NonNullable<NonNullable<GetZonesQuery['zones']>[number]>;
 }
 
 export namespace GetZone {
   export type Variables = GetZoneQueryVariables;
   export type Query = GetZoneQuery;
-  export type Zone = (NonNullable<GetZoneQuery['zone']>);
+  export type Zone = NonNullable<GetZoneQuery['zone']>;
 }
 
 export namespace GetActiveChannelWithZoneMembers {
   export type Variables = GetActiveChannelWithZoneMembersQueryVariables;
   export type Query = GetActiveChannelWithZoneMembersQuery;
-  export type ActiveChannel = (NonNullable<GetActiveChannelWithZoneMembersQuery['activeChannel']>);
-  export type DefaultShippingZone = (NonNullable<(NonNullable<GetActiveChannelWithZoneMembersQuery['activeChannel']>)['defaultShippingZone']>);
-  export type Members = NonNullable<(NonNullable<(NonNullable<(NonNullable<GetActiveChannelWithZoneMembersQuery['activeChannel']>)['defaultShippingZone']>)['members']>)[number]>;
+  export type ActiveChannel = NonNullable<GetActiveChannelWithZoneMembersQuery['activeChannel']>;
+  export type DefaultShippingZone = NonNullable<
+    NonNullable<GetActiveChannelWithZoneMembersQuery['activeChannel']>['defaultShippingZone']
+  >;
+  export type Members = NonNullable<
+    NonNullable<
+      NonNullable<
+        NonNullable<GetActiveChannelWithZoneMembersQuery['activeChannel']>['defaultShippingZone']
+      >['members']
+    >[number]
+  >;
 }
 
 export namespace CreateZone {
   export type Variables = CreateZoneMutationVariables;
   export type Mutation = CreateZoneMutation;
-  export type CreateZone = (NonNullable<CreateZoneMutation['createZone']>);
+  export type CreateZone = NonNullable<CreateZoneMutation['createZone']>;
 }
 
 export namespace UpdateZone {
   export type Variables = UpdateZoneMutationVariables;
   export type Mutation = UpdateZoneMutation;
-  export type UpdateZone = (NonNullable<UpdateZoneMutation['updateZone']>);
+  export type UpdateZone = NonNullable<UpdateZoneMutation['updateZone']>;
 }
 
 export namespace AddMembersToZone {
   export type Variables = AddMembersToZoneMutationVariables;
   export type Mutation = AddMembersToZoneMutation;
-  export type AddMembersToZone = (NonNullable<AddMembersToZoneMutation['addMembersToZone']>);
+  export type AddMembersToZone = NonNullable<AddMembersToZoneMutation['addMembersToZone']>;
 }
 
 export namespace RemoveMembersFromZone {
   export type Variables = RemoveMembersFromZoneMutationVariables;
   export type Mutation = RemoveMembersFromZoneMutation;
-  export type RemoveMembersFromZone = (NonNullable<RemoveMembersFromZoneMutation['removeMembersFromZone']>);
+  export type RemoveMembersFromZone = NonNullable<RemoveMembersFromZoneMutation['removeMembersFromZone']>;
 }

--- a/packages/core/e2e/graphql/generated-e2e-admin-types.ts
+++ b/packages/core/e2e/graphql/generated-e2e-admin-types.ts
@@ -275,11 +275,6 @@ export type AssignPromotionsToChannelInput = {
   channelId: Scalars['ID'];
 };
 
-export type AssignVendorsToChannelInput = {
-  vendorIds: Array<Scalars['ID']>;
-  channelId: Scalars['ID'];
-};
-
 export type AuthenticationInput = {
   native?: Maybe<NativeAuthInput>;
 };
@@ -314,15 +309,6 @@ export type BooleanListOperators = {
 export type BooleanOperators = {
   eq?: Maybe<Scalars['Boolean']>;
   isNull?: Maybe<Scalars['Boolean']>;
-};
-
-export type Brand = Node & {
-  id: Scalars['ID'];
-  createdAt: Scalars['DateTime'];
-  updatedAt: Scalars['DateTime'];
-  vendorId: Scalars['ID'];
-  name?: Maybe<Scalars['String']>;
-  slug?: Maybe<Scalars['String']>;
 };
 
 /** Returned if an attempting to cancel lines from an Order which is still active */
@@ -747,17 +733,13 @@ export type CreatePaymentMethodInput = {
   customFields?: Maybe<Scalars['JSON']>;
 };
 
-export type CreateProductCustomFieldsInput = {
-  brandId?: Maybe<Scalars['ID']>;
-};
-
 export type CreateProductInput = {
   featuredAssetId?: Maybe<Scalars['ID']>;
   enabled?: Maybe<Scalars['Boolean']>;
   assetIds?: Maybe<Array<Scalars['ID']>>;
   facetValueIds?: Maybe<Array<Scalars['ID']>>;
   translations: Array<ProductTranslationInput>;
-  customFields?: Maybe<CreateProductCustomFieldsInput>;
+  customFields?: Maybe<Scalars['JSON']>;
 };
 
 export type CreateProductOptionGroupInput = {
@@ -774,10 +756,6 @@ export type CreateProductOptionInput = {
   customFields?: Maybe<Scalars['JSON']>;
 };
 
-export type CreateProductVariantCustomFieldsInput = {
-  costPerItem?: Maybe<Scalars['Int']>;
-};
-
 export type CreateProductVariantInput = {
   productId: Scalars['ID'];
   translations: Array<ProductVariantTranslationInput>;
@@ -792,7 +770,7 @@ export type CreateProductVariantInput = {
   outOfStockThreshold?: Maybe<Scalars['Int']>;
   useGlobalOutOfStockThreshold?: Maybe<Scalars['Boolean']>;
   trackInventory?: Maybe<GlobalFlag>;
-  customFields?: Maybe<CreateProductVariantCustomFieldsInput>;
+  customFields?: Maybe<Scalars['JSON']>;
 };
 
 export type CreateProductVariantOptionInput = {
@@ -849,31 +827,6 @@ export type CreateTaxRateInput = {
   zoneId: Scalars['ID'];
   customerGroupId?: Maybe<Scalars['ID']>;
   customFields?: Maybe<Scalars['JSON']>;
-};
-
-export type CreateVendorBrandInput = {
-  name: Scalars['String'];
-  slug: Scalars['String'];
-};
-
-export type CreateVendorInput = {
-  name: Scalars['String'];
-  slug: Scalars['String'];
-  address?: Maybe<Scalars['String']>;
-  phone?: Maybe<Scalars['String']>;
-  websiteUrl?: Maybe<Scalars['String']>;
-  featuredAssetId?: Maybe<Scalars['ID']>;
-  stripeConnectedAccountId?: Maybe<Scalars['String']>;
-  assetIds?: Maybe<Array<Scalars['ID']>>;
-  translations: Array<CreateVendorTranslationInput>;
-  shopifyId?: Maybe<Scalars['Int']>;
-  brands?: Maybe<Array<CreateVendorBrandInput>>;
-  colabId?: Maybe<Scalars['Int']>;
-};
-
-export type CreateVendorTranslationInput = {
-  languageCode: LanguageCode;
-  description: Scalars['String'];
 };
 
 export type CreateZoneInput = {
@@ -1268,11 +1221,6 @@ export type CustomFields = {
   Zone: Array<CustomFieldConfig>;
 };
 
-export type CustomProductMappings = {
-  vendorId: Scalars['ID'];
-  vendorName: Scalars['String'];
-};
-
 export type Customer = Node & {
   groups: Array<CustomerGroup>;
   history: HistoryEntryList;
@@ -1287,7 +1235,7 @@ export type Customer = Node & {
   addresses?: Maybe<Array<Address>>;
   orders: OrderList;
   user?: Maybe<User>;
-  customFields?: Maybe<CustomerCustomFields>;
+  customFields?: Maybe<Scalars['JSON']>;
 };
 
 export type CustomerHistoryArgs = {
@@ -1296,10 +1244,6 @@ export type CustomerHistoryArgs = {
 
 export type CustomerOrdersArgs = {
   options?: Maybe<OrderListOptions>;
-};
-
-export type CustomerCustomFields = {
-  shopifyId?: Maybe<Scalars['Float']>;
 };
 
 export type CustomerFilterParameter = {
@@ -1312,7 +1256,6 @@ export type CustomerFilterParameter = {
   lastName?: Maybe<StringOperators>;
   phoneNumber?: Maybe<StringOperators>;
   emailAddress?: Maybe<StringOperators>;
-  shopifyId?: Maybe<NumberOperators>;
 };
 
 export type CustomerGroup = Node & {
@@ -1387,7 +1330,6 @@ export type CustomerSortParameter = {
   lastName?: Maybe<SortOrder>;
   phoneNumber?: Maybe<SortOrder>;
   emailAddress?: Maybe<SortOrder>;
-  shopifyId?: Maybe<SortOrder>;
 };
 
 /** Operators for filtering on a list of Date fields */
@@ -1708,11 +1650,7 @@ export type Fulfillment = Node & {
   state: Scalars['String'];
   method: Scalars['String'];
   trackingCode?: Maybe<Scalars['String']>;
-  customFields?: Maybe<FulfillmentCustomFields>;
-};
-
-export type FulfillmentCustomFields = {
-  fulfilmentCentre?: Maybe<Scalars['String']>;
+  customFields?: Maybe<Scalars['JSON']>;
 };
 
 export type FulfillmentLineSummary = {
@@ -1887,52 +1825,6 @@ export type InvalidCredentialsError = ErrorResult & {
 export type InvalidFulfillmentHandlerError = ErrorResult & {
   errorCode: ErrorCode;
   message: Scalars['String'];
-};
-
-export type InventoryItem = Node & {
-  id: Scalars['ID'];
-  sku: Scalars['String'];
-  name: Scalars['String'];
-  quantity: Scalars['Int'];
-};
-
-export type InventoryItemFilterParameter = {
-  id?: Maybe<IdOperators>;
-  sku?: Maybe<StringOperators>;
-  name?: Maybe<StringOperators>;
-  quantity?: Maybe<NumberOperators>;
-};
-
-export type InventoryItemList = PaginatedList & {
-  items: Array<InventoryItem>;
-  totalItems: Scalars['Int'];
-  lastUpdatedAt?: Maybe<Scalars['DateTime']>;
-};
-
-export type InventoryItemListOptions = {
-  locationIds: Array<Scalars['ID']>;
-  /** Skips the first n results, for use in pagination */
-  skip?: Maybe<Scalars['Int']>;
-  /** Takes n results, for use in pagination */
-  take?: Maybe<Scalars['Int']>;
-  /** Specifies which properties to sort the results by */
-  sort?: Maybe<InventoryItemSortParameter>;
-  /** Allows the results to be filtered */
-  filter?: Maybe<InventoryItemFilterParameter>;
-  /** Specifies whether multiple "filter" arguments should be combines with a logical AND or OR operation. Defaults to AND. */
-  filterOperator?: Maybe<LogicalOperator>;
-};
-
-export type InventoryItemSortParameter = {
-  id?: Maybe<SortOrder>;
-  sku?: Maybe<SortOrder>;
-  name?: Maybe<SortOrder>;
-  quantity?: Maybe<SortOrder>;
-};
-
-export type InventoryLocation = {
-  id: Scalars['ID'];
-  name: Scalars['String'];
 };
 
 /** Returned if the specified items are already part of a Fulfillment */
@@ -2425,7 +2317,6 @@ export type ModifyOrderInput = {
   refund?: Maybe<AdministratorRefundInput>;
   options?: Maybe<ModifyOrderOptions>;
   couponCodes?: Maybe<Array<Scalars['String']>>;
-  customFields?: Maybe<UpdateOrderCustomFieldsInput>;
 };
 
 export type ModifyOrderOptions = {
@@ -2705,16 +2596,6 @@ export type Mutation = {
   addMembersToZone: Zone;
   /** Remove members from a Zone */
   removeMembersFromZone: Zone;
-  requestAdminPasswordReset?: Maybe<Scalars['Boolean']>;
-  resetAdminPassword: ResetAdminPasswordResponse;
-  createVendor: Vendor;
-  updateVendor: Vendor;
-  deleteVendor: DeletionResponse;
-  assignVendorsToChannel: Array<Vendor>;
-  removeVendorsFromChannel: Array<Vendor>;
-  hardDeleteAdministrator: DeletionResponse;
-  hardDeleteVendor: DeletionResponse;
-  deleteVendorChannel: DeletionResponse;
 };
 
 export type MutationCreateAdministratorArgs = {
@@ -3256,47 +3137,6 @@ export type MutationRemoveMembersFromZoneArgs = {
   memberIds: Array<Scalars['ID']>;
 };
 
-export type MutationRequestAdminPasswordResetArgs = {
-  email: Scalars['String'];
-};
-
-export type MutationResetAdminPasswordArgs = {
-  token: Scalars['String'];
-  password: Scalars['String'];
-};
-
-export type MutationCreateVendorArgs = {
-  input: CreateVendorInput;
-};
-
-export type MutationUpdateVendorArgs = {
-  input: UpdateVendorInput;
-};
-
-export type MutationDeleteVendorArgs = {
-  id: Scalars['ID'];
-};
-
-export type MutationAssignVendorsToChannelArgs = {
-  input: AssignVendorsToChannelInput;
-};
-
-export type MutationRemoveVendorsFromChannelArgs = {
-  input: RemoveVendorsFromChannelInput;
-};
-
-export type MutationHardDeleteAdministratorArgs = {
-  emailAddress: Scalars['String'];
-};
-
-export type MutationHardDeleteVendorArgs = {
-  name: Scalars['String'];
-};
-
-export type MutationDeleteVendorChannelArgs = {
-  vendorSlug: Scalars['String'];
-};
-
 export type NativeAuthInput = {
   username: Scalars['String'];
   password: Scalars['String'];
@@ -3417,7 +3257,7 @@ export type Order = Node & {
   /** A summary of the taxes being applied to this Order */
   taxSummary: Array<OrderTaxSummary>;
   history: HistoryEntryList;
-  customFields?: Maybe<OrderCustomFields>;
+  customFields?: Maybe<Scalars['JSON']>;
 };
 
 export type OrderHistoryArgs = {
@@ -3438,14 +3278,6 @@ export type OrderAddress = {
   customFields?: Maybe<Scalars['JSON']>;
 };
 
-export type OrderCustomFields = {
-  deliveryDate?: Maybe<Scalars['String']>;
-  deliveryInstructions?: Maybe<Scalars['String']>;
-  mobileNumber?: Maybe<Scalars['String']>;
-  shopifyId?: Maybe<Scalars['Float']>;
-  giftCard?: Maybe<Scalars['String']>;
-};
-
 export type OrderFilterParameter = {
   customerLastName?: Maybe<StringOperators>;
   transactionId?: Maybe<StringOperators>;
@@ -3464,11 +3296,6 @@ export type OrderFilterParameter = {
   shippingWithTax?: Maybe<NumberOperators>;
   total?: Maybe<NumberOperators>;
   totalWithTax?: Maybe<NumberOperators>;
-  deliveryDate?: Maybe<StringOperators>;
-  deliveryInstructions?: Maybe<StringOperators>;
-  mobileNumber?: Maybe<StringOperators>;
-  shopifyId?: Maybe<NumberOperators>;
-  giftCard?: Maybe<StringOperators>;
 };
 
 export type OrderItem = Node & {
@@ -3572,13 +3399,7 @@ export type OrderLine = Node & {
   taxLines: Array<TaxLine>;
   order: Order;
   fulfillments?: Maybe<Array<Fulfillment>>;
-  customFields?: Maybe<OrderLineCustomFields>;
-};
-
-export type OrderLineCustomFields = {
-  shopifyId?: Maybe<Scalars['Float']>;
-  costPerItem?: Maybe<Scalars['Float']>;
-  vendorOrder?: Maybe<VendorOrder>;
+  customFields?: Maybe<Scalars['JSON']>;
 };
 
 export type OrderLineInput = {
@@ -3650,11 +3471,6 @@ export type OrderSortParameter = {
   shippingWithTax?: Maybe<SortOrder>;
   total?: Maybe<SortOrder>;
   totalWithTax?: Maybe<SortOrder>;
-  deliveryDate?: Maybe<SortOrder>;
-  deliveryInstructions?: Maybe<SortOrder>;
-  mobileNumber?: Maybe<SortOrder>;
-  shopifyId?: Maybe<SortOrder>;
-  giftCard?: Maybe<SortOrder>;
 };
 
 /** Returned if there is an error in transitioning the Order state */
@@ -3987,22 +3803,6 @@ export enum Permission {
   UpdateZone = 'UpdateZone',
   /** Grants permission to delete Zone */
   DeleteZone = 'DeleteZone',
-  /** Allows read access to inventory levels */
-  ReadInventoryLevels = 'ReadInventoryLevels',
-  /** Allows access to temporary links for partners */
-  AccessTemporaryLinks = 'AccessTemporaryLinks',
-  /** Grants permission to create Vendor */
-  CreateVendor = 'CreateVendor',
-  /** Grants permission to read Vendor */
-  ReadVendor = 'ReadVendor',
-  /** Grants permission to update Vendor */
-  UpdateVendor = 'UpdateVendor',
-  /** Grants permission to delete Vendor */
-  DeleteVendor = 'DeleteVendor',
-  /** Allows read access to vendor sales reports */
-  ReadSalesReports = 'ReadSalesReports',
-  /** Allows read access to vendor remittances and payouts */
-  ReadRemittances = 'ReadRemittances',
 }
 
 export type PermissionDefinition = {
@@ -4018,16 +3818,6 @@ export type PreviewCollectionVariantsInput = {
 
 /** The price range where the result has more than one price */
 export type PriceRange = {
-  min: Scalars['Int'];
-  max: Scalars['Int'];
-};
-
-export type PriceRangeBucket = {
-  to: Scalars['Int'];
-  count: Scalars['Int'];
-};
-
-export type PriceRangeInput = {
   min: Scalars['Int'];
   max: Scalars['Int'];
 };
@@ -4052,18 +3842,11 @@ export type Product = Node & {
   facetValues: Array<FacetValue>;
   translations: Array<ProductTranslation>;
   collections: Array<Collection>;
-  customFields?: Maybe<ProductCustomFields>;
+  customFields?: Maybe<Scalars['JSON']>;
 };
 
 export type ProductVariantListArgs = {
   options?: Maybe<ProductVariantListOptions>;
-};
-
-export type ProductCustomFields = {
-  shopifyId?: Maybe<Scalars['Float']>;
-  toDisable?: Maybe<Scalars['Boolean']>;
-  isBundle?: Maybe<Scalars['Boolean']>;
-  brand?: Maybe<Brand>;
 };
 
 export type ProductFilterParameter = {
@@ -4075,9 +3858,6 @@ export type ProductFilterParameter = {
   name?: Maybe<StringOperators>;
   slug?: Maybe<StringOperators>;
   description?: Maybe<StringOperators>;
-  shopifyId?: Maybe<NumberOperators>;
-  toDisable?: Maybe<BooleanOperators>;
-  isBundle?: Maybe<BooleanOperators>;
 };
 
 export type ProductList = PaginatedList & {
@@ -4120,11 +3900,7 @@ export type ProductOptionGroup = Node & {
   name: Scalars['String'];
   options: Array<ProductOption>;
   translations: Array<ProductOptionGroupTranslation>;
-  customFields?: Maybe<ProductOptionGroupCustomFields>;
-};
-
-export type ProductOptionGroupCustomFields = {
-  shopifyId?: Maybe<Scalars['Float']>;
+  customFields?: Maybe<Scalars['JSON']>;
 };
 
 export type ProductOptionGroupTranslation = {
@@ -4164,47 +3940,6 @@ export type ProductOptionTranslationInput = {
   customFields?: Maybe<Scalars['JSON']>;
 };
 
-export type ProductSales = Node & {
-  id: Scalars['ID'];
-  name: Scalars['String'];
-  quantitySold: Scalars['Int'];
-  revenue: Scalars['Int'];
-};
-
-export type ProductSalesFilterParameter = {
-  id?: Maybe<IdOperators>;
-  name?: Maybe<StringOperators>;
-  quantitySold?: Maybe<NumberOperators>;
-  revenue?: Maybe<NumberOperators>;
-};
-
-export type ProductSalesList = PaginatedList & {
-  items: Array<ProductSales>;
-  totalItems: Scalars['Int'];
-};
-
-export type ProductSalesListOptions = {
-  startDate: Scalars['DateTime'];
-  endDate: Scalars['DateTime'];
-  /** Skips the first n results, for use in pagination */
-  skip?: Maybe<Scalars['Int']>;
-  /** Takes n results, for use in pagination */
-  take?: Maybe<Scalars['Int']>;
-  /** Specifies which properties to sort the results by */
-  sort?: Maybe<ProductSalesSortParameter>;
-  /** Allows the results to be filtered */
-  filter?: Maybe<ProductSalesFilterParameter>;
-  /** Specifies whether multiple "filter" arguments should be combines with a logical AND or OR operation. Defaults to AND. */
-  filterOperator?: Maybe<LogicalOperator>;
-};
-
-export type ProductSalesSortParameter = {
-  id?: Maybe<SortOrder>;
-  name?: Maybe<SortOrder>;
-  quantitySold?: Maybe<SortOrder>;
-  revenue?: Maybe<SortOrder>;
-};
-
 export type ProductSortParameter = {
   id?: Maybe<SortOrder>;
   createdAt?: Maybe<SortOrder>;
@@ -4212,10 +3947,6 @@ export type ProductSortParameter = {
   name?: Maybe<SortOrder>;
   slug?: Maybe<SortOrder>;
   description?: Maybe<SortOrder>;
-  shopifyId?: Maybe<SortOrder>;
-  toDisable?: Maybe<SortOrder>;
-  isBundle?: Maybe<SortOrder>;
-  brand?: Maybe<SortOrder>;
 };
 
 export type ProductTranslation = {
@@ -4265,16 +3996,11 @@ export type ProductVariant = Node & {
   options: Array<ProductOption>;
   facetValues: Array<FacetValue>;
   translations: Array<ProductVariantTranslation>;
-  customFields?: Maybe<ProductVariantCustomFields>;
+  customFields?: Maybe<Scalars['JSON']>;
 };
 
 export type ProductVariantStockMovementsArgs = {
   options?: Maybe<StockMovementListOptions>;
-};
-
-export type ProductVariantCustomFields = {
-  shopifyId?: Maybe<Scalars['Float']>;
-  costPerItem?: Maybe<Scalars['Int']>;
 };
 
 export type ProductVariantFilterParameter = {
@@ -4295,8 +4021,6 @@ export type ProductVariantFilterParameter = {
   currencyCode?: Maybe<StringOperators>;
   priceWithTax?: Maybe<NumberOperators>;
   stockLevel?: Maybe<StringOperators>;
-  shopifyId?: Maybe<NumberOperators>;
-  costPerItem?: Maybe<NumberOperators>;
 };
 
 export type ProductVariantList = PaginatedList & {
@@ -4330,8 +4054,6 @@ export type ProductVariantSortParameter = {
   price?: Maybe<SortOrder>;
   priceWithTax?: Maybe<SortOrder>;
   stockLevel?: Maybe<SortOrder>;
-  shopifyId?: Maybe<SortOrder>;
-  costPerItem?: Maybe<SortOrder>;
 };
 
 export type ProductVariantTranslation = {
@@ -4485,14 +4207,6 @@ export type Query = {
   taxRate?: Maybe<TaxRate>;
   zones: Array<Zone>;
   zone?: Maybe<Zone>;
-  locations: Array<InventoryLocation>;
-  inventory: InventoryItemList;
-  vendors: VendorList;
-  vendor?: Maybe<Vendor>;
-  productSales: ProductSalesList;
-  salesSummary: SalesSummary;
-  remittanceSummaries: RemittanceSummaryList;
-  remittance: Remittance;
 };
 
 export type QueryAdministratorsArgs = {
@@ -4687,41 +4401,6 @@ export type QueryZoneArgs = {
   id: Scalars['ID'];
 };
 
-export type QueryInventoryArgs = {
-  vendorId: Scalars['ID'];
-  options?: Maybe<InventoryItemListOptions>;
-};
-
-export type QueryVendorsArgs = {
-  options?: Maybe<VendorListOptions>;
-};
-
-export type QueryVendorArgs = {
-  id?: Maybe<Scalars['ID']>;
-  slug?: Maybe<Scalars['String']>;
-};
-
-export type QueryProductSalesArgs = {
-  vendorId: Scalars['ID'];
-  options?: Maybe<ProductSalesListOptions>;
-};
-
-export type QuerySalesSummaryArgs = {
-  vendorId: Scalars['ID'];
-  startDate: Scalars['DateTime'];
-  endDate: Scalars['DateTime'];
-};
-
-export type QueryRemittanceSummariesArgs = {
-  vendorId: Scalars['ID'];
-  options?: Maybe<RemittanceSummaryListOptions>;
-};
-
-export type QueryRemittanceArgs = {
-  vendorId: Scalars['ID'];
-  id: Scalars['ID'];
-};
-
 export type Refund = Node & {
   id: Scalars['ID'];
   createdAt: Scalars['DateTime'];
@@ -4808,86 +4487,6 @@ export type Release = Node &
     orderItem: OrderItem;
   };
 
-export type Remittance = {
-  id: Scalars['ID'];
-  vendorId: Scalars['ID'];
-  invoiceNumber: Scalars['ID'];
-  invoiceDate: Scalars['DateTime'];
-  paymentDate: Scalars['DateTime'];
-  totalPaid: Scalars['Int'];
-  transactions: Array<RemittanceTransaction>;
-  products: Array<RemittanceProduct>;
-  payout: RemittancePayout;
-  downloadLink: Scalars['String'];
-};
-
-export type RemittancePayout = {
-  subTotal: Scalars['Int'];
-  totalFees: Scalars['Int'];
-  payout: Scalars['Int'];
-  totalPaid: Scalars['Int'];
-};
-
-export type RemittanceProduct = {
-  name: Scalars['String'];
-  productName: Scalars['String'];
-  totalUnits: Scalars['Int'];
-  cost: Scalars['Int'];
-  date: Scalars['DateTime'];
-  subTotal: Scalars['Int'];
-  fee: Scalars['Int'];
-  net: Scalars['Int'];
-};
-
-export type RemittanceSummary = Node & {
-  id: Scalars['ID'];
-  paymentDate: Scalars['DateTime'];
-  amount: Scalars['Int'];
-  downloadLink: Scalars['String'];
-};
-
-export type RemittanceSummaryFilterParameter = {
-  id?: Maybe<IdOperators>;
-  paymentDate?: Maybe<DateOperators>;
-  amount?: Maybe<NumberOperators>;
-  downloadLink?: Maybe<StringOperators>;
-};
-
-export type RemittanceSummaryList = PaginatedList & {
-  items: Array<RemittanceSummary>;
-  totalEarnings: Scalars['Int'];
-  totalItems: Scalars['Int'];
-  vendorId: Scalars['ID'];
-};
-
-export type RemittanceSummaryListOptions = {
-  /** Skips the first n results, for use in pagination */
-  skip?: Maybe<Scalars['Int']>;
-  /** Takes n results, for use in pagination */
-  take?: Maybe<Scalars['Int']>;
-  /** Specifies which properties to sort the results by */
-  sort?: Maybe<RemittanceSummarySortParameter>;
-  /** Allows the results to be filtered */
-  filter?: Maybe<RemittanceSummaryFilterParameter>;
-  /** Specifies whether multiple "filter" arguments should be combines with a logical AND or OR operation. Defaults to AND. */
-  filterOperator?: Maybe<LogicalOperator>;
-};
-
-export type RemittanceSummarySortParameter = {
-  id?: Maybe<SortOrder>;
-  paymentDate?: Maybe<SortOrder>;
-  amount?: Maybe<SortOrder>;
-  downloadLink?: Maybe<SortOrder>;
-};
-
-export type RemittanceTransaction = {
-  transaction: Scalars['String'];
-  date: Scalars['DateTime'];
-  subTotal: Scalars['Int'];
-  fee: Scalars['Int'];
-  net: Scalars['Int'];
-};
-
 export type RemoveCollectionsFromChannelInput = {
   collectionIds: Array<Scalars['ID']>;
   channelId: Scalars['ID'];
@@ -4918,16 +4517,6 @@ export type RemoveProductsFromChannelInput = {
 export type RemovePromotionsFromChannelInput = {
   promotionIds: Array<Scalars['ID']>;
   channelId: Scalars['ID'];
-};
-
-export type RemoveVendorsFromChannelInput = {
-  vendorIds: Array<Scalars['ID']>;
-  channelId: Scalars['ID'];
-};
-
-export type ResetAdminPasswordResponse = {
-  success: Scalars['Boolean'];
-  message?: Maybe<Scalars['String']>;
 };
 
 export type Return = Node &
@@ -4996,13 +4585,6 @@ export type Sale = Node &
     orderItem: OrderItem;
   };
 
-export type SalesSummary = {
-  vendorId: Scalars['ID'];
-  revenue: Scalars['Int'];
-  orders: Scalars['Int'];
-  itemsSold: Scalars['Int'];
-};
-
 export type SearchInput = {
   term?: Maybe<Scalars['String']>;
   facetValueIds?: Maybe<Array<Scalars['ID']>>;
@@ -5014,10 +4596,6 @@ export type SearchInput = {
   take?: Maybe<Scalars['Int']>;
   skip?: Maybe<Scalars['Int']>;
   sort?: Maybe<SearchResultSortParameter>;
-  priceRange?: Maybe<PriceRangeInput>;
-  priceRangeWithTax?: Maybe<PriceRangeInput>;
-  inStock?: Maybe<Scalars['Boolean']>;
-  vendorId?: Maybe<Scalars['ID']>;
 };
 
 export type SearchReindexResponse = {
@@ -5029,14 +4607,6 @@ export type SearchResponse = {
   totalItems: Scalars['Int'];
   facetValues: Array<FacetValueResult>;
   collections: Array<CollectionResult>;
-  prices: SearchResponsePriceData;
-};
-
-export type SearchResponsePriceData = {
-  range: PriceRange;
-  rangeWithTax: PriceRange;
-  buckets: Array<PriceRangeBucket>;
-  bucketsWithTax: Array<PriceRangeBucket>;
 };
 
 export type SearchResult = {
@@ -5061,10 +4631,6 @@ export type SearchResult = {
   collectionIds: Array<Scalars['ID']>;
   /** A relevance score for the result. Differs between database implementations */
   score: Scalars['Float'];
-  inStock?: Maybe<Scalars['Boolean']>;
-  /** @deprecated Use customProductMappings or customProductVariantMappings */
-  customMappings: CustomProductMappings;
-  customProductMappings: CustomProductMappings;
 };
 
 export type SearchResultAsset = {
@@ -5613,15 +5179,9 @@ export type UpdateOrderAddressInput = {
   phoneNumber?: Maybe<Scalars['String']>;
 };
 
-export type UpdateOrderCustomFieldsInput = {
-  deliveryDate?: Maybe<Scalars['String']>;
-  deliveryInstructions?: Maybe<Scalars['String']>;
-  mobileNumber?: Maybe<Scalars['String']>;
-};
-
 export type UpdateOrderInput = {
   id: Scalars['ID'];
-  customFields?: Maybe<UpdateOrderCustomFieldsInput>;
+  customFields?: Maybe<Scalars['JSON']>;
 };
 
 export type UpdateOrderItemsResult =
@@ -5648,10 +5208,6 @@ export type UpdatePaymentMethodInput = {
   customFields?: Maybe<Scalars['JSON']>;
 };
 
-export type UpdateProductCustomFieldsInput = {
-  brandId?: Maybe<Scalars['ID']>;
-};
-
 export type UpdateProductInput = {
   id: Scalars['ID'];
   enabled?: Maybe<Scalars['Boolean']>;
@@ -5659,7 +5215,7 @@ export type UpdateProductInput = {
   assetIds?: Maybe<Array<Scalars['ID']>>;
   facetValueIds?: Maybe<Array<Scalars['ID']>>;
   translations?: Maybe<Array<ProductTranslationInput>>;
-  customFields?: Maybe<UpdateProductCustomFieldsInput>;
+  customFields?: Maybe<Scalars['JSON']>;
 };
 
 export type UpdateProductOptionGroupInput = {
@@ -5676,10 +5232,6 @@ export type UpdateProductOptionInput = {
   customFields?: Maybe<Scalars['JSON']>;
 };
 
-export type UpdateProductVariantCustomFieldsInput = {
-  costPerItem?: Maybe<Scalars['Int']>;
-};
-
 export type UpdateProductVariantInput = {
   id: Scalars['ID'];
   enabled?: Maybe<Scalars['Boolean']>;
@@ -5694,7 +5246,7 @@ export type UpdateProductVariantInput = {
   outOfStockThreshold?: Maybe<Scalars['Int']>;
   useGlobalOutOfStockThreshold?: Maybe<Scalars['Boolean']>;
   trackInventory?: Maybe<GlobalFlag>;
-  customFields?: Maybe<UpdateProductVariantCustomFieldsInput>;
+  customFields?: Maybe<Scalars['JSON']>;
 };
 
 export type UpdatePromotionInput = {
@@ -5753,34 +5305,6 @@ export type UpdateTaxRateInput = {
   customFields?: Maybe<Scalars['JSON']>;
 };
 
-export type UpdateVendorBrandInput = {
-  name: Scalars['String'];
-  slug: Scalars['String'];
-  id?: Maybe<Scalars['ID']>;
-};
-
-export type UpdateVendorInput = {
-  id: Scalars['ID'];
-  name?: Maybe<Scalars['String']>;
-  slug?: Maybe<Scalars['String']>;
-  address?: Maybe<Scalars['String']>;
-  phone?: Maybe<Scalars['String']>;
-  websiteUrl?: Maybe<Scalars['String']>;
-  featuredAssetId?: Maybe<Scalars['ID']>;
-  stripeConnectedAccountId?: Maybe<Scalars['String']>;
-  assetIds?: Maybe<Array<Scalars['ID']>>;
-  translations?: Maybe<Array<UpdateVendorTranslationInput>>;
-  shopifyId?: Maybe<Scalars['Int']>;
-  brands?: Maybe<Array<UpdateVendorBrandInput>>;
-  colabId?: Maybe<Scalars['Int']>;
-};
-
-export type UpdateVendorTranslationInput = {
-  id?: Maybe<Scalars['ID']>;
-  languageCode: LanguageCode;
-  description?: Maybe<Scalars['String']>;
-};
-
 export type UpdateZoneInput = {
   id: Scalars['ID'];
   name?: Maybe<Scalars['String']>;
@@ -5797,90 +5321,6 @@ export type User = Node & {
   lastLogin?: Maybe<Scalars['DateTime']>;
   authenticationMethods: Array<AuthenticationMethod>;
   customFields?: Maybe<Scalars['JSON']>;
-};
-
-export type Vendor = Node & {
-  id: Scalars['ID'];
-  createdAt: Scalars['DateTime'];
-  updatedAt: Scalars['DateTime'];
-  languageCode?: Maybe<LanguageCode>;
-  name: Scalars['String'];
-  slug: Scalars['String'];
-  description: Scalars['String'];
-  address?: Maybe<Scalars['String']>;
-  phone?: Maybe<Scalars['String']>;
-  websiteUrl?: Maybe<Scalars['String']>;
-  featuredAsset?: Maybe<Asset>;
-  assets: Array<Asset>;
-  translations: Array<VendorTranslation>;
-  products?: Maybe<ProductList>;
-  stripeConnectedAccountId?: Maybe<Scalars['String']>;
-  channels: Array<Channel>;
-};
-
-export type VendorProductsArgs = {
-  options?: Maybe<ProductListOptions>;
-};
-
-export type VendorFilterParameter = {
-  id?: Maybe<IdOperators>;
-  createdAt?: Maybe<DateOperators>;
-  updatedAt?: Maybe<DateOperators>;
-  languageCode?: Maybe<StringOperators>;
-  name?: Maybe<StringOperators>;
-  slug?: Maybe<StringOperators>;
-  description?: Maybe<StringOperators>;
-  address?: Maybe<StringOperators>;
-  phone?: Maybe<StringOperators>;
-  websiteUrl?: Maybe<StringOperators>;
-  stripeConnectedAccountId?: Maybe<StringOperators>;
-};
-
-export type VendorList = PaginatedList & {
-  items: Array<Vendor>;
-  totalItems: Scalars['Int'];
-};
-
-export type VendorListOptions = {
-  /** Skips the first n results, for use in pagination */
-  skip?: Maybe<Scalars['Int']>;
-  /** Takes n results, for use in pagination */
-  take?: Maybe<Scalars['Int']>;
-  /** Specifies which properties to sort the results by */
-  sort?: Maybe<VendorSortParameter>;
-  /** Allows the results to be filtered */
-  filter?: Maybe<VendorFilterParameter>;
-  /** Specifies whether multiple "filter" arguments should be combines with a logical AND or OR operation. Defaults to AND. */
-  filterOperator?: Maybe<LogicalOperator>;
-};
-
-export type VendorOrder = {
-  id: Scalars['ID'];
-  createdAt: Scalars['DateTime'];
-  updatedAt: Scalars['DateTime'];
-  vendorId: Scalars['ID'];
-  orderId: Scalars['ID'];
-};
-
-export type VendorSortParameter = {
-  id?: Maybe<SortOrder>;
-  createdAt?: Maybe<SortOrder>;
-  updatedAt?: Maybe<SortOrder>;
-  name?: Maybe<SortOrder>;
-  slug?: Maybe<SortOrder>;
-  description?: Maybe<SortOrder>;
-  address?: Maybe<SortOrder>;
-  phone?: Maybe<SortOrder>;
-  websiteUrl?: Maybe<SortOrder>;
-  stripeConnectedAccountId?: Maybe<SortOrder>;
-};
-
-export type VendorTranslation = {
-  id: Scalars['ID'];
-  createdAt: Scalars['DateTime'];
-  updatedAt: Scalars['DateTime'];
-  languageCode: LanguageCode;
-  description: Scalars['String'];
 };
 
 export type Zone = Node & {

--- a/packages/core/e2e/graphql/shared-definitions.ts
+++ b/packages/core/e2e/graphql/shared-definitions.ts
@@ -208,6 +208,10 @@ export const ATTEMPT_LOGIN = gql`
     mutation AttemptLogin($username: String!, $password: String!, $rememberMe: Boolean) {
         login(username: $username, password: $password, rememberMe: $rememberMe) {
             ...CurrentUser
+            ... on ErrorResult {
+                errorCode
+                message
+            }
         }
     }
     ${CURRENT_USER_FRAGMENT}

--- a/packages/core/src/api/resolvers/entity/customer-entity.resolver.ts
+++ b/packages/core/src/api/resolvers/entity/customer-entity.resolver.ts
@@ -56,7 +56,7 @@ export class CustomerEntityResolver {
             return customer.user;
         }
 
-        return this.userService.getUserByEmailAddress(ctx, customer.emailAddress);
+        return this.userService.getUserByEmailAddress(ctx, customer.emailAddress, 'customer');
     }
 }
 

--- a/packages/core/src/service/services/customer.service.ts
+++ b/packages/core/src/service/services/customer.service.ts
@@ -227,12 +227,11 @@ export class CustomerService {
                 deletedAt: null,
             },
         });
-        const existingUser = await this.connection.getRepository(ctx, User).findOne({
-            where: {
-                identifier: input.emailAddress,
-                deletedAt: null,
-            },
-        });
+        const existingUser = await this.userService.getUserByEmailAddress(
+            ctx,
+            input.emailAddress,
+            'customer',
+        );
 
         if (existingCustomer && existingUser) {
             // Customer already exists, bring to this Channel
@@ -326,6 +325,7 @@ export class CustomerService {
                     const existingUserWithEmailAddress = await this.userService.getUserByEmailAddress(
                         ctx,
                         input.emailAddress,
+                        'customer',
                     );
 
                     if (

--- a/packages/core/src/service/services/user.service.ts
+++ b/packages/core/src/service/services/user.service.ts
@@ -53,7 +53,8 @@ export class UserService {
         emailAddress: string,
         userType?: 'administrator' | 'customer',
     ): Promise<User | undefined> {
-        const table = userType ?? ctx.apiType === 'admin' ? 'administrator' : 'customer';
+        const entity = userType ?? (ctx.apiType === 'admin' ? 'administrator' : 'customer');
+        const table = `${this.configService.dbConnectionOptions.entityPrefix ?? ''}${entity}`;
 
         return this.connection
             .getRepository(ctx, User)


### PR DESCRIPTION
Slack thread [here](https://vendure-ecommerce.slack.com/archives/CKYMF0ZTJ/p1674795935727559).

Anyone can be both customer and an administrator using the same email address, since `identifier` is not a unique key in the `user` table. However, some of the existing logic - most notably authentication - ignores that fact and retrieves the first user in the database with a given email without taking user type (Customer vs Admin) or context (Admin vs Shop API) into account. An example of a consequence can be reproduced following the steps below:

* Register a customer and set, say, test@test.com as their email address
* Create a new administrator in the Admin UI using the same email
* Attempt to login to the Admin UI using the credentials of the administrator created above. We always get an "invalid credentials" error even with the right password

In this case, the issue occurs because the user associated to the customer record was created first, and when matching the provided admin password the user connected to the administrator account is never retrieved.

The main change this PR introduces is an update to the `UserService.getUserByEmailAddress` method, which is ultimately used for, among others:

* Login
* Password reset
* Some customer-related operations
* Resolving the `user` field for customers and administrators

Instead of retrieving the first user with the provided email, it now takes an optional `userType` parameter for cases where user type _**cannot**_ be inferred by the API type (Admin or Shop):

* Resolving `user` for customers, since querying the entity is available in both APIs
* Creating or updating a customer, whose operations are also available in both APIs

In all other cases, user type is inferred by API type.