### PR TITLE
fix(dev-server): remove additional /package from admin-ui dependency

### DIFF
--- a/packages/dev-server/package.json
+++ b/packages/dev-server/package.json
@@ -24,7 +24,7 @@
     },
     "devDependencies": {
         "@types/csv-stringify": "^3.1.0",
-        "@vendure/admin-ui": "./packages/admin-ui/package",
+        "@vendure/admin-ui": "./packages/admin-ui",
         "@vendure/testing": "2.0.0-beta.2",
         "@vendure/ui-devkit": "2.0.0-beta.2",
         "commander": "^7.1.0",


### PR DESCRIPTION
`yarn` command fails since it can't find the /package directory, removing that fixes it