### PR TITLE
Fix(payments-plugin): Only find payment methods in the current channel

### DIFF
--- a/packages/payments-plugin/src/stripe/stripe.controller.ts
+++ b/packages/payments-plugin/src/stripe/stripe.controller.ts
@@ -6,6 +6,7 @@ import {
     Order,
     OrderService,
     PaymentMethod,
+    PaymentMethodService,
     RequestContext,
     RequestContextService,
     TransactionalConnection,
@@ -27,6 +28,7 @@ const noPaymentIntentErrorMessage = 'No payment intent in the event payload';
 export class StripeController {
     constructor(
         private connection: TransactionalConnection,
+        private paymentMethodService: PaymentMethodService,
         private orderService: OrderService,
         private stripeService: StripeService,
         private requestContextService: RequestContextService,
@@ -124,10 +126,9 @@ export class StripeController {
     }
 
     private async getPaymentMethod(ctx: RequestContext): Promise<PaymentMethod> {
-        const method = (await this.connection.getRepository(ctx, PaymentMethod).find()).find(
+        const method = (await this.paymentMethodService.findAll(ctx)).items.find(
             m => m.handler.code === stripePaymentMethodHandler.code,
         );
-
         if (!method) {
             throw new InternalServerError(`[${loggerCtx}] Could not find Stripe PaymentMethod`);
         }

--- a/packages/payments-plugin/src/stripe/stripe.controller.ts
+++ b/packages/payments-plugin/src/stripe/stripe.controller.ts
@@ -9,7 +9,6 @@ import {
     PaymentMethodService,
     RequestContext,
     RequestContextService,
-    TransactionalConnection,
 } from '@vendure/core';
 import { OrderStateTransitionError } from '@vendure/core/dist/common/error/generated-graphql-shop-errors';
 import { Response } from 'express';
@@ -27,7 +26,6 @@ const noPaymentIntentErrorMessage = 'No payment intent in the event payload';
 @Controller('payments')
 export class StripeController {
     constructor(
-        private connection: TransactionalConnection,
         private paymentMethodService: PaymentMethodService,
         private orderService: OrderService,
         private stripeService: StripeService,


### PR DESCRIPTION
Only search payment methods in the current channel if they have a stripe handler, not all payment methods of all channels.
Fixes #2290