### PR TITLE
fix(core): Aligns items horizontally in the Chip component

### DIFF
--- a/packages/admin-ui/src/lib/core/src/shared/components/chip/chip.component.scss
+++ b/packages/admin-ui/src/lib/core/src/shared/components/chip/chip.component.scss
@@ -51,7 +51,7 @@
     padding: 5px 8px;
     white-space: nowrap;
     display: flex;
-    align-items: center;
+    align-items: flex-start;
     gap: 2px;
 }
 

--- a/packages/admin-ui/src/lib/core/src/shared/components/chip/chip.component.scss
+++ b/packages/admin-ui/src/lib/core/src/shared/components/chip/chip.component.scss
@@ -51,7 +51,7 @@
     padding: 5px 8px;
     white-space: nowrap;
     display: flex;
-    align-items: baseline;
+    align-items: center;
     gap: 2px;
 }
 


### PR DESCRIPTION
## 🎯 Goal

Aligns the icon and label horizontally in the Chip component

## 📝 Approach

Before, the align items was set to baseline, so there was a horizontal shift between elements 
![Capture d’écran 2023-09-05 à 09 28 03](https://github.com/vendure-ecommerce/vendure/assets/6134849/d75d01de-c333-4cd3-8f95-117a9ca1d0d7)

After with the change to `center`
![Capture d’écran 2023-09-05 à 09 28 26](https://github.com/vendure-ecommerce/vendure/assets/6134849/10689779-6567-4039-ac04-41fbbac09fb2)




