### PR TITLE
fix(core): Fix loading multiple customField relations

### DIFF
--- a/packages/core/e2e/list-query-builder.e2e-spec.ts
+++ b/packages/core/e2e/list-query-builder.e2e-spec.ts
@@ -1268,6 +1268,27 @@ describe('ListQueryBuilder', () => {
                 },
             ]);
         });
+
+        it('should resolve multiple relations in customFields successfully', async () => {
+            const { testEntities } = await shopClient.query(GET_LIST_WITH_MULTIPLE_CUSTOM_FIELD_RELATION, {
+                options: {
+                    filter: {
+                        label: { eq: 'A' },
+                    },
+                },
+            });
+
+            expect(testEntities.items).toEqual([
+                {
+                    id: 'T_1',
+                    label: 'A',
+                    customFields: {
+                        relation: [{ id: 'T_1', data: 'A' }],
+                        otherRelation: [{ id: 'T_1', data: 'A' }],
+                    },
+                },
+            ]);
+        });
     });
 });
 
@@ -1343,6 +1364,27 @@ const GET_LIST_WITH_CUSTOM_FIELD_RELATION = gql`
                 label
                 customFields {
                     relation {
+                        id
+                        data
+                    }
+                }
+            }
+        }
+    }
+`;
+
+const GET_LIST_WITH_MULTIPLE_CUSTOM_FIELD_RELATION = gql`
+    query GetTestWithMultipleCustomFieldRelation($options: TestEntityListOptions) {
+        testEntities(options: $options) {
+            items {
+                id
+                label
+                customFields {
+                    relation {
+                        id
+                        data
+                    }
+                    otherRelation {
                         id
                         data
                     }

--- a/packages/core/src/service/helpers/list-query-builder/list-query-builder.ts
+++ b/packages/core/src/service/helpers/list-query-builder/list-query-builder.ts
@@ -493,14 +493,21 @@ export class ListQueryBuilder implements OnApplicationBootstrap {
                         loadEagerRelations: true,
                     } as FindManyOptions<T>)
                     .then(results =>
-                        results.map(r => ({ relation: relationPaths[0] as keyof T, entity: r })),
+                        results.map(r => ({
+                            relations: relationPaths[0].startsWith('customFields.')
+                                ? relationPaths
+                                : [relationPaths[0]],
+                            entity: r,
+                        })),
                     );
             }),
         ).then(all => all.flat());
         for (const entry of entitiesIdsWithRelations) {
             const finalEntity = entityMap.get(entry.entity.id);
-            if (finalEntity) {
-                this.assignDeep(entry.relation, entry.entity, finalEntity);
+            for (const relation of entry.relations) {
+                if (finalEntity) {
+                    this.assignDeep(relation, entry.entity, finalEntity);
+                }
             }
         }
         return Array.from(entityMap.values());


### PR DESCRIPTION
fixes #2555

# Description
If a list query contained multiple `customFields` relations, only one had been assigned to the target entity. This fix allows storing multiple relations in `customFields` to be fetched.

# Breaking changes
None

# Checklist

:pushpin: Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

:zap: Most of the time:
- [x] I have added or updated test cases
- [ ] I have updated the README if needed