### PR TITLE
fix(mollie): Add missing `status` type

### DIFF
--- a/packages/payments-plugin/src/mollie/graphql/generated-shop-types.ts
+++ b/packages/payments-plugin/src/mollie/graphql/generated-shop-types.ts
@@ -1671,6 +1671,7 @@ export type MolliePaymentMethod = {
   image?: Maybe<MolliePaymentMethodImages>;
   maximumAmount?: Maybe<MollieAmount>;
   minimumAmount?: Maybe<MollieAmount>;
+  status?: Maybe<Scalars['String']['output']>;
 };
 
 export type MolliePaymentMethodImages = {

--- a/packages/payments-plugin/src/mollie/mollie-shop-schema.ts
+++ b/packages/payments-plugin/src/mollie/mollie-shop-schema.ts
@@ -21,6 +21,7 @@ export const shopSchema = gql`
         minimumAmount: MollieAmount
         maximumAmount: MollieAmount
         image: MolliePaymentMethodImages
+        status: String
     }
     type MolliePaymentIntent {
         url: String!


### PR DESCRIPTION
# Description

Adds a missing `status` field to the `molliePaymentMethods` query. This type was previously not typed by Mollie. It is documented however. 

PR on Mollie's API plugin: https://github.com/mollie/mollie-api-node/pull/335

# Breaking changes

None.

# Checklist

:pushpin: Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

:zap: Most of the time:
- [x] I have added or updated test cases
- [x] I have updated the README if needed