### PR TITLE
Fix/mollie klarna AutoCapture doesn't work!

### DIFF
--- a/packages/payments-plugin/e2e/mollie-payment.e2e-spec.ts
+++ b/packages/payments-plugin/e2e/mollie-payment.e2e-spec.ts
@@ -381,8 +381,7 @@ describe('Mollie payments (with useDynamicRedirectUrl set to true)', () => {
                 body: JSON.stringify({ id: mockData.mollieOrderResponse.id }),
                 headers: { 'Content-Type': 'application/json' },
             });
-            // tslint:disable-next-line:no-non-null-assertion
-            const { order: adminOrder } = await adminClient.query(GET_ORDER_PAYMENTS, { id: order!.id });
+            const { order: adminOrder } = await adminClient.query(GET_ORDER_PAYMENTS, { id: order?.id });
             expect(adminOrder.state).toBe('ArrangingPayment');
         });
 
@@ -457,7 +456,7 @@ describe('Mollie payments (with useDynamicRedirectUrl set to true)', () => {
                 adminClient,
                 order.lines[0].id,
                 10,
-                // tslint:disable-next-line:no-non-null-assertion
+                // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
                 order.payments!.find(p => p.amount === 108990)!.id,
                 SURCHARGE_AMOUNT,
             );
@@ -468,6 +467,8 @@ describe('Mollie payments (with useDynamicRedirectUrl set to true)', () => {
     });
 
     describe('Handle pay-later methods', () => {
+        // TODO: Add testcases that mock incoming webhook to: 1. Authorize payment and 2. AutoCapture payments
+
         it('Should prepare a new order', async () => {
             await shopClient.asUserWithCredentials(customers[0].emailAddress, 'test');
             const { addItemToOrder } = await shopClient.query<

--- a/packages/payments-plugin/src/mollie/mollie.service.ts
+++ b/packages/payments-plugin/src/mollie/mollie.service.ts
@@ -308,6 +308,7 @@ export class MollieService {
      * Settle an existing payment based on the given mollieOrder
      */
     async settleExistingPayment(ctx: RequestContext, order: Order, mollieOrderId: string): Promise<void> {
+        order = await this.entityHydrator.hydrate(ctx, order, { relations: ['payments'] });
         const payment = order.payments.find(p => p.transactionId === mollieOrderId);
         if (!payment) {
             throw Error(
@@ -335,7 +336,7 @@ export class MollieService {
         }
         const client = createMollieClient({ apiKey });
         // We use the orders API, so list available methods for that API usage
-        const methods = await client.methods.list({resource: 'orders'});
+        const methods = await client.methods.list({ resource: 'orders' });
         return methods.map(m => ({
             ...m,
             code: m.id,


### PR DESCRIPTION
Quite an impactful fix:

* Somewhere between V1.9 and v2.0.8 the relation `order.payments` got lost, resulting in Klarna Pay Later orders nver transitioning to PaymentSettled
* Without this fix orders stay in PaymentAuthorized, and shop owners never receive their money. Klarna has a policy that payments should be captured within 30 days, after that capturing payments (= receiving money) is not possible anymore.
* A test case is very useful here, but, time... I've added a Todo in the e2e file