### PR TITLE
fix(ui-devkit): Add call to exit in sigint handler

### DIFF
--- a/packages/ui-devkit/src/compiler/compile.ts
+++ b/packages/ui-devkit/src/compiler/compile.ts
@@ -267,6 +267,7 @@ function runWatchMode({
         if (buildProcess) {
             buildProcess.kill();
         }
+        process.exit();
     };
 
     process.on('SIGINT', close);


### PR DESCRIPTION
# Description

Required exit because the default node handler is removed, and when developing a vendure app it never exits when using ctrl+c

# Breaking changes

No

# Checklist

:pushpin: Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

:zap: Most of the time:
- [ ] I have added or updated test cases
- [ ] I have updated the README if needed