### PR TITLE
fix(core): expose enabled field for product in shop api

### DIFF
--- a/packages/common/src/generated-shop-types.ts
+++ b/packages/common/src/generated-shop-types.ts
@@ -2535,6 +2535,7 @@ export type Product = Node & {
   createdAt: Scalars['DateTime']['output'];
   customFields?: Maybe<Scalars['JSON']['output']>;
   description: Scalars['String']['output'];
+  enabled: Scalars['Boolean']['output'];
   facetValues: Array<FacetValue>;
   featuredAsset?: Maybe<Asset>;
   id: Scalars['ID']['output'];

--- a/packages/core/src/api/schema/admin-api/product-admin.type.graphql
+++ b/packages/core/src/api/schema/admin-api/product-admin.type.graphql
@@ -1,5 +1,4 @@
 type Product implements Node {
-    enabled: Boolean!
     channels: [Channel!]!
 }
 

--- a/packages/core/src/api/schema/common/product.type.graphql
+++ b/packages/core/src/api/schema/common/product.type.graphql
@@ -6,6 +6,7 @@ type Product implements Node {
     name: String!
     slug: String!
     description: String!
+    enabled: Boolean!
     featuredAsset: Asset
     assets: [Asset!]!
     "Returns all ProductVariants"


### PR DESCRIPTION
# Description

Expose enabled field for product in shop api

# Breaking changes


# Screenshots
![Capture d’écran 2023-11-23 à 13 58 18](https://github.com/vendure-ecommerce/vendure/assets/6134849/5292a43f-d427-4805-907a-752403935d84)


# Checklist

:pushpin: Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

:zap: Most of the time:
- [ ] I have added or updated test cases
- [ ] I have updated the README if needed