### PR TITLE
fix(default-search-plugin): Fix typo in option searchStrategy

### DIFF
--- a/docs/content/typescript-api/core-plugins/default-search-plugin/default-search-plugin-init-options.md
+++ b/docs/content/typescript-api/core-plugins/default-search-plugin/default-search-plugin-init-options.md
@@ -23,7 +23,7 @@ Options which configure the behaviour of the DefaultSearchPlugin
 interface DefaultSearchPluginInitOptions {
   indexStockStatus?: boolean;
   bufferUpdates?: boolean;
-  searchStategy?: SearchStrategy;
+  searchStrategy?: SearchStrategy;
 }
 ```
 ## Members
@@ -49,7 +49,7 @@ Collections, as the buffering allows better control over when these expensive jo
 and also performs optimizations to minimize the amount of work that needs to be performed by
 the worker.{{< /member-description >}}
 
-### searchStategy
+### searchStrategy
 
 {{< member-info kind="property" type="SearchStrategy" default="undefined"  since="1.6.0" >}}
 

--- a/packages/core/src/plugin/default-search-plugin/fulltext-search.service.ts
+++ b/packages/core/src/plugin/default-search-plugin/fulltext-search.service.ts
@@ -111,8 +111,8 @@ export class FulltextSearchService {
      * Sets the SearchStrategy appropriate to th configured database type.
      */
     private setSearchStrategy() {
-        if (this.options.searchStategy) {
-            this._searchStrategy = this.options.searchStategy;
+        if (this.options.searchStrategy) {
+            this._searchStrategy = this.options.searchStrategy;
         } else {
             switch (this.connection.rawConnection.options.type) {
                 case 'mysql':

--- a/packages/core/src/plugin/default-search-plugin/types.ts
+++ b/packages/core/src/plugin/default-search-plugin/types.ts
@@ -120,7 +120,7 @@ export interface DefaultSearchPluginInitOptions {
      * @since 1.6.0
      * @default undefined
      */
-    searchStategy?: SearchStrategy;
+    searchStrategy?: SearchStrategy;
 }
 
 /**


### PR DESCRIPTION
Fix typo in option searchStrategy

https://docs.vendure.io/typescript-api/core-plugins/default-search-plugin/default-search-plugin-init-options/#searchstategy