### PR TITLE
Add Missing Closing Parentheses on TransitionToState Example Mutation

### DIFF
--- a/docs/docs/guides/storefront/checkout-flow/index.mdx
+++ b/docs/docs/guides/storefront/checkout-flow/index.mdx
@@ -308,7 +308,7 @@ while the payment is being arranged. The [`transitionOrderToState`](/reference/g
 <TabItem value="Query" label="Query" default>
 
 ```graphql
-mutation TransitionToState($state: String!)
+mutation TransitionToState($state: String!) {
   transitionOrderToState(state: $state) {
     ...ActiveOrder
     ...on OrderStateTransitionError {


### PR DESCRIPTION
Fixes minor typo that can cause issue when people copy and paste the code.