### PR TITLE
fix(core): Fix collection findBySlug issue2395 

### DIFF
--- a/packages/core/src/service/services/collection.service.ts
+++ b/packages/core/src/service/services/collection.service.ts
@@ -228,11 +228,26 @@ export class CollectionService implements OnModuleInit {
         if (!translations?.length) {
             return;
         }
-        const bestMatch =
-            translations.find(t => t.languageCode === ctx.languageCode) ??
-            translations.find(t => t.languageCode === ctx.channel.defaultLanguageCode) ??
-            translations[0];
-        return this.findOne(ctx, bestMatch.base.id, relations);
+
+        let bestMatches = translations.filter(t => t.languageCode === ctx.channel.defaultLanguageCode);
+
+        if (!(bestMatches.length > 0)) {
+            bestMatches = translations.filter(t => t.languageCode === ctx.channel.defaultLanguageCode);
+        }
+
+        // In case there is best matches return the first found in the channel.
+        let collection: Translated<Collection> | undefined;
+        if (bestMatches.length > 0) {
+            for (const bestMatch of bestMatches) {
+                collection = await this.findOne(ctx, bestMatch.base.id, relations);
+                if (collection) {
+                    return collection;
+                }
+            }
+            return collection;
+        }
+
+        return this.findOne(ctx, translations[0].base.id, relations);
     }
 
     /**

--- a/packages/core/src/service/services/collection.service.ts
+++ b/packages/core/src/service/services/collection.service.ts
@@ -229,7 +229,7 @@ export class CollectionService implements OnModuleInit {
             return;
         }
 
-        let bestMatches = translations.filter(t => t.languageCode === ctx.channel.defaultLanguageCode);
+        let bestMatches = translations.filter(t => t.languageCode === ctx.languageCode);
 
         if (!(bestMatches.length > 0)) {
             bestMatches = translations.filter(t => t.languageCode === ctx.channel.defaultLanguageCode);

--- a/packages/core/src/service/services/collection.service.ts
+++ b/packages/core/src/service/services/collection.service.ts
@@ -235,7 +235,7 @@ export class CollectionService implements OnModuleInit {
             bestMatches = translations.filter(t => t.languageCode === ctx.channel.defaultLanguageCode);
         }
 
-        // In case there is best matches return the first found in the channel.
+        // In case there are better matches, we return the first found in the channel.
         let collection: Translated<Collection> | undefined;
         if (bestMatches.length > 0) {
             for (const bestMatch of bestMatches) {


### PR DESCRIPTION
Fix the : https://github.com/vendure-ecommerce/vendure/issues/2395 issue.

Return the first found collection matching the findBySlug criteria.

To Test :

1. Create 2 channel
2. Create a collection with slug 'test' in the first channel
3. Create a collection with the same slug the the other channel
4. Go to the admin-api playground (or shop-api).
5. Use the `collection` query with the header set to the first channel token -> you get the collection of this channel
6. Do the same with the header set to the other channel -> you should get the other collection (the one corresponding to the channel in the header).
