### PR TITLE
refactor(admin-ui): Use generics in ReactDataTableComponentProps

### DIFF
--- a/docs/docs/guides/extending-the-admin-ui/custom-data-table-components/index.md
+++ b/docs/docs/guides/extending-the-admin-ui/custom-data-table-components/index.md
@@ -46,8 +46,8 @@ React components will receive the value of the current column as the `rowItem` p
 import { ReactDataTableComponentProps } from '@vendure/admin-ui/react';
 import React from 'react';
 
-export function SlugLink({ rowItem }: ReactDataTableComponentProps) {
-    const slug: string = rowItem.slug;
+export function SlugLink({ rowItem }: ReactDataTableComponentProps<{ slug: string }>) {
+    const slug = rowItem.slug;
     return (
         <a href={`https://example.com/category/${slug}`} target="_blank">
             {slug}

--- a/docs/docs/reference/admin-ui-api/react-extensions/register-react-data-table-component.md
+++ b/docs/docs/reference/admin-ui-api/react-extensions/register-react-data-table-component.md
@@ -23,7 +23,7 @@ e.g. the `Product` object if used in the `product-list` table.
 import { ReactDataTableComponentProps } from '@vendure/admin-ui/react';
 import React from 'react';
 
-export function SlugWithLink({ rowItem }: ReactDataTableComponentProps) {
+export function SlugWithLink({ rowItem }: ReactDataTableComponentProps<{ slug: string }>) {
     return (
         <a href={`https://example.com/products/${rowItem.slug}`} target="_blank">
             {rowItem.slug}

--- a/packages/admin-ui/src/lib/react/src/register-react-data-table-component.ts
+++ b/packages/admin-ui/src/lib/react/src/register-react-data-table-component.ts
@@ -37,16 +37,16 @@ export interface ReactDataTableComponentConfig {
      * @description
      * Optional props to pass to the React component.
      */
-    props?: Record<string, any>;
+    props?: Record<string, unknown>;
 }
 
 /**
  * @description
  * The props that will be passed to the React component registered via {@link registerReactDataTableComponent}.
  */
-export interface ReactDataTableComponentProps {
-    rowItem: any;
-    [prop: string]: any;
+export interface ReactDataTableComponentProps<T> {
+    rowItem: T;
+    [prop: string]: unknown;
 }
 
 /**
@@ -60,7 +60,7 @@ export interface ReactDataTableComponentProps {
  * import { ReactDataTableComponentProps } from '\@vendure/admin-ui/react';
  * import React from 'react';
  *
- * export function SlugWithLink({ rowItem }: ReactDataTableComponentProps) {
+ * export function SlugWithLink({ rowItem }: ReactDataTableComponentProps<{ slug: string }>) {
  *     return (
  *         <a href={`https://example.com/products/${rowItem.slug}`} target="_blank">
  *             {rowItem.slug}
@@ -79,7 +79,7 @@ export interface ReactDataTableComponentProps {
  *         tableId: 'product-list',
  *         columnId: 'slug',
  *         props: {
- *         foo: 'bar',
+ *           foo: 'bar',
  *         },
  *     }),
  * ];

--- a/packages/dev-server/test-plugins/experimental-ui/components/SlugWithLink.tsx
+++ b/packages/dev-server/test-plugins/experimental-ui/components/SlugWithLink.tsx
@@ -1,8 +1,8 @@
 import { ReactDataTableComponentProps } from '@vendure/admin-ui/react';
 import React from 'react';
 
-export function SlugWithLink({ rowItem }: ReactDataTableComponentProps) {
-    const slug: string = rowItem.slug;
+export function SlugWithLink({ rowItem }: ReactDataTableComponentProps<{ slug: string }>) {
+    const slug = rowItem.slug;
     return (
         <a href={`https://example.com/category/${slug}`} target="_blank">
             {slug}


### PR DESCRIPTION
# Description

Add generics to `ReactDataTableComponentProps`  
Fixes #2486

# Breaking changes

None

# Checklist

:pushpin: Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

:zap: Most of the time:
- [ ] I have added or updated test cases
- [x] I have updated the README if needed