### PR TITLE
test(testing): allow Nest to rethrow errors on e2e tests

### DIFF
--- a/packages/testing/src/test-server.ts
+++ b/packages/testing/src/test-server.ts
@@ -116,6 +116,7 @@ export class TestServer {
             const app = await NestFactory.create(appModule.AppModule, {
                 cors: config.apiOptions.cors,
                 logger: new Logger(),
+                abortOnError: false,
             });
             const { tokenMethod } = config.authOptions;
             const usingCookie =


### PR DESCRIPTION
# Description

Allow Nest to rethrow errors on e2e tests
[Nest documentation](https://github.com/nestjs/nest/blob/master/packages/common/interfaces/nest-application-context-options.interface.ts#L18)

# Screenshots

Before, when an e2e test crashed due to a missing import
![Capture d’écran 2023-11-07 à 14 39 09](https://github.com/vendure-ecommerce/vendure/assets/6134849/8ef2e601-e836-43c4-a0bc-e74586b31459)

After
![Capture d’écran 2023-11-07 à 14 21 23](https://github.com/vendure-ecommerce/vendure/assets/6134849/213cf42d-67d5-4578-883d-988632b713fc)



# Checklist

:pushpin: Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

:zap: Most of the time:
- [ ] I have added or updated test cases
- [ ] I have updated the README if needed