### PR TITLE
chore: Add a note for first time "yarn"

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ The root directory has a `package.json` which contains build-related dependencie
 * Generating TypeScript types from the GraphQL schema
 * Linting, formatting & testing tasks to run on git commit & push
 
+> Note:
+> When you do `yarn` for the first time, you will need to manually create the `package` folder under [/packages/admin-ui](/packages/admin-ui).
+
 ### 2. Bootstrap the packages
 
 `yarn bootstrap`


### PR DESCRIPTION
You will receive an error message when executing yarn for the first time: "error Package "" refers to a non-existing file '"/packages/admin-ui/package"'." This note will be of some help to beginners.