### PR TITLE
feat(testing): Turn productsCsvPath into an optional property for test server initialization

### DIFF
--- a/docs/content/developer-guide/testing.md
+++ b/docs/content/developer-guide/testing.md
@@ -95,7 +95,7 @@ afterAll(async () => {
 
 An explanation of the options:
 
-* `productsCsvPath` This is a path to a CSV file containing product data. See [Product Import Format]({{< relref "importing-product-data" >}}#product-import-format). You can see [an example used in the Vendure e2e tests](https://github.com/vendure-ecommerce/vendure/blob/master/packages/core/e2e/fixtures/e2e-products-full.csv) to get an idea of how it works. To start with you can just copy this file directly and use it as-is.
+* `productsCsvPath` This is a path to an optional CSV file containing product data. See [Product Import Format]({{< relref "importing-product-data" >}}#product-import-format). You can see [an example used in the Vendure e2e tests](https://github.com/vendure-ecommerce/vendure/blob/master/packages/core/e2e/fixtures/e2e-products-full.csv) to get an idea of how it works. To start with you can just copy this file directly and use it as-is.
 * `initialData` This is an object which defines how other non-product data (Collections, ShippingMethods, Countries etc.) is populated. See [Initial Data Format]({{< relref "importing-product-data" >}}#initial-data). You can [copy this example from the Vendure e2e tests](https://github.com/vendure-ecommerce/vendure/blob/master/e2e-common/e2e-initial-data.ts)
 * `customerCount` Specifies the number of fake Customers to create. Defaults to 10 if not specified.
 

--- a/packages/testing/src/data-population/populate-for-testing.ts
+++ b/packages/testing/src/data-population/populate-for-testing.ts
@@ -35,11 +35,22 @@ export async function populateForTesting<T extends INestApplicationContext>(
     return app;
 }
 
-async function populateProducts(app: INestApplicationContext, productsCsvPath: string, logging: boolean) {
+async function populateProducts(
+    app: INestApplicationContext,
+    productsCsvPath: string | undefined,
+    logging: boolean,
+) {
+    if (!productsCsvPath) {
+        if (logging) {
+            console.log(`\nNo product data provided, skipping product import`);
+        }
+        return;
+    }
+
     const importResult = await importProductsFromCsv(app, productsCsvPath, LanguageCode.en);
     if (importResult.errors && importResult.errors.length) {
         console.log(`${importResult.errors.length} errors encountered when importing product data:`);
-        await console.log(importResult.errors.join('\n'));
+        console.log(importResult.errors.join('\n'));
     }
 
     if (logging) {

--- a/packages/testing/src/types.ts
+++ b/packages/testing/src/types.ts
@@ -14,9 +14,9 @@ export type Mutable<T> = { -readonly [K in keyof T]: T[K] };
 export interface TestServerOptions {
     /**
      * @description
-     * The path to a CSV file containing product data to import.
+     * The path to an optional CSV file containing product data to import.
      */
-    productsCsvPath: string;
+    productsCsvPath?: string;
     /**
      * @description
      * An object containing non-product data which is used to populate the database.


### PR DESCRIPTION
Currently, `productsCsvPath` is a required field when [initialising the test server](https://www.vendure.io/docs/developer-guide/testing/#initialize-the-server), regardless whether or not the developer needs product data to begin with. An alternative is to provide a CSV with headers only and not data rows, which is not a big deal but as a matter of convenience it would be nice to skip the property entirely. This PR updates the attribute to be optional.