### PR TITLE
Pull Request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,22 @@
+# Description
+
+Please include a summary of the changes and the related issue.
+
+# Breaking changes
+
+Does this PR include any breaking changes we should be aware of?
+
+# Screenshots
+
+You can add screenshots here if applicable.
+
+# Checklist
+
+:pushpin: Always:
+- [ ] I have set a clear title
+- [ ] My PR is small and contains a single feature
+- [ ] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")
+
+:zap: Most of the time:
+- [ ] I have added or updated test cases
+- [ ] I have updated the README if needed


### PR DESCRIPTION
Not sure if this is something you'd want in the Vendure repo, but it might save you some work reviewing. With this PR template contributors are aware of what they can pay attention to, to have their PR's merged faster.

It renders like this (you can even click the checkboxes after you've created the description):

# Description

Please include a summary of the changes and the related issue.

# Breaking changes

Does this PR include any breaking changes we should be aware of?

# Screenshots

You can add screenshots here if applicable.

# Checklist

:pushpin: Always:
- [ ] I have set a clear title
- [ ] My PR is small and contains a single feature
- [ ] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

:zap: Most of the time:
- [ ] I have added or updated test cases
- [ ] I have updated the README if needed