### PR TITLE
fix: fix channel aware channel picker

### DIFF
--- a/packages/admin-ui/src/lib/core/src/shared/components/assign-to-channel-dialog/assign-to-channel-dialog.component.html
+++ b/packages/admin-ui/src/lib/core/src/shared/components/assign-to-channel-dialog/assign-to-channel-dialog.component.html
@@ -20,7 +20,7 @@
     <vdr-form-field [label]="'common.channel' | translate" class="mb-4">
         <vdr-channel-assignment-control
             clrInput
-            [multiple]="false"
+            [multiple]="true"
             [includeDefaultChannel]="false"
             [formControl]="selectedChannelIdControl"
         ></vdr-channel-assignment-control>


### PR DESCRIPTION
closes https://github.com/vendure-ecommerce/vendure/issues/2377

`packages/admin-ui/src/lib/settings/src/components/role-detail/role-detail.component.html`
has the 
```
                <vdr-channel-assignment-control
                    formControlName="channelIds"
                    [vdrDisabled]="!('UpdateAdministrator' | hasPermission)"
                ></vdr-channel-assignment-control>
```
Didn't change anything here..