### PR TITLE
fix(core): send the correct amount to `refundOrder` on cancelled OrderLines

### DIFF
--- a/packages/core/src/config/order/default-order-process.ts
+++ b/packages/core/src/config/order/default-order-process.ts
@@ -412,13 +412,7 @@ export function configureDefaultOrderProcess(options: DefaultOrderProcessOptions
                 if (shouldSetAsPlaced) {
                     order.active = false;
                     order.orderPlacedAt = new Date();
-                    await Promise.all(
-                        order.lines.map(line =>
-                            connection
-                                .getRepository(ctx, OrderLine)
-                                .update(line.id, { orderPlacedQuantity: line.quantity }),
-                        ),
-                    );
+                    order.lines.map(line => line.orderPlacedQuantity = line.quantity)
                     eventBus.publish(new OrderPlacedEvent(fromState, toState, ctx, order));
                     await orderSplitter.createSellerOrders(ctx, order);
                 }


### PR DESCRIPTION
# Description

Fix issue https://github.com/vendure-ecommerce/vendure/issues/2523 related to https://github.com/vendure-ecommerce/vendure/issues/2302

Issue: The amount received by the `refundOrder` function is 0
After investigation, `orderPlacedQuantity` is always 0 [here](https://github.com/vendure-ecommerce/vendure/blob/master/packages/core/src/service/services/payment.service.ts#L306)

As explained in the [documentation](https://docs.vendure.io/guides/core-concepts/orders/#responding-to-a-state-transition
), the order is persisted later, and overrides the value set in each orderLine update.
So, this PR defines the correct value for `orderPlacedQuantity` of each orderLines when the order is placed to have the right value at persistence.

Work done in pairs with @ttournie 🙏 

# Screenshots

![Capture d’écran 2023-11-30 à 17 59 33](https://github.com/vendure-ecommerce/vendure/assets/6134849/4beea3c3-8831-4453-8e55-b2306ea80089)

# Checklist

:pushpin: Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

:zap: Most of the time:
- [ ] I have added or updated test cases
- [ ] I have updated the README if needed