### PR TITLE
fix(docs): Change Uploading Files example files.map to Array.from

### DIFF
--- a/docs/content/developer-guide/uploading-files.md
+++ b/docs/content/developer-guide/uploading-files.md
@@ -42,15 +42,10 @@ function UploadFile() {
 
   function onChange(event) {
     const { target } = event;  
-    
     if (target.validity.valid) {
-      const files = [];
-      for (let i = 0; i < target.files.length; i++) {
-        files.push({ file: target.files.item(i) })
-      }
       mutate({ 
         variables: {
-          input: files
+          input: Array.from(target.files).map((file) => ({ file }));
         }  
       });
     }

--- a/docs/content/developer-guide/uploading-files.md
+++ b/docs/content/developer-guide/uploading-files.md
@@ -42,10 +42,15 @@ function UploadFile() {
 
   function onChange(event) {
     const { target } = event;  
+    
     if (target.validity.valid) {
+      const files = [];
+      for (let i = 0; i < target.files.length; i++) {
+        files.push({ file: target.files.item(i) })
+      }
       mutate({ 
         variables: {
-          input: target.files.map(file => ({ file }))
+          input: files
         }  
       });
     }


### PR DESCRIPTION
I made this change because i was receiving an error based in the documentation for uploading files, files.map is undefined in the context of FileList and according to [FileList Documentation](https://developer.mozilla.org/pt-BR/docs/Web/API/FileList) we should use a for-loop to populate the sent array.