### PR TITLE
Fix: Merge nested relations correctly

### DIFF
--- a/packages/core/e2e/list-query-builder.e2e-spec.ts
+++ b/packages/core/e2e/list-query-builder.e2e-spec.ts
@@ -1246,6 +1246,28 @@ describe('ListQueryBuilder', () => {
             ]);
         });
     });
+
+    describe('relations in customFields', () => {
+        it('should resolve relations in customFields successfully', async () => {
+            const { testEntities } = await shopClient.query(GET_LIST_WITH_CUSTOM_FIELD_RELATION, {
+                options: {
+                    filter: {
+                        label: { eq: 'A' },
+                    },
+                },
+            });
+
+            expect(testEntities.items).toEqual([
+                {
+                    id: 'T_1',
+                    label: 'A',
+                    customFields: {
+                        relation: [{ id: 'T_1', data: 'A' }],
+                    },
+                },
+            ]);
+        });
+    });
 });
 
 const GET_LIST = gql`
@@ -1308,6 +1330,23 @@ const GET_ARRAY_LIST = gql`
             name
             date
             price
+        }
+    }
+`;
+
+const GET_LIST_WITH_CUSTOM_FIELD_RELATION = gql`
+    query GetTestWithCustomFieldRelation($options: TestEntityListOptions) {
+        testEntities(options: $options) {
+            items {
+                id
+                label
+                customFields {
+                    relation {
+                        id
+                        data
+                    }
+                }
+            }
         }
     }
 `;

--- a/packages/core/src/service/helpers/list-query-builder/list-query-builder.ts
+++ b/packages/core/src/service/helpers/list-query-builder/list-query-builder.ts
@@ -492,10 +492,33 @@ export class ListQueryBuilder implements OnApplicationBootstrap {
         for (const entry of entitiesIdsWithRelations) {
             const finalEntity = entityMap.get(entry.entity.id);
             if (finalEntity) {
-                finalEntity[entry.relation] = entry.entity[entry.relation];
+                this.assignDeep(entry.relation, entry.entity, finalEntity);
             }
         }
         return Array.from(entityMap.values());
+    }
+
+    private assignDeep<T>(relation: string | keyof T, source: T, target: T) {
+        if (typeof relation === 'string') {
+            const parts = relation.split('.');
+            let resolvedTarget: any = target;
+            let resolvedSource: any = source;
+
+            for (const part of parts.slice(0, parts.length - 1)) {
+                if (!resolvedTarget[part]) {
+                    resolvedTarget[part] = {};
+                }
+                if (!resolvedSource[part]) {
+                    return;
+                }
+                resolvedTarget = resolvedTarget[part];
+                resolvedSource = resolvedSource[part];
+            }
+
+            resolvedTarget[parts[parts.length - 1]] = resolvedSource[parts[parts.length - 1]];
+        } else {
+            target[relation] = source[relation];
+        }
     }
 
     /**


### PR DESCRIPTION
We have a custom field for `Order` that contains a relation list. Something like this:

```ts
{
  name: "xxx",
  type: "relation",
  list: true,
  entity: TargetEntity,
  readonly: true,
  internal: true,
},
```

the relation works great when reading the order directly using the `order(id: "orderId")` query. However when reading it as part of a list via `activeCustomer` the relation is not populated correctly. This is because the current version:

```ts
finalEntity[entry.relation] = entry.entity[entry.relation];
```

doe snot work for nested relations. In our case `entry.relation` would have been `customFields.xxx`.