### PR TITLE
feat(email-plugin): Expose template vars to template loader

### DIFF
--- a/docs/content/typescript-api/core-plugins/email-plugin/custom-template-loader.md
+++ b/docs/content/typescript-api/core-plugins/email-plugin/custom-template-loader.md
@@ -24,7 +24,7 @@ and return the template as a string.
 import { EmailPlugin, TemplateLoader } from '@vendure/email-plugin';
 
 class MyTemplateLoader implements TemplateLoader {
-     loadTemplate(injector, ctx, { type, templateName }){
+     loadTemplate(injector, ctx, { type, templateName, templateVars }){
          return myCustomTemplateFunction(ctx);
      }
 }

--- a/packages/email-plugin/src/email-processor.ts
+++ b/packages/email-plugin/src/email-processor.ts
@@ -81,6 +81,7 @@ export class EmailProcessor {
                 {
                     templateName: data.templateFile,
                     type: data.type,
+                    templateVars: data.templateVars,
                 },
             );
             const generated = this.generator.generate(data.from, data.subject, bodySource, data.templateVars);

--- a/packages/email-plugin/src/types.ts
+++ b/packages/email-plugin/src/types.ts
@@ -354,6 +354,7 @@ export interface EmailTemplateConfig {
 export interface LoadTemplateInput {
     type: string;
     templateName: string;
+    templateVars: any;
 }
 
 export interface Partial {


### PR DESCRIPTION
Closes #2242 

Let me know if you'd like to pass more of the `data` object or if you somehow would hard-type the `templateVars`.