### PR TITLE
fix(docs): remove wrong example

### DIFF
--- a/packages/asset-server-plugin/src/s3-asset-storage-strategy.ts
+++ b/packages/asset-server-plugin/src/s3-asset-storage-strategy.ts
@@ -75,7 +75,6 @@ export interface S3Config {
  *   AssetServerPlugin.init({
  *     route: 'assets',
  *     assetUploadDir: path.join(__dirname, 'assets'),
- *     port: 5002,
  *     namingStrategy: new DefaultAssetNamingStrategy(),
  *     storageStrategyFactory: configureS3AssetStorage({
  *       bucket: 'my-s3-bucket',
@@ -102,7 +101,6 @@ export interface S3Config {
  *   AssetServerPlugin.init({
  *     route: 'assets',
  *     assetUploadDir: path.join(__dirname, 'assets'),
- *     port: 5002,
  *     namingStrategy: new DefaultAssetNamingStrategy(),
  *     storageStrategyFactory: configureS3AssetStorage({
  *       bucket: 'my-minio-bucket',


### PR DESCRIPTION
`port` property is not listed in the `AssetServerOptions` (anymore?)