### PR TITLE
feat(admin-ui): Implement custom components in order detail data table

### DIFF
--- a/packages/admin-ui/src/lib/order/src/components/order-data-table/order-data-table.component.html
+++ b/packages/admin-ui/src/lib/order/src/components/order-data-table/order-data-table.component.html
@@ -21,7 +21,16 @@
                     [class.expand]="column.expand"
                 >
                     <div class="cell-content" [ngClass]="column.align">
-                        <span>{{ column.heading }}</span>
+                        <vdr-ui-extension-point
+                            [locationId]="id"
+                            [metadata]="column.id"
+                            api="dataTable"
+                            [topPx]="-6"
+                            [leftPx]="-24"
+                            display="block"
+                        >
+                            <span>{{ column.heading }}</span>
+                        </vdr-ui-extension-point>
                         <div *ngIf="column.sort as sort" class="sort-toggle">
                             <button (click)="sort.toggleSortOrder()" [class.active]="sort.sortOrder">
                                 <clr-icon *ngIf="!sort.sortOrder" shape="two-way-arrows left"></clr-icon>
@@ -105,8 +114,21 @@
                 <td *ngFor="let column of visibleSortedColumns" [class.active]="activeIndex === i">
                     <div class="cell-content" [ngClass]="column.align">
                         <ng-container
-                            *ngTemplateOutlet="column.template; context: { item: item, index: i }"
-                        ></ng-container>
+                            *ngIf="customComponents.get(column.id) as componentConfig; else defaultComponent"
+                        >
+                            <ng-container
+                                *ngComponentOutlet="
+                                    componentConfig.config.component;
+                                    inputs: { rowItem: item };
+                                    injector: componentConfig.injector
+                                "
+                            ></ng-container>
+                        </ng-container>
+                        <ng-template #defaultComponent>
+                            <ng-container
+                                *ngTemplateOutlet="column.template; context: { item: item, index: i }"
+                            ></ng-container>
+                        </ng-template>
                     </div>
                 </td>
                 <td [class.active]="activeIndex === i"><!-- column select --></td>

--- a/packages/admin-ui/src/lib/order/src/components/order-table/order-table.component.html
+++ b/packages/admin-ui/src/lib/order/src/components/order-table/order-table.component.html
@@ -1,4 +1,4 @@
-<vdr-order-data-table id="order-detail-" [items]="order.lines" [order]="order">
+<vdr-order-data-table id="order-detail-list" [items]="order.lines" [order]="order">
     <vdr-dt2-column [heading]="'common.image' | translate" id="image">
         <ng-template let-line="item">
             <div class="image-placeholder">


### PR DESCRIPTION
Added custom data table components to the data table on the order detail page per my usecase: https://github.com/vendure-ecommerce/vendure/issues/2353

I was unable to get the dev-server compileUIExtensions to work so this is untested with a custom component defined, but I'm 90% sure it should work.