### PR TITLE
feat(payments-plugin): Add metadata field to StripePluginOptions

### DIFF
--- a/packages/payments-plugin/e2e/stripe-metadata-sanitize.e2e-spec.ts
+++ b/packages/payments-plugin/e2e/stripe-metadata-sanitize.e2e-spec.ts
@@ -1,0 +1,39 @@
+import { sanitizeMetadata } from '../src/stripe/metadata-sanitize';
+
+describe('Stripe Metadata Sanitize', () => {
+    const metadata = {
+        customerEmail: 'test@gmail.com',
+    };
+    it('should sanitize and create new object metadata', () => {
+        const newMetadata = sanitizeMetadata(metadata);
+        expect(newMetadata).toEqual(metadata);
+        expect(newMetadata).not.toBe(metadata);
+    });
+    it('should omit fields that have key length exceed 40 characters', () => {
+        const newMetadata = sanitizeMetadata({
+            ...metadata,
+            reallylongkey_reallylongkey_reallylongkey_reallylongkey_reallylongkey: 1,
+        });
+        expect(newMetadata).toEqual(metadata);
+    });
+    it('should omit fields that have value length exceed 500 characters', () => {
+        const reallyLongText = Array(501).fill('a').join();
+        const newMetadata = sanitizeMetadata({
+            ...metadata,
+            complexField: reallyLongText,
+        });
+        expect(newMetadata).toEqual(metadata);
+    });
+    it('should truncate metadata that have more than 50 keys', () => {
+        const moreThan50KeysMetadata = Array(51)
+            .fill('a')
+            .reduce((obj, val, idx) => {
+                obj[idx] = val;
+                return obj;
+            }, {});
+        const newMetadata = sanitizeMetadata(moreThan50KeysMetadata);
+        expect(Object.keys(newMetadata).length).toEqual(50);
+        delete moreThan50KeysMetadata['50'];
+        expect(newMetadata).toEqual(moreThan50KeysMetadata);
+    });
+});

--- a/packages/payments-plugin/e2e/stripe-payment.e2e-spec.ts
+++ b/packages/payments-plugin/e2e/stripe-payment.e2e-spec.ts
@@ -164,8 +164,8 @@ describe('Stripe payments', () => {
 
     // https://github.com/vendure-ecommerce/vendure/issues/1935
     it('should attach metadata to stripe payment intent', async () => {
-        StripePlugin.options.metadata = async (ctx, currentOrder) => {
-            const hydrator = server.app.get(EntityHydrator);
+        StripePlugin.options.metadata = async (injector, ctx, currentOrder) => {
+            const hydrator = await injector.get(EntityHydrator);
             await hydrator.hydrate(ctx, currentOrder, { relations: ['customer'] });
             return {
                 customerEmail: currentOrder.customer?.emailAddress ?? 'demo',

--- a/packages/payments-plugin/src/stripe/metadata-sanitize.ts
+++ b/packages/payments-plugin/src/stripe/metadata-sanitize.ts
@@ -1,0 +1,35 @@
+import Stripe from 'stripe';
+
+const MAX_KEYS = 50;
+const MAX_KEY_NAME_LENGTH = 40;
+const MAX_VALUE_LENGTH = 500;
+/**
+ * @description
+ * Santitize metadata to ensure it follow Stripe's instructions
+ *
+ * @link
+ * https://stripe.com/docs/api/metadata
+ *
+ * @Restriction
+ * You can specify up to 50 keys, with key names up to 40 characters long and values up to 500 characters long.
+ *
+ */
+export function sanitizeMetadata(metadata: Stripe.MetadataParam) {
+    if (typeof metadata !== 'object' && metadata !== null) return {};
+
+    const keys = Object.keys(metadata)
+        .filter(keyName => keyName.length <= MAX_KEY_NAME_LENGTH)
+        .filter(
+            keyName =>
+                typeof metadata[keyName] !== 'string' ||
+                (metadata[keyName] as string).length <= MAX_VALUE_LENGTH,
+        )
+        .slice(0, MAX_KEYS) as Array<keyof Stripe.MetadataParam>;
+
+    const sanitizedMetadata = keys.reduce((obj, keyName) => {
+        obj[keyName] = metadata[keyName];
+        return obj;
+    }, {} as Stripe.MetadataParam);
+
+    return sanitizedMetadata;
+}

--- a/packages/payments-plugin/src/stripe/stripe.service.ts
+++ b/packages/payments-plugin/src/stripe/stripe.service.ts
@@ -1,8 +1,16 @@
 import { Inject, Injectable } from '@nestjs/common';
-import { Customer, Logger, Order, RequestContext, TransactionalConnection } from '@vendure/core';
+import {
+    Customer,
+    EntityHydrator,
+    Logger,
+    Order,
+    RequestContext,
+    TransactionalConnection,
+} from '@vendure/core';
 import Stripe from 'stripe';
 
 import { loggerCtx, STRIPE_PLUGIN_OPTIONS } from './constants';
+import { sanitizeMetadata } from './metadata-sanitize';
 import { getAmountInStripeMinorUnits } from './stripe-utils';
 import { StripePluginOptions } from './types';
 
@@ -26,6 +34,14 @@ export class StripeService {
             customerId = await this.getStripeCustomerId(ctx, order);
         }
         const amountInMinorUnits = getAmountInStripeMinorUnits(order);
+
+        const metadata = sanitizeMetadata({
+            ...(typeof this.options.metadata === 'function' ? await this.options.metadata(ctx, order) : {}),
+            channelToken: ctx.channel.token,
+            orderId: order.id,
+            orderCode: order.code,
+        });
+
         const { client_secret } = await this.stripe.paymentIntents.create(
             {
                 amount: amountInMinorUnits,
@@ -34,11 +50,7 @@ export class StripeService {
                 automatic_payment_methods: {
                     enabled: true,
                 },
-                metadata: {
-                    channelToken: ctx.channel.token,
-                    orderId: order.id,
-                    orderCode: order.code,
-                },
+                metadata,
             },
             { idempotencyKey: `${order.code}_${amountInMinorUnits}` },
         );

--- a/packages/payments-plugin/src/stripe/types.ts
+++ b/packages/payments-plugin/src/stripe/types.ts
@@ -1,5 +1,7 @@
+import { Order, RequestContext } from '@vendure/core';
 import '@vendure/core/dist/entity/custom-entity-fields';
 import { Request } from 'express';
+import Stripe from 'stripe';
 
 // Note: deep import is necessary here because CustomCustomerFields is also extended in the Braintree
 // plugin. Reference: https://github.com/microsoft/TypeScript/issues/46617
@@ -37,6 +39,14 @@ export interface StripePluginOptions {
      * @default false
      */
     storeCustomersInStripe?: boolean;
+
+    /**
+     * @description
+     * Attach extra metadata to Stripe payment intent
+     *
+     * @since 1.9.7
+     */
+    metadata?: (ctx: RequestContext, order: Order) => Stripe.MetadataParam | Promise<Stripe.MetadataParam>;
 }
 
 export interface RequestWithRawBody extends Request {

--- a/packages/payments-plugin/src/stripe/types.ts
+++ b/packages/payments-plugin/src/stripe/types.ts
@@ -1,4 +1,4 @@
-import { Order, RequestContext } from '@vendure/core';
+import { Injector, Order, RequestContext } from '@vendure/core';
 import '@vendure/core/dist/entity/custom-entity-fields';
 import { Request } from 'express';
 import Stripe from 'stripe';
@@ -46,7 +46,11 @@ export interface StripePluginOptions {
      *
      * @since 1.9.7
      */
-    metadata?: (ctx: RequestContext, order: Order) => Stripe.MetadataParam | Promise<Stripe.MetadataParam>;
+    metadata?: (
+        injector: Injector,
+        ctx: RequestContext,
+        order: Order,
+    ) => Stripe.MetadataParam | Promise<Stripe.MetadataParam>;
 }
 
 export interface RequestWithRawBody extends Request {


### PR DESCRIPTION
Relates to [#1935](https://github.com/vendure-ecommerce/vendure/issues/1935). Allow to append extra metadata to Stripe payment intent based on developer needs.