### PR TITLE
Change tsconfig resolving of eslint

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -30,7 +30,7 @@ module.exports = {
     ],
     parser: '@typescript-eslint/parser',
     parserOptions: {
-        project: 'tsconfig.json',
+        project: true, // Resolve the nearest single tsconfig - See: https://github.com/typescript-eslint/typescript-eslint/issues/1192#issuecomment-1483926773
         sourceType: 'module',
     },
     plugins: [


### PR DESCRIPTION
@michaelbromley @martijnvdbrug I think I found one reason eslint was crashing for the monorepo.

I ran the linting with debug infos and it did correctly apply only changed files. I just picked a random file and completely destroyed the indentation and included a console.log to test. But still even for just two files it took **40 seconds** and even crashed on me with a:

```log
FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory
```

So I found a relevant section in the [typescript-eslint docs](https://typescript-eslint.io/linting/typed-linting/monorepos#important-note-regarding-large--10-multi-package-monorepos) - I quote:

> ## Important note regarding large (> 10) multi-package monorepos
> We've had reports that for sufficiently large and/or interdependent projects, you may run into OOMs using this approach. Our advice is to set it up and test first, as there are very few cases that trigger this OOM. See [#1192](https://github.com/typescript-eslint/typescript-eslint/issues/1192) for more information and discussion.

Which links to the issue with a [comment](https://github.com/typescript-eslint/typescript-eslint/issues/1192#issuecomment-1483926773) describing that you can use a different parseroption:

> If you want a lighter experience, consider setting parserOptions.project = true - which was released in v5.52.0, which will automatically resolve the nearest single tsconfig.

Which I tried out now and it reduced my linting time from **40s** down to **10s** with the same result and no crashing.

I'm currently unsure if its an option to only have a single tsconfig, maybe this'll improve this further, this is also recommended in the earlier mentioned docs.

> Switching to one root tsconfig.eslint.json (see [One root tsconfig.json](https://typescript-eslint.io/linting/typed-linting/monorepos#one-root-tsconfigjson))

You may want to try this out. :smile: :+1: 