### PR TITLE
fix(payments-plugin): Idempotent 'paid' Mollie webhooks

### DIFF
--- a/packages/payments-plugin/src/mollie/mollie.helpers.ts
+++ b/packages/payments-plugin/src/mollie/mollie.helpers.ts
@@ -61,14 +61,16 @@ export function toMollieOrderLines(order: Order, alreadyPaid: number): CreatePar
         vatAmount: toAmount(surcharge.priceWithTax - surcharge.price, order.currencyCode),
     })));
     // Deduct amount already paid
-    lines.push({
-        name: 'Already paid',
-        quantity: 1,
-        unitPrice: toAmount(-alreadyPaid, order.currencyCode),
-        totalAmount: toAmount(-alreadyPaid, order.currencyCode),
-        vatRate: String(0),
-        vatAmount: toAmount(0, order.currencyCode),
-    });
+    if (alreadyPaid) {
+        lines.push({
+            name: 'Already paid',
+            quantity: 1,
+            unitPrice: toAmount(-alreadyPaid, order.currencyCode),
+            totalAmount: toAmount(-alreadyPaid, order.currencyCode),
+            vatRate: String(0),
+            vatAmount: toAmount(0, order.currencyCode),
+        });
+    }
     return lines;
 }
 

--- a/packages/payments-plugin/src/mollie/mollie.service.ts
+++ b/packages/payments-plugin/src/mollie/mollie.service.ts
@@ -227,6 +227,13 @@ export class MollieService {
                 `Unable to find order ${mollieOrder.orderNumber}, unable to process Mollie order ${mollieOrder.id}`,
             );
         }
+        if (order.state === 'PaymentSettled') {
+            Logger.info(
+                `Order ${order.code} is already 'PaymentSettled', no need for handling Mollie status '${mollieOrder.status}'`,
+                loggerCtx,
+            );
+            return;
+        }
         if (mollieOrder.status === OrderStatus.expired) {
             // Expired is fine, a customer can retry the payment later
             return;
@@ -247,13 +254,6 @@ export class MollieService {
         }
         if (order.state === 'PaymentAuthorized' && mollieOrder.status === OrderStatus.completed) {
             return this.settleExistingPayment(ctx, order, mollieOrder.id);
-        }
-        if (order.state === 'PaymentAuthorized' || order.state === 'PaymentSettled') {
-            Logger.info(
-                `Order ${order.code} is '${order.state}', no need for handling Mollie status '${mollieOrder.status}'`,
-                loggerCtx,
-            );
-            return;
         }
         // Any other combination of Mollie status and Vendure status indicates something is wrong.
         throw Error(


### PR DESCRIPTION
This PR fixes:

* Only add `Already paid` orderline to Mollie order if it has a value. [See more info here about already paid](https://github.com/vendure-ecommerce/vendure/issues/2026)
![image](https://github.com/vendure-ecommerce/vendure/assets/6604455/d5d32b9a-3097-41b5-bf22-63316ff641d8)
:arrow_up: We dont want this.
* Error throwing for multiple Mollie webhooks coming in with status 'paid'. Status update is now idempotent: if Mollie says order is `paid` but Vendure order is already `paymentSettled`, we don't do anything and return 200. (It was throwing an error). This was the error thrown when another `paid` webhook comes in: `Failed to process incoming webhook: "Error adding payment to order A47MESUAJY7NVBHV: ORDER_PAYMENT_STATE_ERROR"`

