### PR TITLE
feat(admin-ui): Add product slug in product multi selector dialog component

### DIFF
--- a/packages/admin-ui/src/lib/core/src/shared/components/product-multi-selector-dialog/product-multi-selector-dialog.component.html
+++ b/packages/admin-ui/src/lib/core/src/shared/components/product-multi-selector-dialog/product-multi-selector-dialog.component.html
@@ -37,6 +37,12 @@
                 <span [title]="mode === 'product' ? item.productName : item.productVariantName">{{
                     mode === 'product' ? item.productName : item.productVariantName
                 }}</span>
+                <div *ngIf="mode === 'product'">
+                    <small>
+                        <span class="slug-label">slug:</span>
+                        <code>{{ item.slug }}</code>
+                    </small>
+                </div>
                 <div *ngIf="mode === 'variant'"><small>{{ item.sku }}</small></div>
             </div>
         </div>

--- a/packages/admin-ui/src/lib/core/src/shared/components/product-multi-selector-dialog/product-multi-selector-dialog.component.scss
+++ b/packages/admin-ui/src/lib/core/src/shared/components/product-multi-selector-dialog/product-multi-selector-dialog.component.scss
@@ -28,6 +28,10 @@
     }
 }
 
+.slug-label {
+    margin-right: 4px;
+}
+
 .detail {
     margin: 0 3px;
     font-size: 12px;
@@ -74,3 +78,4 @@ vdr-select-toggle {
     align-items: center;
     justify-content: space-between;
 }
+


### PR DESCRIPTION
### Initial issue

When trying to fill in the collections by manually selecting products, we sometimes have issues because products of different sellers have the exact same names.

For instance, we have a lot of `Amazon` products which we can't distinguish between all our vendors.

![image](https://github.com/vendure-ecommerce/vendure/assets/17927632/631c2498-4a40-4841-9b3a-676c8b491b0c)

### Solution

In this PR, I enhanced the `product-multi-selector-dialog` Angular component so as to display the product `slug` in case the display mode is `product`.

Therefore, we know exactly what product corresponds to each card.

<img width="1202" alt="image" src="https://github.com/vendure-ecommerce/vendure/assets/17927632/6c8b186e-023d-4262-9bb3-1dd523a250f7">
