### PR TITLE
fix(payments-plugin): Stripe controller crashes server instance

### DIFF
--- a/packages/payments-plugin/src/stripe/raw-body.middleware.ts
+++ b/packages/payments-plugin/src/stripe/raw-body.middleware.ts
@@ -1,4 +1,4 @@
-import { raw } from 'body-parser';
+import { json } from 'body-parser';
 import * as http from 'http';
 
 import { RequestWithRawBody } from './types';
@@ -7,7 +7,8 @@ import { RequestWithRawBody } from './types';
  * Middleware which adds the raw request body to the incoming message object. This is needed by
  * Stripe to properly verify webhook events.
  */
-export const rawBodyMiddleware = raw({
+export const rawBodyMiddleware = json({
+    type: '*/*',
     verify(req: RequestWithRawBody, res: http.ServerResponse, buf: Buffer, encoding: string) {
         if (Buffer.isBuffer(buf)) {
             req.rawBody = Buffer.from(buf);

--- a/packages/payments-plugin/src/stripe/raw-body.middleware.ts
+++ b/packages/payments-plugin/src/stripe/raw-body.middleware.ts
@@ -1,4 +1,4 @@
-import { json } from 'body-parser';
+import { raw } from 'body-parser';
 import * as http from 'http';
 
 import { RequestWithRawBody } from './types';
@@ -7,7 +7,7 @@ import { RequestWithRawBody } from './types';
  * Middleware which adds the raw request body to the incoming message object. This is needed by
  * Stripe to properly verify webhook events.
  */
-export const rawBodyMiddleware = json({
+export const rawBodyMiddleware = raw({
     type: '*/*',
     verify(req: RequestWithRawBody, res: http.ServerResponse, buf: Buffer, encoding: string) {
         if (Buffer.isBuffer(buf)) {

--- a/packages/payments-plugin/src/stripe/stripe.controller.ts
+++ b/packages/payments-plugin/src/stripe/stripe.controller.ts
@@ -45,7 +45,7 @@ export class StripeController {
             return;
         }
 
-        const event = request.body as Stripe.Event;
+        const event = JSON.parse(request.body.toString()) as Stripe.Event;
         const paymentIntent = event.data.object as Stripe.PaymentIntent;
 
         if (!paymentIntent) {
@@ -120,14 +120,20 @@ export class StripeController {
                     `Error adding payment to order ${orderCode}: ${addPaymentToOrderResult.message}`,
                     loggerCtx,
                 );
+                return;
             }
 
+            // The payment intent ID is added to the order only if we can reach this point.
             Logger.info(
                 `Stripe payment intent id ${paymentIntent.id} added to order ${orderCode}`,
                 loggerCtx,
             );
-            response.status(HttpStatus.OK).send('Ok');
         });
+
+        // Send the response status only if we didn't sent anything yet.
+        if (!response.headersSent) {
+            response.status(HttpStatus.OK).send('Ok');
+        }
     }
 
     private async createContext(channelToken: string, req: RequestWithRawBody): Promise<RequestContext> {

--- a/packages/payments-plugin/src/stripe/stripe.controller.ts
+++ b/packages/payments-plugin/src/stripe/stripe.controller.ts
@@ -121,10 +121,13 @@ export class StripeController {
                     loggerCtx,
                 );
             }
-        });
 
-        Logger.info(`Stripe payment intent id ${paymentIntent.id} added to order ${orderCode}`, loggerCtx);
-        response.status(HttpStatus.OK).send('Ok');
+            Logger.info(
+                `Stripe payment intent id ${paymentIntent.id} added to order ${orderCode}`,
+                loggerCtx,
+            );
+            response.status(HttpStatus.OK).send('Ok');
+        });
     }
 
     private async createContext(channelToken: string, req: RequestWithRawBody): Promise<RequestContext> {


### PR DESCRIPTION
This patch is slightly related to the issue [2450](https://github.com/vendure-ecommerce/vendure/issues/2450), but fixes only the crash side of it: 

I've put the last `response.status(HttpStatus.OK).send('Ok')` to the transaction block, otherwise it crashes the backend with the following error: 
```
...
[server] Error [ERR_HTTP_HEADERS_SENT]: Cannot set headers after they are sent to the client
[server]     at new NodeError (node:internal/errors:387:5)
[server]     at ServerResponse.setHeader (node:_http_outgoing:644:11)
[server]     at ServerResponse.header (/usr/src/app/node_modules/express/lib/response.js:794:10)
[server]     at ServerResponse.send (/usr/src/app/node_modules/express/lib/response.js:174:12)
[server]     at StripeController.webhook (/usr/src/app/node_modules/@vendure/payments-plugin/package/stripe/stripe.controller.js:95:49)
[server]     at processTicksAndRejections (node:internal/process/task_queues:96:5) 
[server] node:internal/errors:478
...
```

Please note that this does not solves the issue that the `rawBody` is not defined because the middleware is not executed, but at least the backend won't crash because of any unidentified issues.