### PR TITLE
Removed shipping address & customer email from payment intent metadata

### DIFF
--- a/packages/payments-plugin/e2e/stripe-payment.e2e-spec.ts
+++ b/packages/payments-plugin/e2e/stripe-payment.e2e-spec.ts
@@ -204,7 +204,6 @@ describe('Stripe payments', () => {
             'metadata[channelToken]': E2E_DEFAULT_CHANNEL_TOKEN,
             'metadata[orderId]': '1',
             'metadata[orderCode]': activeOrder?.code,
-            'metadata[customerEmail]': customers[0].emailAddress,
         });
         expect(createStripePaymentIntent).toEqual('test-client-secret');
         StripePlugin.options.metadata = undefined;

--- a/packages/payments-plugin/src/stripe/stripe.service.ts
+++ b/packages/payments-plugin/src/stripe/stripe.service.ts
@@ -1,5 +1,4 @@
 import { Inject, Injectable } from '@nestjs/common';
-import { ModuleRef } from '@nestjs/core';
 import { ConfigArg } from '@vendure/common/lib/generated-types';
 import {
     Ctx,
@@ -28,8 +27,7 @@ export class StripeService {
         private connection: TransactionalConnection,
         private paymentMethodService: PaymentMethodService,
         @Inject(STRIPE_PLUGIN_OPTIONS) private options: StripePluginOptions,
-        private moduleRef: ModuleRef,
-    ) {}
+    ) { }
 
     async createPaymentIntent(ctx: RequestContext, order: Order): Promise<string> {
         let customerId: string | undefined;
@@ -41,9 +39,6 @@ export class StripeService {
         const amountInMinorUnits = getAmountInStripeMinorUnits(order);
 
         const metadata = sanitizeMetadata({
-            ...(typeof this.options.metadata === 'function'
-                ? await this.options.metadata(new Injector(this.moduleRef), ctx, order)
-                : {}),
             channelToken: ctx.channel.token,
             orderId: order.id,
             orderCode: order.code,


### PR DESCRIPTION
This should solve https://github.com/vendure-ecommerce/vendure/issues/2364

Removed shipping address and customer email from payment intent request metadata. This is because Stripe express payments require a payment intent, but at the point of doing an express payment we may not have customer details (they are fetched from the payment resolver, such as Google/Apple pay.

