### PR TITLE
fix(core): fix configurable operation id decoding when using uuids

### DIFF
--- a/packages/core/src/api/common/configurable-operation-codec.ts
+++ b/packages/core/src/api/common/configurable-operation-codec.ts
@@ -43,8 +43,7 @@ export class ConfigurableOperationCodec {
                         const decodedIds = ids.map(id => this.idCodecService.decode(id));
                         arg.value = JSON.stringify(decodedIds);
                     } else {
-                        const decodedId = this.idCodecService.decode(arg.value);
-                        arg.value = JSON.stringify(decodedId);
+                        arg.value = this.idCodecService.decode(arg.value);
                     }
                 }
             }


### PR DESCRIPTION
Fixes issue #2019 

Id's were getting JSON stringified when they shouldn't have been. It only worked for integer ids because `JSON.stringify(1) == 1`. For uuids, `JSON.stringify("XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX") != "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"`.

Later, when it uses the values in business logic: https://github.com/vendure-ecommerce/vendure/blob/218561f04cbaf738c0f18302b67b1b077a056a7f/packages/core/src/common/configurable-operation.ts#L459-L460 , JSON.parse() is not called on ids.

I can't guarantee this doesn't break anything as the change is in a critical area.