### PR TITLE
feat(admin-ui): Export React useDataService hook

### DIFF
--- a/packages/admin-ui/src/lib/react/src/react-hooks/use-query.ts
+++ b/packages/admin-ui/src/lib/react/src/react-hooks/use-query.ts
@@ -112,7 +112,7 @@ export function useMutation<T, V extends Record<string, any> = Record<string, an
     return [execute, rest] as [typeof execute, typeof rest];
 }
 
-function useDataService<T, V extends Record<string, any> = Record<string, any>>(
+export function useDataService<T, V extends Record<string, any> = Record<string, any>>(
     operation: (dataService: DataService, variables?: V) => Observable<T>,
 ) {
     const context = useContext(HostedComponentContext);


### PR DESCRIPTION
# Description

The aim is to export React `useDataService` hook until the PR https://github.com/vendure-ecommerce/vendure/pull/2498 is available in the next minor release
I haven't added any documentation to limit its use because the export is temporary. Tell me if it's necessary

# Checklist

:pushpin: Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

:zap: Most of the time:
- [ ] I have added or updated test cases
- [ ] I have updated the README if needed