### PR TITLE
fix(payments-plugin): List missing available Mollie payment methods for orders api

### DIFF
--- a/packages/payments-plugin/e2e/mollie-payment.e2e-spec.ts
+++ b/packages/payments-plugin/e2e/mollie-payment.e2e-spec.ts
@@ -349,7 +349,7 @@ describe('Mollie payments (with useDynamicRedirectUrl set to true)', () => {
 
         it('Should get available paymentMethods', async () => {
             nock('https://api.mollie.com/')
-                .get('/v2/methods')
+                .get('/v2/methods?resource=orders')
                 .reply(200, mockData.molliePaymentMethodsResponse);
             await shopClient.asUserWithCredentials(customers[0].emailAddress, 'test');
             const { molliePaymentMethods } = await shopClient.query(GET_MOLLIE_PAYMENT_METHODS, {

--- a/packages/payments-plugin/src/mollie/mollie.service.ts
+++ b/packages/payments-plugin/src/mollie/mollie.service.ts
@@ -334,7 +334,8 @@ export class MollieService {
             throw Error(`No apiKey configured for payment method ${paymentMethodCode}`);
         }
         const client = createMollieClient({ apiKey });
-        const methods = await client.methods.list();
+        // We use the orders API, so list available methods for that API usage
+        const methods = await client.methods.list({resource: 'orders'});
         return methods.map(m => ({
             ...m,
             code: m.id,


### PR DESCRIPTION
By default `mollie.methods.list()` lists payment methods for use with the `payments` API. However, the Mollie integration uses the `orders` integration. This resulted in some payment methods, like `Klarna pay later` not being listed.

This PR fixes that by passing `orders` to the mollie function: `mollie.methods.list({resource: 'orders'})`.