### PR TITLE
Fix/ignore soft deleted product options

### DIFF
--- a/packages/core/src/service/services/product-option-group.service.ts
+++ b/packages/core/src/service/services/product-option-group.service.ts
@@ -145,7 +145,9 @@ export class ProductOptionGroupService {
             };
         }
 
-        for (const option of optionGroup.options) {
+        const optionsToDelete = optionGroup.options && optionGroup.options.filter(group => !group.deletedAt);
+
+        for (const option of optionsToDelete) {
             const { result, message } = await this.productOptionService.delete(ctx, option.id);
             if (result === DeletionResult.NOT_DELETED) {
                 await this.connection.rollBackTransaction(ctx);

--- a/packages/core/src/service/services/product-variant.service.ts
+++ b/packages/core/src/service/services/product-variant.service.ts
@@ -733,8 +733,9 @@ export class ProductVariantService {
         ).optionGroups;
 
         const optionIds = input.optionIds || [];
+        const activeOptions = optionGroups && optionGroups.filter(group => !group.deletedAt);
 
-        if (optionIds.length !== optionGroups.length) {
+        if (optionIds.length !== activeOptions.length) {
             this.throwIncompatibleOptionsError(optionGroups);
         }
         if (


### PR DESCRIPTION
Fixes https://github.com/vendure-ecommerce/vendure/issues/2015

**Cause:** If a product group has one or more deleted options, the remove group from product function fails.

**Fix:** Excludes deleted options to not try to redelete them. So, it allows to set deleteAt in the ProductOptionGroup entity correctly.