### PR TITLE
Change the table-layout to inherit always for better design when have…

### DIFF
--- a/packages/admin-ui/src/lib/catalog/src/components/collection-data-table/collection-data-table.component.html
+++ b/packages/admin-ui/src/lib/catalog/src/components/collection-data-table/collection-data-table.component.html
@@ -5,7 +5,7 @@
     <table
         class=""
         [class.no-select]="disableSelect"
-        [style.table-layout]="!items?.length ? 'fixed' : 'inherit'"
+        [style.table-layout]="inherit"
     >
         <thead [class.items-selected]="selectionManager?.selection.length">
             <tr class="heading-row">

--- a/packages/admin-ui/src/lib/core/src/shared/components/data-table-2/data-table2.component.html
+++ b/packages/admin-ui/src/lib/core/src/shared/components/data-table-2/data-table2.component.html
@@ -5,7 +5,7 @@
     <table
         class=""
         [class.no-select]="disableSelect"
-        [style.table-layout]="!items?.length ? 'fixed' : 'inherit'"
+        [style.table-layout]="inherit"
     >
         <thead [class.items-selected]="selectionManager?.selection.length">
             <tr class="heading-row">

--- a/packages/admin-ui/src/lib/order/src/components/order-data-table/order-data-table.component.html
+++ b/packages/admin-ui/src/lib/order/src/components/order-data-table/order-data-table.component.html
@@ -5,7 +5,7 @@
     <table
         class=""
         [class.no-select]="disableSelect"
-        [style.table-layout]="!items?.length ? 'fixed' : 'inherit'"
+        [style.table-layout]="inherit"
     >
         <thead [class.items-selected]="selectionManager?.selection.length">
             <tr class="heading-row">


### PR DESCRIPTION
… empty table (#2323) 
In case of a empty table for orders, collections or other data tables the table will be inherit his columns and not overwrite each other.

https://user-images.githubusercontent.com/17176500/256823830-8643b143-32a2-4be6-a25e-17c7081eccc2.png