### PR TITLE
Fixed typos in docs

### DIFF
--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -25,7 +25,7 @@ Learn how to run your store in our [Administrator Guide]({{< relref "user-guide"
 
 Vendure is a headless e-commerce framework.
 
-* *Headless* is a term which means that it does not concern itself with rendering the HTML pages of a website. Rather, it exposes a GraphQL API which which can be *queried* for data ("Give me a list of available products") or issued with *mutation* instructions ("Add product '123' to the current order") by a *client application*. Thus the client is responsible for how the e-commerce "storefront" looks and how it works. Vendure is responsible for the rest.
+* *Headless* is a term that means it does not concern itself with rendering the HTML pages of a website. Rather, it exposes a GraphQL API which can be *queried* for data ("Give me a list of available products") or issued with *mutation* instructions ("Add product '123' to the current order") by a *client application*. Thus the client is responsible for how the e-commerce "storefront" looks and how it works. Vendure is responsible for the rest.
 * Vendure is a *framework* in that it supplies core e-commerce functionality, but is open to further extension by the developer.
 
 ## Who should use Vendure?

--- a/docs/content/deployment/deploying-admin-ui.md
+++ b/docs/content/deployment/deploying-admin-ui.md
@@ -5,7 +5,7 @@ showtoc: true
 
 ## Deploying the Admin UI
 
-If you have customized the Admin UI with extensions, you should [compile your extensions ahead-of-time as part of the deployment process]({{< relref "/docs/plugins/extending-the-admin-ui" >}}#compiling-as-a-deployment-step).
+If you have customized the Admin UI with extensions, you should [compile your extensions ahead of time as part of the deployment process]({{< relref "/docs/plugins/extending-the-admin-ui" >}}#compiling-as-a-deployment-step).
 
 ### Deploying a stand-alone Admin UI
 

--- a/docs/content/developer-guide/authentication.md
+++ b/docs/content/developer-guide/authentication.md
@@ -10,7 +10,7 @@ Authentication is the process of determining the identity of a user. Common ways
 By default, Vendure uses a username/email address and password to authenticate users, but also supports a wide range of authentication methods via configurable AuthenticationStrategies.
 
 {{< alert "primary" >}}
-See the [Managing Sessions guide]({{< relref "managing-sessions" >}}) for how to manage authenticated session in your storefront/client applications.
+See the [Managing Sessions guide]({{< relref "managing-sessions" >}}) for how to manage authenticated sessions in your storefront/client applications.
 {{< /alert >}}
 
 ## Adding support for external authentication
@@ -161,7 +161,7 @@ This example demonstrates how to implement a Facebook login flow.
 
 ### Storefront setup
 
-In this example we are assuming the use of the [Facebook SDK for JavaScript](https://developers.facebook.com/docs/javascript/) in the storefront.
+In this example, we are assuming the use of the [Facebook SDK for JavaScript](https://developers.facebook.com/docs/javascript/) in the storefront.
 
 An implementation in React might look like this:
 
@@ -329,7 +329,7 @@ This example uses [Keycloak](https://www.keycloak.org/), a popular open-source i
 
 ### Configure a login page & Admin UI
 
-In this example we'll assume the login page is hosted at `http://intranet/login`. We'll also assume that a "login to Vendure" button has been added to that page and that the page is using the [Keycloak JavaScript adapter](https://www.keycloak.org/docs/latest/securing_apps/index.html#_javascript_adapter), which can be used to get the current user's authorization token:
+In this example, we'll assume the login page is hosted at `http://intranet/login`. We'll also assume that a "login to Vendure" button has been added to that page and that the page is using the [Keycloak JavaScript adapter](https://www.keycloak.org/docs/latest/securing_apps/index.html#_javascript_adapter), which can be used to get the current user's authorization token:
 
 ```JavaScript
 vendureLoginButton.addEventListener('click', () => {

--- a/docs/content/developer-guide/configuration.md
+++ b/docs/content/developer-guide/configuration.md
@@ -11,7 +11,7 @@ The `VendureConfig` object is organised into sections, grouping related settings
 
 ## Working with the VendureConfig object
 
-Since the VendureConfig is just a JavaScript object, it can be managed and manipulated according to your needs. For example:
+Since the `VendureConfig` is just a JavaScript object, it can be managed and manipulated according to your needs. For example:
 
 ### Using environment variables
 
@@ -79,7 +79,7 @@ export const config: VendureConfig = {
 
 ## Important Configuration Settings
 
-In this guide we will take a look at those configuration options needed for getting the server up-and-running.
+In this guide, we will take a look at those configuration options needed for getting the server up and running.
 
 {{< alert "primary" >}}
 A description of every available configuration option can be found in the [VendureConfig API documentation]({{< relref "vendure-config" >}}).

--- a/docs/content/developer-guide/customizing-models.md
+++ b/docs/content/developer-guide/customizing-models.md
@@ -362,7 +362,7 @@ Customer: [
 
 ### Relations
 
-It is possible to set up custom fields which hold references to other entities using the `'relation'` type:
+It is possible to set up custom fields that hold references to other entities using the `'relation'` type:
 
 ```TypeScript
 Customer: [
@@ -405,7 +405,7 @@ mutation {
 {{% alert %}}
 **UI for relation type**
 
-The Admin UI app has built-in selection components for "relation" custom fields which reference certain common entity types, such as Asset, Product, ProductVariant and Customer. If you are relating to an entity not covered by the built-in selection components, you will see a generic relation component which allows you to manually enter the ID of the entity you wish to select.
+The Admin UI app has built-in selection components for "relation" custom fields that reference certain common entity types, such as Asset, Product, ProductVariant and Customer. If you are relating to an entity not covered by the built-in selection components, you will see a generic relation component which allows you to manually enter the ID of the entity you wish to select.
 
-If the generic selector is not suitable, or is you wish to replace one of the built-in selector components, you can create a UI extension which defines a custom field control for that custom field. You can read more about this in the [custom form input guide]({{< relref "custom-form-inputs" >}})
+If the generic selector is not suitable, or is you wish to replace one of the built-in selector components, you can create a UI extension that defines a custom field control for that custom field. You can read more about this in the [custom form input guide]({{< relref "custom-form-inputs" >}})
 {{< /alert >}}

--- a/docs/content/developer-guide/error-handling.md
+++ b/docs/content/developer-guide/error-handling.md
@@ -10,7 +10,7 @@ Errors in Vendure can be divided into two categories:
 * Unexpected errors
 * Expected errors
 
-These two types have different meanings and are handled differently to one another.
+These two types have different meanings and are handled differently from one another.
 
 ## Unexpected Errors
 
@@ -81,7 +81,7 @@ type OrderStateTransitionError implements ErrorResult {
 }
 ```
 
-Operations which may return ErrorResults use a GraphQL `union` as their return type:
+Operations that may return ErrorResults use a GraphQL `union` as their return type:
 
 ```GraphQL
 type Mutation {

--- a/docs/content/developer-guide/importing-product-data.md
+++ b/docs/content/developer-guide/importing-product-data.md
@@ -165,8 +165,8 @@ export const initialData: InitialData = {
 * `roles`: Defines which user roles are available.
   * `code`: Role code name.
   * `description`: Role description.
-  * `permissions`: List of permissions to applied to the role.
-* `defaultLanguage`: Sets the language which will be used for all translatable entities created by the initial data e.g. Products, ProductVariants, Collections etc. Should correspond to the language used in your product csv file.
+  * `permissions`: List of permissions to apply to the role.
+* `defaultLanguage`: Sets the language that will be used for all translatable entities created by the initial data e.g. Products, ProductVariants, Collections etc. Should correspond to the language used in your product csv file.
 * `countries`: Defines which countries are available.
   * `name`: The name of the country in the language specified by `defaultLanguage`
   * `code`: A standardized code for the country, e.g. [ISO 3166-1](https://en.wikipedia.org/wiki/List_of_ISO_3166_country_codes)
@@ -219,7 +219,7 @@ populate(
 );
 ```
 **Attention:** When removing the `DefaultJobQueuePlugin` from the plugins list as in the code snippet above, one should manually rebuild the search index in order for the newly added products to appear.
-In the Admin UI this can be done by navigating to the Products page and clicking the gear icon next to the search input.
+In the Admin UI, this can be done by navigating to the Products page and clicking the gear icon next to the search input.
 
 ### Custom populate scripts
 

--- a/docs/content/developer-guide/shipping.md
+++ b/docs/content/developer-guide/shipping.md
@@ -6,7 +6,7 @@ showtoc: true
 
 Shipping in Vendure is handled by [ShippingMethods]({{< relref "shipping-method" >}}). Multiple ShippingMethods can be set up and then your storefront can query [`eligibleShippingMethods`]({{< relref "/docs/graphql-api/shop/queries" >}}#eligibleshippingmethods) to find out which ones can be applied to the active order.
 
-A ShippingMethod is composed of a **checker** and a **calculator**. When querying `eligibleShippingMethods`, each of the defined ShippingMethods' checker functions are executed to find out whether the order is eligible for that method, and if so, the calculator is executed to determine the shipping cost.
+A ShippingMethod is composed of a **checker** and a **calculator**. When querying `eligibleShippingMethods`, each of the defined ShippingMethods' checker functions is executed to find out whether the order is eligible for that method, and if so, the calculator is executed to determine the shipping cost.
 
 ## Creating a custom checker
 

--- a/docs/content/developer-guide/taxes.md
+++ b/docs/content/developer-guide/taxes.md
@@ -8,7 +8,7 @@ Most e-commerce applications need to correctly handle taxes such as sales tax or
 
 * **Tax categories** Each ProductVariant is assigned to a specific TaxCategory. In some tax systems, the tax rate differs depending on the type of good. For example, VAT in the UK has 3 rates, "standard" (most goods), "reduced" (e.g. child car seats) and "zero" (e.g. books).
 * **Tax rates** This is the tax rate applied to a specific tax category for a specific [Zone]({{< relref "zone" >}}). E.g., the tax rate for "standard" goods in the UK Zone is 20%.
-* **Channel tax settings** Each Channel can specify whether the prices of produce variants are inclusive of tax or not, and also specify the default Zone to use for tax calculations.
+* **Channel tax settings** Each Channel can specify whether the prices of product variants are inclusive of tax or not, and also specify the default Zone to use for tax calculations.
 * **TaxZoneStrategy** Determines the active tax Zone used when calculating what TaxRate to apply. By default, it uses the default tax Zone from the Channel settings.
 * **TaxLineCalculationStrategy** This determines the taxes applied when adding an item to an Order. If you want to integrate a 3rd-party tax API or other async lookup, this is where it would be done.
 
@@ -35,7 +35,7 @@ query {
 }
 ```
 
-In your storefront you can therefore choose whether to display the prices with or without tax, according to the laws and conventions of the area in which your business operates.
+In your storefront, you can therefore choose whether to display the prices with or without tax, according to the laws and conventions of the area in which your business operates.
 
 ## Calculating taxes on OrderItems
 

--- a/docs/content/developer-guide/testing.md
+++ b/docs/content/developer-guide/testing.md
@@ -18,7 +18,7 @@ The `@vendure/testing` package gives you some simple but powerful tooling for cr
 ### Install dependencies
 
 * [`@vendure/testing`](https://www.npmjs.com/package/@vendure/testing)
-* [`jest`](https://www.npmjs.com/package/jest) You'll need to install a testing framework. In this example we will use [Jest](https://jestjs.io/), but any other framework such as Jasmine should work too.
+* [`jest`](https://www.npmjs.com/package/jest) You'll need to install a testing framework. In this example, we will use [Jest](https://jestjs.io/), but any other framework such as Jasmine should work too.
 * [`graphql-tag`](https://www.npmjs.com/package/graphql-tag) This is not strictly required but makes it much easier to create the DocumentNodes needed to query your server.
 
 Please see the [Jest documentation](https://jestjs.io/docs/en/getting-started) on how to get set up. The remainder of this article will assume a working Jest setup configured to work with TypeScript.

--- a/docs/content/developer-guide/translations.md
+++ b/docs/content/developer-guide/translations.md
@@ -6,7 +6,7 @@ showtoc: true
 # Translation
 
 Using [`addTranslation`]({{< relref "i18n-service" >}}#addtranslation) inside the `onApplicationBootstrap` ([Nestjs lifecycle hooks](https://docs.nestjs.com/fundamentals/lifecycle-events)) of a Plugin is the easiest way to add new translations.
-While vendure is only using `error`, `errorResult` and `message` resource keys you are free to use your own.
+While Vendure is only using `error`, `errorResult` and `message` resource keys you are free to use your own.
 
 ## Translatable Error
 This example shows how to create a custom translatable error
@@ -59,7 +59,7 @@ To receive an error in a specific language you need to use the `languageCode` qu
 
 ## Use translations
 
-Vendures uses the internationalization-framework [i18next](https://www.i18next.com/).
+Vendure uses the internationalization-framework [i18next](https://www.i18next.com/).
 
 Therefore you are free to use the i18next translate function to [access keys](https://www.i18next.com/translation-function/essentials#accessing-keys) \
 `i18next.t('error.any-message');`

--- a/docs/content/developer-guide/uploading-files.md
+++ b/docs/content/developer-guide/uploading-files.md
@@ -9,7 +9,7 @@ Vendure handles file uploads with the [GraphQL multipart request specification](
 
 ## Upload clients
 
-Here is a [list of client implementations](https://github.com/jaydenseric/graphql-multipart-request-spec#client) which will allow you to upload files using the spec. If you are using Apollo Client, then you should install the [apollo-upload-client](https://github.com/jaydenseric/apollo-upload-client) npm package.
+Here is a [list of client implementations](https://github.com/jaydenseric/graphql-multipart-request-spec#client) that will allow you to upload files using the spec. If you are using Apollo Client, then you should install the [apollo-upload-client](https://github.com/jaydenseric/apollo-upload-client) npm package.
 
 For testing, it is even possible to use a [plain curl request](https://github.com/jaydenseric/graphql-multipart-request-spec#single-file).
 
@@ -85,7 +85,7 @@ In a later step, we will refactor this config to encapsulate it in a plugin.
 
 ### Schema definition
 
-Next we will define the schema for the mutation:
+Next, we will define the schema for the mutation:
 
 ```TypeScript
 // api-extensions.ts

--- a/docs/content/developer-guide/vendure-worker.md
+++ b/docs/content/developer-guide/vendure-worker.md
@@ -5,7 +5,7 @@ showtoc: true
 
 # Vendure Worker
  
-The Vendure Worker is a process which is responsible for running computationally intensive or otherwise long-running tasks in the background. For example updating a search index or sending emails. Running such tasks in the background allows the server to stay responsive, since a response can be returned immediately without waiting for the slower tasks to complete. 
+The Vendure Worker is a process responsible for running computationally intensive or otherwise long-running tasks in the background. For example, updating a search index or sending emails. Running such tasks in the background allows the server to stay responsive, since a response can be returned immediately without waiting for the slower tasks to complete. 
 
 Put another way, the Worker executes jobs registered with the [JobQueueService]({{< relref "job-queue-service" >}}).
 
@@ -31,8 +31,8 @@ The Worker is a [NestJS standalone application](https://docs.nestjs.com/standalo
 
 ## Multiple workers
 
-It is possible to run multiple workers in parallel, in order to better handle heavy loads. Using the [JobQueueOptions.activeQueues]({{< relref "job-queue-options" >}}#activequeues) configuration, it is even possible to have particular workers dedicated to one or more specific type of job.
-For example, if you application does video transcoding, you might want to set up a dedicated worker just for that task:
+It is possible to run multiple workers in parallel to better handle heavy loads. Using the [JobQueueOptions.activeQueues]({{< relref "job-queue-options" >}}#activequeues) configuration, it is even possible to have particular workers dedicated to one or more specific types of jobs.
+For example, if your application does video transcoding, you might want to set up a dedicated worker just for that task:
 
 ```TypeScript
 import { bootstrapWorker, mergeConfig } from '@vendure/core';
@@ -74,7 +74,7 @@ If you are authoring a [Vendure plugin]({{< relref "/docs/plugins" >}}) to imple
 
 ## ProcessContext
 
-Sometimes your code may need to be aware of whether it is being run on the as part of a server or worker process. In this case you can inject the [ProcessContext]({{< relref "process-context" >}}) provider and query it like this:
+Sometimes your code may need to be aware of whether it is being run as part of a server or worker process. In this case you can inject the [ProcessContext]({{< relref "process-context" >}}) provider and query it like this:
 
 ```TypeScript
 import { Injectable, OnApplicationBootstrap } from '@nestjs/common';

--- a/docs/content/plugins/_index.md
+++ b/docs/content/plugins/_index.md
@@ -10,7 +10,7 @@ Plugins are the method by which the built-in functionality of Vendure can be ext
 * Modify the [VendureConfig]({{< ref "/docs/typescript-api/configuration" >}}#vendureconfig) object.
 * Extend the GraphQL API, including modifying existing types and adding completely new queries and mutations.
 * Define new database entities and interact directly with the database.
-* Run code before the server bootstraps, such as starting webservers.
+* Run code before the server bootstraps, such as starting web servers.
 * Respond to events such as new orders being placed.
 * Trigger background tasks to run on the worker process.
 * ... and more!

--- a/docs/content/plugins/extending-the-admin-ui/_index.md
+++ b/docs/content/plugins/extending-the-admin-ui/_index.md
@@ -10,12 +10,12 @@ When creating a plugin, you may wish to extend the Admin UI in order to expose a
 This is possible by defining [AdminUiExtensions]({{< ref "admin-ui-extension" >}}).
 
 {{< alert "primary" >}}
-For a complete working example of a Vendure plugin which extends the Admin UI, see the [real-world-vendure Reviews plugin](https://github.com/vendure-ecommerce/real-world-vendure/tree/master/src/plugins/reviews)
+For a complete working example of a Vendure plugin that extends the Admin UI, see the [real-world-vendure Reviews plugin](https://github.com/vendure-ecommerce/real-world-vendure/tree/master/src/plugins/reviews)
 {{< /alert >}}
 
 ## How It Works
 
-A UI extension is an [Angular module](https://angular.io/guide/ngmodules) which gets compiled into the Admin UI application bundle by the [`compileUiExtensions`]({{< relref "compile-ui-extensions" >}}) function exported by the `@vendure/ui-devkit` package. Internally, the ui-devkit package makes use of the Angular CLI to compile an optimized set of JavaScript bundles containing your extensions.
+A UI extension is an [Angular module](https://angular.io/guide/ngmodules) that gets compiled into the Admin UI application bundle by the [`compileUiExtensions`]({{< relref "compile-ui-extensions" >}}) function exported by the `@vendure/ui-devkit` package. Internally, the ui-devkit package makes use of the Angular CLI to compile an optimized set of JavaScript bundles containing your extensions.
 
 ## Use Your Favourite Framework
 
@@ -26,7 +26,7 @@ The Vendure Admin UI is built with Angular, and writing UI extensions in Angular
 
 ## Lazy vs Shared Modules
 
-Angular uses the concept of modules ([NgModules](https://angular.io/guide/ngmodules)) for organizing related code. These modules can be lazily-loaded, which means that the code is not loaded when the app starts, but only later once that code is required. This keeps the main bundle small and improves performance.
+Angular uses the concept of modules ([NgModules](https://angular.io/guide/ngmodules)) for organizing related code. These modules can be lazily loaded, which means that the code is not loaded when the app starts, but only later once that code is required. This keeps the main bundle small and improves performance.
 
 When creating your UI extensions, you can set your module to be either `lazy` or `shared`. Shared modules are loaded _eagerly_, i.e. their code is bundled up with the main app and loaded as soon as the app loads.
 

--- a/docs/content/plugins/plugin-architecture/_index.md
+++ b/docs/content/plugins/plugin-architecture/_index.md
@@ -8,7 +8,7 @@ showtoc: true
 
 {{< figure src="plugin_architecture.png" >}}
 
-A plugin in Vendure is a specialized Nestjs Module which is decorated with the [`VendurePlugin` class decorator]({{< relref "vendure-plugin" >}}). This diagram illustrates how a plugin can integrate with and extend Vendure.
+A plugin in Vendure is a specialized Nestjs Module that is decorated with the [`VendurePlugin` class decorator]({{< relref "vendure-plugin" >}}). This diagram illustrates how a plugin can integrate with and extend Vendure.
  
 1. A Plugin may define logic to be run by the [Vendure Worker]({{< relref "/docs/developer-guide/vendure-worker" >}}). This is suitable for long-running or resource-intensive tasks.
 2. A Plugin can modify any aspect of server configuration via the [`configuration` metadata property]({{< relref "vendure-plugin-metadata" >}}#configuration).

--- a/docs/content/plugins/plugin-examples/_index.md
+++ b/docs/content/plugins/plugin-examples/_index.md
@@ -6,7 +6,7 @@ showtoc: true
 
 # Plugin Examples 
 
-Here are some simplified examples of plugins which serve to illustrate what can be done with Vendure plugins. *Note: implementation details are skipped in these examples for the sake of brevity. A complete example with explanation can be found in [Writing A Vendure Plugin]({{< relref "writing-a-vendure-plugin" >}}).*
+Here are some simplified examples of plugins that serve to illustrate what can be done with Vendure plugins. *Note: implementation details are skipped in these examples for the sake of brevity. A complete example with explanations can be found in [Writing A Vendure Plugin]({{< relref "writing-a-vendure-plugin" >}}).*
 
 {{< alert "primary" >}}
   For a complete working example of a Vendure plugin, see the [real-world-vendure Reviews plugin](https://github.com/vendure-ecommerce/real-world-vendure/tree/master/src/plugins/reviews)

--- a/docs/content/plugins/plugin-lifecycle/index.md
+++ b/docs/content/plugins/plugin-lifecycle/index.md
@@ -17,7 +17,7 @@ Note that lifecycle hooks are run in _both_ the server and worker contexts.
 
 ## Configure
 
-Another hook which is not strictly a lifecycle hook, but which can be useful to know is the [`configure` method](https://docs.nestjs.com/middleware#applying-middleware) which is used by NestJS to apply middleware. This method is called _only_ for the server and _not_ for the worker, since middleware relates to the network stack, and the worker has no network part.
+Another hook that is not strictly a lifecycle hook, but which can be useful to know is the [`configure` method](https://docs.nestjs.com/middleware#applying-middleware) which is used by NestJS to apply middleware. This method is called _only_ for the server and _not_ for the worker, since middleware relates to the network stack, and the worker has no network part.
 
 ## Example
 

--- a/docs/content/plugins/writing-a-vendure-plugin.md
+++ b/docs/content/plugins/writing-a-vendure-plugin.md
@@ -15,7 +15,7 @@ This is a complete example of how to implement a simple plugin step-by-step.
 
 ## Example: RandomCatPlugin
 
-Let's learn about Vendure plugins by writing a plugin which defines a new database entity and a GraphQL mutation.
+Let's learn about Vendure plugins by writing a plugin that defines a new database entity and a GraphQL mutation.
 
 This plugin will add a new mutation, `addRandomCat`, to the GraphQL API which allows us to conveniently link a random cat image from [http://random.cat](http://random.cat) to any product in our catalog.
 
@@ -74,7 +74,7 @@ To use decorators with TypeScript, you must set the "emitDecoratorMetadata" and 
 
 ### Step 3: Define the new mutation
 
-Next we will define how the GraphQL API should be extended:
+Next, we will define how the GraphQL API should be extended:
 
 ```TypeScript
 import gql from 'graphql-tag';

--- a/docs/content/storefront/building-a-storefront/_index.md
+++ b/docs/content/storefront/building-a-storefront/_index.md
@@ -6,13 +6,13 @@ showtoc: true
 
 # Building a Storefront
 
-The storefront is the application which customers use to buy things from your store.
+The storefront is the application that customers use to buy things from your store.
 
 One of the benefits of Vendure's headless architecture is that you can build your storefront using any technology you like, and in the future you can update your storefront without requiring any changes to the Vendure server itself!
 
 ## Storefront starters
 
-To get you up-and-running with your storefront implementation, we offer a number of integrations with popular front-end frameworks such as Next.js, Vue Storefront, Remix & Angular. See all of our [storefront integrations]({{< relref "integration" >}}).
+To get you up and running with your storefront implementation, we offer a number of integrations with popular front-end frameworks such as Next.js, Vue Storefront, Remix & Angular. See all of our [storefront integrations]({{< relref "integration" >}}).
 
 ## Custom-building
 

--- a/docs/content/storefront/managing-sessions.md
+++ b/docs/content/storefront/managing-sessions.md
@@ -32,9 +32,9 @@ const config = {
 
 ## Bearer-token sessions
 
-In environments when cookies cannot be easily used (e.g. in some server environments or mobile apps), then the bearer-token method can be used.
+In environments where cookies cannot be easily used (e.g. in some server environments or mobile apps), then the bearer-token method can be used.
 
-Using bearer tokens involes a bit more work on your part: you'll need to manually read response headers to get the token, and once you have it you'll have to manually add it to the headers of each request. 
+Using bearer tokens involves a bit more work on your part: you'll need to manually read response headers to get the token, and once you have it you'll have to manually add it to the headers of each request. 
 
 The workflow would be as follows:
 

--- a/docs/content/storefront/order-workflow/_index.md
+++ b/docs/content/storefront/order-workflow/_index.md
@@ -31,7 +31,7 @@ So if the customer adds 2 *Widgets* to the Order, there will be **one OrderLine*
 
 The [GraphQL Shop API Guide]({{< relref "/docs/storefront/shop-api-guide" >}}#order-flow) lists the GraphQL operations you will need to implement this workflow in your storefront client application.
 
-In this section we'll cover some examples of how these operations would look in your storefront.
+In this section, we'll cover some examples of how these operations would look in your storefront.
 
 ### Manipulating the Order
 
@@ -117,7 +117,7 @@ query ActiveOrder {
 
 ### Checking out
 
-During the checkout process, we'll need to make sure a Customer is assigned to the Order. If the Customer is already signed-in, then this can be skipped since Vendure will have already assigned them. If not, then you'd execute:
+During the checkout process, we'll need to make sure a Customer is assigned to the Order. If the Customer is already signed in, then this can be skipped since Vendure will have already assigned them. If not, then you'd execute:
 
 ```GraphQL
 mutation SetCustomerForOrder($input: CreateCustomerInput!){
@@ -230,4 +230,4 @@ query OrderByCode($code: String!) {
 
 In the above examples, the active Order is always associated with the current session and is therefore implicit - which is why there is no need to pass an ID to each of the above operations.
 
-Sometimes you _do_ want to be able to explicitly specify the Order you wish to operate on. In this case you need to define a custom [ActiveOrderStrategy]({{< relref "active-order-strategy" >}}).
+Sometimes you _do_ want to be able to explicitly specify the Order you wish to operate on. In this case, you need to define a custom [ActiveOrderStrategy]({{< relref "active-order-strategy" >}}).

--- a/docs/content/storefront/shop-api-guide.md
+++ b/docs/content/storefront/shop-api-guide.md
@@ -14,9 +14,9 @@ This guide only lists some of the more common operations you'll need for your st
 
 ## Universal Parameters
 
-There are a couple of query parameters which are valid for all GraphQL operations:
+There are a couple of query parameters that are valid for all GraphQL operations:
 
-* `languageCode`: This sets the current langauge for the request. Any translatable types (e.g. Products, Facets, Collections) will be returned in that language, if a translation is defined for that language. If not, they will fall back to the default language. The value should be one of the ISO 639-1 codes defined by the [`LanguageCode` enum]({{< relref "language-code" >}}).
+* `languageCode`: This sets the current language for the request. Any translatable types (e.g. Products, Facets, Collections) will be returned in that language, if a translation is defined for that language. If not, they will fall back to the default language. The value should be one of the ISO 639-1 codes defined by the [`LanguageCode` enum]({{< relref "language-code" >}}).
 
   ```text
   POST http://localhost:3000/shop-api?languageCode=de

--- a/docs/content/user-guide/customers/index.md
+++ b/docs/content/user-guide/customers/index.md
@@ -10,7 +10,7 @@ A Customer is anybody who has:
 * Placed an order
 * Registered an account
 
-The Customers section allows you to view and search your customers. Clicking "edit" in the list view brings up the detail view, allowing you to edit the customer details and view orders and history.
+The Customers section allows you to view and search for your customers. Clicking "edit" in the list view brings up the detail view, allowing you to edit the customer details and view orders and history.
 
 ## Guest, Registered, Verified
 

--- a/docs/content/user-guide/orders/_index.md
+++ b/docs/content/user-guide/orders/_index.md
@@ -25,7 +25,7 @@ When a new Order arrives, you would:
 
 ## Refunds
 
-You can refund one or more items from an Order by clicking this menu item, which is available one the payments are settled:
+You can refund one or more items from an Order by clicking this menu item, which is available once the payments are settled:
 
 {{< figure src="./screen-refund-button.webp" >}}
 

--- a/docs/content/user-guide/settings/channels.md
+++ b/docs/content/user-guide/settings/channels.md
@@ -6,7 +6,7 @@ title: "Channels"
 
 Channels allow you to split your store into multiple sub-stores, each of which can have its own selection of inventory, customers, orders, shipping methods etc.
 
-There various reasons why you might want to do this:
+There are various reasons why you might want to do this:
 
 * Creating distinct stores for different countries, each with country-specific pricing, shipping and payment rules.
 * Implementing a multi-tenant application where many merchants have their own store, each confined to its own channel.

--- a/docs/content/user-guide/settings/shipping-methods.md
+++ b/docs/content/user-guide/settings/shipping-methods.md
@@ -36,7 +36,7 @@ By default, Vendure comes with a simple flat-rate shipping calculator. Your deve
 
 ## Fulfillment handler
 
-By "fulfillment" we mean how do we physically get the goods into the hands of the customer. Common fulfillment methods include:
+By "fulfillment" we mean how we physically get the goods into the hands of the customer. Common fulfillment methods include:
 
 * Courier services such as FedEx, DPD, DHL, etc.
 * Collection by customer

--- a/docs/content/user-guide/settings/taxes.md
+++ b/docs/content/user-guide/settings/taxes.md
@@ -21,7 +21,7 @@ For example, in the UK there are three rates of VAT:
 * Reduced rate (5%)
 * Zero rate (0%)
 
-Most types of product would fall into the "standard rate" category, but for instance books are classified as "zero rate".
+Most types of products would fall into the "standard rate" category, but for instance books are classified as "zero rate".
 
 ## Tax Rate
 
@@ -29,4 +29,4 @@ Tax rates set the rate of tax for a given **tax category** destined for a partic
 
 ## Tax Compliance
 
-Please note that tax compliance is a complex topic that varies significantly between countries. Vendure does not (and cannot) offer a complete out-of-the box tax solution which is guaranteed to be compliant for your use-case. What we strive to do is to provide a very flexible set of tools that your developers can use to tailor tax calculations exactly to your needs. These are covered in the [Developer's guide to taxes]({{< relref "/docs/developer-guide/taxes" >}}). 
+Please note that tax compliance is a complex topic that varies significantly between countries. Vendure does not (and cannot) offer a complete out-of-the-box tax solution which is guaranteed to be compliant with your use-case. What we strive to do is to provide a very flexible set of tools that your developers can use to tailor tax calculations exactly to your needs. These are covered in the [Developer's guide to taxes]({{< relref "/docs/developer-guide/taxes" >}}). 


### PR DESCRIPTION
I stumbled upon a few typos and "unnatural" wordings when browsing the Vendure documentation. Here are my corrections.