### PR TITLE
feat(core): Support bi-directional relations in customFields

### DIFF
--- a/packages/core/e2e/fixtures/test-plugins/with-custom-entity.ts
+++ b/packages/core/e2e/fixtures/test-plugins/with-custom-entity.ts
@@ -1,0 +1,58 @@
+import { Collection, PluginCommonModule, VendureEntity, VendurePlugin } from '@vendure/core';
+import gql from 'graphql-tag';
+import { DeepPartial, Entity, ManyToMany, OneToMany } from 'typeorm';
+
+@Entity()
+export class TestCustomEntity extends VendureEntity {
+    constructor(input?: DeepPartial<TestCustomEntity>) {
+        super(input);
+    }
+
+    @ManyToMany(() => Collection, x => (x as any).customFields?.customEntityList, {
+        eager: true,
+    })
+    customEntityListInverse: Collection[];
+
+    @OneToMany(() => Collection, (a: Collection) => (a.customFields as any).customEntity)
+    customEntityInverse: Collection[];
+}
+
+@VendurePlugin({
+    imports: [PluginCommonModule],
+    entities: [TestCustomEntity],
+    adminApiExtensions: {
+        schema: gql`
+            type TestCustomEntity {
+                id: ID!
+            }
+        `,
+    },
+    configuration: config => {
+        config.customFields = {
+            ...(config.customFields ?? {}),
+            Collection: [
+                ...(config.customFields?.Collection ?? []),
+                {
+                    name: 'customEntity',
+                    type: 'relation',
+                    entity: TestCustomEntity,
+                    list: false,
+                    public: false,
+                    inverseSide: (t: TestCustomEntity) => t.customEntityInverse,
+                    graphQLType: 'TestCustomEntity',
+                },
+                {
+                    name: 'customEntityList',
+                    type: 'relation',
+                    entity: TestCustomEntity,
+                    list: true,
+                    public: false,
+                    inverseSide: (t: TestCustomEntity) => t.customEntityListInverse,
+                    graphQLType: 'TestCustomEntity',
+                },
+            ],
+        };
+        return config;
+    },
+})
+export class WithCustomEntity {}

--- a/packages/core/src/config/custom-field/custom-field-types.ts
+++ b/packages/core/src/config/custom-field/custom-field-types.ts
@@ -96,7 +96,12 @@ export type DateTimeCustomFieldConfig = TypedCustomFieldConfig<'datetime', Graph
 export type RelationCustomFieldConfig = TypedCustomFieldConfig<
     'relation',
     Omit<GraphQLRelationCustomFieldConfig, 'entity' | 'scalarFields'>
-> & { entity: Type<VendureEntity>; graphQLType?: string; eager?: boolean };
+> & {
+    entity: Type<VendureEntity>;
+    graphQLType?: string;
+    eager?: boolean;
+    inverseSide: string | ((object: VendureEntity) => any);
+};
 
 /**
  * @description
@@ -180,6 +185,8 @@ export type CustomFieldConfig =
  *
  * * `entity: VendureEntity`: The entity which this custom field is referencing
  * * `eager?: boolean`: Whether to [eagerly load](https://typeorm.io/#/eager-and-lazy-relations) the relation. Defaults to false.
+ * * `inverseSide?: inverseSide: string | ((object: any) => any`: The inverse side for
+ *     [bi-directional relations](https://typeorm.io/many-to-many-relations#bi-directional-relations)
  * * `graphQLType?: string`: The name of the GraphQL type that corresponds to the entity.
  *     Can be omitted if it is the same, which is usually the case.
  *

--- a/packages/core/src/entity/register-custom-entity-fields.ts
+++ b/packages/core/src/entity/register-custom-entity-fields.ts
@@ -80,10 +80,14 @@ function registerCustomFieldsForEntity(
             const registerColumn = () => {
                 if (customField.type === 'relation') {
                     if (customField.list) {
-                        ManyToMany(type => customField.entity, { eager: customField.eager })(instance, name);
+                        ManyToMany(type => customField.entity, customField.inverseSide, {
+                            eager: customField.eager,
+                        })(instance, name);
                         JoinTable()(instance, name);
                     } else {
-                        ManyToOne(type => customField.entity, { eager: customField.eager })(instance, name);
+                        ManyToOne(type => customField.entity, customField.inverseSide, {
+                            eager: customField.eager,
+                        })(instance, name);
                         JoinColumn()(instance, name);
                     }
                 } else {


### PR DESCRIPTION
As mentioned in the issues (https://github.com/vendure-ecommerce/vendure/issues/2344) we would like to add the inversSide-Property for bidrection Relations on CustomFields.

With this it would be more convenientto work with a Custom Entities because it allows to query relations from both sides.