### PR TITLE
docs: Change plugin version info for bullmq and fix typos on writing a plugin page

### DIFF
--- a/docs/docs/guides/developer-guide/plugins/index.mdx
+++ b/docs/docs/guides/developer-guide/plugins/index.mdx
@@ -138,7 +138,7 @@ export class MyPlugin implements NestModule {
 
 In Vendure **plugins** are used to extend the core functionality of the server. Plugins can be pre-made functionality that you can install via npm, or they can be custom plugins that you write yourself.
 
-For any unit of functionality that you need to add to your project, you'll be writing creating a Vendure plugin. By convention, plugins are stored in the `plugins` directory of your project. However, this is not a requirement, and you are free to arrange your plugin files in any way you like.
+For any unit of functionality that you need to add to your project, you'll be creating a Vendure plugin. By convention, plugins are stored in the `plugins` directory of your project. However, this is not a requirement, and you are free to arrange your plugin files in any way you like.
 
 ```txt
 ├──src
@@ -284,7 +284,7 @@ In order to make use of this custom field in a type-safe way, we can tell TypeSc
 import { CustomCustomerFields } from '@vendure/core/dist/entity/custom-entity-fields';
 import { WishlistItem } from './entities/wishlist-item.entity';
 
-declare module '@vendure/core/dist/entity/custom-entity-fields' {
+declare module '@vendure/core' {
   interface CustomCustomerFields {
     wishlistItems: WishlistItem[];
   }
@@ -312,7 +312,7 @@ Let's create a service to handle the wishlist functionality:
         ├── wishlist.service.ts
 ```
 
-```ts title="src/plugins/wishlist-plugin/wishlist.service.ts"
+```ts title="src/plugins/wishlist-plugin/services/wishlist.service.ts"
 import { Injectable } from '@nestjs/common';
 import {
     Customer,

--- a/docs/docs/reference/core-plugins/job-queue-plugin/bull-mqjob-queue-plugin.md
+++ b/docs/docs/reference/core-plugins/job-queue-plugin/bull-mqjob-queue-plugin.md
@@ -32,13 +32,13 @@ in processing jobs.
 
 ## Installation
 
-`yarn add @vendure/job-queue-plugin bullmq@1`
+`yarn add @vendure/job-queue-plugin bullmq`
 
 or
 
-`npm install @vendure/job-queue-plugin bullmq@1`
+`npm install @vendure/job-queue-plugin bullmq`
 
-**Note:** The v1.x version of this plugin is designed to work with bullmq v1.x.
+**Note:** The v1.x version of this plugin is designed to work with bullmq v1.x, etc.
 
 *Example*
 


### PR DESCRIPTION
# Description

Docs only: Fixes minor typos to avoid confusion.  The most substantive change is to the module path for custom entity typing.  I got errors until I change to @vendure/core, but please check to be sure this is correct.

```ts title="src/plugins/wishlist-plugin/types.ts"
declare module '@vendure/core' {
  interface CustomCustomerFields {
    wishlistItems: WishlistItem[];
  }
}
```

:pushpin: Always:
- [X] I have set a clear title
- [X] My PR is small and contains a single feature
- [X] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

:zap: Most of the time:
- [ ] I have added or updated test cases
- [X] I have updated the README if needed