### PR TITLE
fix(slug): Remove trademark symbols from normalized strings

### DIFF
--- a/packages/common/src/normalize-string.spec.ts
+++ b/packages/common/src/normalize-string.spec.ts
@@ -25,7 +25,7 @@ describe('normalizeString()', () => {
     it('strips non-alphanumeric characters', () => {
         expect(normalizeString('hi!!!')).toBe('hi');
         expect(normalizeString('who? me?')).toBe('who me');
-        expect(normalizeString('!"£$%^&*()+[]{};:@#~?/,|\\><`¬\'=')).toBe('');
+        expect(normalizeString('!"£$%^&*()+[]{};:@#~?/,|\\><`¬\'=©®™')).toBe('');
     });
 
     it('allows a subset of non-alphanumeric characters to pass through', () => {

--- a/packages/common/src/normalize-string.ts
+++ b/packages/common/src/normalize-string.ts
@@ -8,6 +8,6 @@ export function normalizeString(input: string, spaceReplacer = ' '): string {
         .normalize('NFD')
         .replace(/[\u0300-\u036f]/g, '')
         .toLowerCase()
-        .replace(/[!"£$%^&*()+[\]{};:@#~?\\/,|><`¬'=‘’]/g, '')
+        .replace(/[!"£$%^&*()+[\]{};:@#~?\\/,|><`¬'=‘’©®™]/g, '')
         .replace(/\s+/g, spaceReplacer);
 }


### PR DESCRIPTION
When importing a product, we resulted in a slug containing a `®` trademark symbol, which is invalid.

Therefore, in this PR, I made sure to remove the trademark symbols from the normalized strings, such as `©`, `®` and `™`.