### PR TITLE
fix(docs): Correct plugin-example configuration key

### DIFF
--- a/docs/docs/guides/developer-guide/plugins/index.mdx
+++ b/docs/docs/guides/developer-guide/plugins/index.mdx
@@ -40,7 +40,7 @@ import { LanguageCode, PluginCommonModule, VendurePlugin } from '@vendure/core';
 
 @VendurePlugin({
     imports: [PluginCommonModule],
-    configure: config => {
+    configuration: config => {
         config.customFields.Customer.push({
             type: 'string',
             name: 'avatarUrl',


### PR DESCRIPTION
# Description

Correct the doc's plugin-example configuration key from `configure` to `configuration`.

# Checklist

:pushpin: Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

:zap: Most of the time:
- [ ] I have added or updated test cases
- [ ] I have updated the README if needed