### PR TITLE
fix(admin-ui): Fix UI for long channel list tab on Administrator detail page

### DIFF
--- a/packages/admin-ui/src/lib/settings/src/components/admin-detail/admin-detail.component.scss
+++ b/packages/admin-ui/src/lib/settings/src/components/admin-detail/admin-detail.component.scss
@@ -1,0 +1,3 @@
+ul.nav {
+    overflow-x: auto;
+}


### PR DESCRIPTION
Fix small cosmetic issue on the Administrator detail page when the channel list is too long. As it can be seen below, it overflows the content box and doesn't respect the boundaries of the view. A quick solution is to present a horizontal scrollbar when necessary.

#### Before

![before_list](https://user-images.githubusercontent.com/8788208/216237426-6a802f24-4526-447e-a320-6b568f0fb187.gif)

#### After

![after_list](https://user-images.githubusercontent.com/8788208/216237449-ccb56328-268e-496f-9113-b91422c95675.gif)