### PR TITLE
feat(core): allow specifying transaction isolation level

### DIFF
--- a/packages/core/src/api/decorators/transaction.decorator.ts
+++ b/packages/core/src/api/decorators/transaction.decorator.ts
@@ -34,11 +34,13 @@ export type TransactionMode = 'auto' | 'manual';
 export const TRANSACTION_ISOLATION_LEVEL_METADATA_KEY = '__transaction_isolation_level__';
 /**
  * @description
- * Transactions can be run at different isolation levels. The default is "SERIALIZABLE", which
- * is the only correct mode. See the documentation of your database for more information on available
- * isolation levels.
+ * Transactions can be run at different isolation levels. The default is undefined, which
+ * falls back to the default of your database. See the documentation of your database for more
+ * information on available isolation levels.
  * 
- * @default 'SERIALIZABLE'
+ * @default undefined
+ * @docsCategory request
+ * @docsPage Transaction Decorator
  */
 export type TransactionIsolationLevel = 'READ UNCOMMITTED' | 'READ COMMITTED' | 'REPEATABLE READ' | 'SERIALIZABLE';
 

--- a/packages/core/src/api/decorators/transaction.decorator.ts
+++ b/packages/core/src/api/decorators/transaction.decorator.ts
@@ -31,6 +31,17 @@ export const TRANSACTION_MODE_METADATA_KEY = '__transaction_mode__';
  */
 export type TransactionMode = 'auto' | 'manual';
 
+export const TRANSACTION_ISOLATION_LEVEL_METADATA_KEY = '__transaction_isolation_level__';
+/**
+ * @description
+ * Transactions can be run at different isolation levels. The default is "SERIALIZABLE", which
+ * is the only correct mode. See the documentation of your database for more information on available
+ * isolation levels.
+ * 
+ * @default 'SERIALIZABLE'
+ */
+export type TransactionIsolationLevel = 'READ UNCOMMITTED' | 'READ COMMITTED' | 'REPEATABLE READ' | 'SERIALIZABLE';
+
 /**
  * @description
  * Runs the decorated method in a TypeORM transaction. It works by creating a transactional
@@ -61,9 +72,10 @@ export type TransactionMode = 'auto' | 'manual';
  * @docsPage Transaction Decorator
  * @docsWeight 0
  */
-export const Transaction = (transactionMode: TransactionMode = 'auto') => {
+export const Transaction = (transactionMode: TransactionMode = 'auto', transactionIsolationLevel: TransactionIsolationLevel = 'SERIALIZABLE') => {
     return applyDecorators(
         SetMetadata(TRANSACTION_MODE_METADATA_KEY, transactionMode),
+        SetMetadata(TRANSACTION_ISOLATION_LEVEL_METADATA_KEY, transactionIsolationLevel),
         UseInterceptors(TransactionInterceptor),
     );
 };

--- a/packages/core/src/api/decorators/transaction.decorator.ts
+++ b/packages/core/src/api/decorators/transaction.decorator.ts
@@ -72,7 +72,7 @@ export type TransactionIsolationLevel = 'READ UNCOMMITTED' | 'READ COMMITTED' | 
  * @docsPage Transaction Decorator
  * @docsWeight 0
  */
-export const Transaction = (transactionMode: TransactionMode = 'auto', transactionIsolationLevel: TransactionIsolationLevel = 'SERIALIZABLE') => {
+export const Transaction = (transactionMode: TransactionMode = 'auto', transactionIsolationLevel?: TransactionIsolationLevel) => {
     return applyDecorators(
         SetMetadata(TRANSACTION_MODE_METADATA_KEY, transactionMode),
         SetMetadata(TRANSACTION_ISOLATION_LEVEL_METADATA_KEY, transactionIsolationLevel),

--- a/packages/core/src/api/middleware/transaction-interceptor.ts
+++ b/packages/core/src/api/middleware/transaction-interceptor.ts
@@ -31,7 +31,7 @@ export class TransactionInterceptor implements NestInterceptor {
                 TRANSACTION_MODE_METADATA_KEY,
                 context.getHandler(),
             );
-            const transactionIsolationLevel = this.reflector.get<TransactionIsolationLevel>(
+            const transactionIsolationLevel = this.reflector.get<TransactionIsolationLevel | undefined>(
                 TRANSACTION_ISOLATION_LEVEL_METADATA_KEY,
                 context.getHandler(),
             );

--- a/packages/core/src/connection/transaction-wrapper.ts
+++ b/packages/core/src/connection/transaction-wrapper.ts
@@ -27,7 +27,7 @@ export class TransactionWrapper {
         originalCtx: RequestContext,
         work: (ctx: RequestContext) => Observable<T> | Promise<T>,
         mode: TransactionMode,
-        isolationLevel: TransactionIsolationLevel,
+        isolationLevel: TransactionIsolationLevel | undefined,
         connection: Connection,
     ): Promise<T> {
         // Copy to make sure original context will remain valid after transaction completes
@@ -81,7 +81,7 @@ export class TransactionWrapper {
      * Attempts to start a DB transaction, with retry logic in the case that a transaction
      * is already started for the connection (which is mainly a problem with SQLite/Sql.js)
      */
-    private async startTransaction(queryRunner: QueryRunner, isolationLevel: TransactionIsolationLevel = 'SERIALIZABLE') {
+    private async startTransaction(queryRunner: QueryRunner, isolationLevel: TransactionIsolationLevel | undefined) {
         const maxRetries = 25;
         let attempts = 0;
         let lastError: any;

--- a/packages/core/src/connection/transaction-wrapper.ts
+++ b/packages/core/src/connection/transaction-wrapper.ts
@@ -4,7 +4,7 @@ import { Connection, EntityManager, QueryRunner } from 'typeorm';
 import { TransactionAlreadyStartedError } from 'typeorm/error/TransactionAlreadyStartedError';
 
 import { RequestContext } from '../api/common/request-context';
-import { TransactionMode } from '../api/decorators/transaction.decorator';
+import { TransactionIsolationLevel, TransactionMode } from '../api/decorators/transaction.decorator';
 import { TRANSACTION_MANAGER_KEY } from '../common/constants';
 
 /**
@@ -27,16 +27,17 @@ export class TransactionWrapper {
         originalCtx: RequestContext,
         work: (ctx: RequestContext) => Observable<T> | Promise<T>,
         mode: TransactionMode,
+        isolationLevel: TransactionIsolationLevel,
         connection: Connection,
     ): Promise<T> {
         // Copy to make sure original context will remain valid after transaction completes
         const ctx = originalCtx.copy();
 
         const entityManager: EntityManager | undefined = (ctx as any)[TRANSACTION_MANAGER_KEY];
-        const queryRunner = entityManager?.queryRunner || connection.createQueryRunner();
+        const queryRunner = entityManager ?.queryRunner || connection.createQueryRunner();
 
         if (mode === 'auto') {
-            await this.startTransaction(queryRunner);
+            await this.startTransaction(queryRunner, isolationLevel);
         }
         (ctx as any)[TRANSACTION_MANAGER_KEY] = queryRunner.manager;
 
@@ -66,7 +67,7 @@ export class TransactionWrapper {
             }
             throw error;
         } finally {
-            if (!queryRunner.isTransactionActive 
+            if (!queryRunner.isTransactionActive
                 && queryRunner.isReleased === false) {
                 // There is a check for an active transaction
                 // because this could be a nested transaction (savepoint).
@@ -80,7 +81,7 @@ export class TransactionWrapper {
      * Attempts to start a DB transaction, with retry logic in the case that a transaction
      * is already started for the connection (which is mainly a problem with SQLite/Sql.js)
      */
-    private async startTransaction(queryRunner: QueryRunner) {
+    private async startTransaction(queryRunner: QueryRunner, isolationLevel: TransactionIsolationLevel = 'SERIALIZABLE') {
         const maxRetries = 25;
         let attempts = 0;
         let lastError: any;
@@ -88,7 +89,7 @@ export class TransactionWrapper {
         // Returns false if a transaction is already in progress
         async function attemptStartTransaction(): Promise<boolean> {
             try {
-                await queryRunner.startTransaction();
+                await queryRunner.startTransaction(isolationLevel);
                 return true;
             } catch (err) {
                 lastError = err;

--- a/packages/core/src/connection/transactional-connection.ts
+++ b/packages/core/src/connection/transactional-connection.ts
@@ -22,6 +22,7 @@ import { VendureEntity } from '../entity/base/base.entity';
 import { removeCustomFieldsWithEagerRelations } from './remove-custom-fields-with-eager-relations';
 import { TransactionWrapper } from './transaction-wrapper';
 import { GetEntityOrThrowOptions } from './types';
+import { TransactionIsolationLevel } from '../api/decorators/transaction.decorator';
 
 /**
  * @description
@@ -40,7 +41,7 @@ export class TransactionalConnection {
     constructor(
         @InjectConnection() private connection: Connection,
         private transactionWrapper: TransactionWrapper,
-    ) {}
+    ) { }
 
     /**
      * @description
@@ -147,7 +148,7 @@ export class TransactionalConnection {
             ctx = RequestContext.empty();
             work = ctxOrWork;
         }
-        return this.transactionWrapper.executeInTransaction(ctx, work, 'auto', this.rawConnection);
+        return this.transactionWrapper.executeInTransaction(ctx, work, 'auto', 'SERIALIZABLE', this.rawConnection);
     }
 
     /**
@@ -155,10 +156,10 @@ export class TransactionalConnection {
      * Manually start a transaction if one is not already in progress. This method should be used in
      * conjunction with the `'manual'` mode of the {@link Transaction} decorator.
      */
-    async startTransaction(ctx: RequestContext) {
+    async startTransaction(ctx: RequestContext, isolationLevel?: TransactionIsolationLevel) {
         const transactionManager = this.getTransactionManager(ctx);
-        if (transactionManager?.queryRunner?.isTransactionActive === false) {
-            await transactionManager.queryRunner.startTransaction();
+        if (transactionManager ?.queryRunner ?.isTransactionActive === false) {
+            await transactionManager.queryRunner.startTransaction(isolationLevel);
         }
     }
 
@@ -171,7 +172,7 @@ export class TransactionalConnection {
      */
     async commitOpenTransaction(ctx: RequestContext) {
         const transactionManager = this.getTransactionManager(ctx);
-        if (transactionManager?.queryRunner?.isTransactionActive) {
+        if (transactionManager ?.queryRunner ?.isTransactionActive) {
             await transactionManager.queryRunner.commitTransaction();
         }
     }
@@ -184,7 +185,7 @@ export class TransactionalConnection {
      */
     async rollBackTransaction(ctx: RequestContext) {
         const transactionManager = this.getTransactionManager(ctx);
-        if (transactionManager?.queryRunner?.isTransactionActive) {
+        if (transactionManager ?.queryRunner ?.isTransactionActive) {
             await transactionManager.queryRunner.rollbackTransaction();
         }
     }

--- a/packages/core/src/connection/transactional-connection.ts
+++ b/packages/core/src/connection/transactional-connection.ts
@@ -148,7 +148,7 @@ export class TransactionalConnection {
             ctx = RequestContext.empty();
             work = ctxOrWork;
         }
-        return this.transactionWrapper.executeInTransaction(ctx, work, 'auto', 'SERIALIZABLE', this.rawConnection);
+        return this.transactionWrapper.executeInTransaction(ctx, work, 'auto', undefined, this.rawConnection);
     }
 
     /**


### PR DESCRIPTION
The default isolation level in some databases (see e.g. for postgres https://www.postgresql.org/docs/current/transaction-iso.html - `READ COMMITTED` is default) allows several anomalies, leading to incorrect data. https://en.wikipedia.org/wiki/Isolation_%28database_systems%29 for more context (or do some googling).

I think it would make sense to at least easily allow users to opt in to stronger isolation levels, and preferably do so by default (picking a lower isolation level should only be done when really needed and when you understand what you're doing).

This PR aims to achieve the above. Note that I'm not a seasoned typescript developer, and I had some issues with `yarn` in this repo, so I had to bypass the pre-commit hook.