### PR TITLE
fix(payments-plugin, Mollie): Ignore completed state to prevent unneccesary error throwing

### DIFF
--- a/packages/payments-plugin/src/mollie/mollie.service.ts
+++ b/packages/payments-plugin/src/mollie/mollie.service.ts
@@ -184,7 +184,7 @@ export class MollieService {
             orderInput.method = molliePaymentMethodCode as MollieClientMethod;
         }
         const mollieOrder = await mollieClient.orders.create(orderInput);
-        Logger.info(`Created Mollie order ${mollieOrder.id} for order ${order.code}`);
+        Logger.info(`Created Mollie order ${mollieOrder.id} for order ${order.code}`, loggerCtx);
         const url = mollieOrder.getCheckoutUrl();
         if (!url) {
             throw Error('Unable to getCheckoutUrl() from Mollie order');

--- a/packages/payments-plugin/src/mollie/mollie.service.ts
+++ b/packages/payments-plugin/src/mollie/mollie.service.ts
@@ -255,6 +255,11 @@ export class MollieService {
         if (order.state === 'PaymentAuthorized' && mollieOrder.status === OrderStatus.completed) {
             return this.settleExistingPayment(ctx, order, mollieOrder.id);
         }
+        if (autoCapture && mollieOrder.status === OrderStatus.completed) {
+            // When autocapture is enabled, we should not handle the completed status from Mollie,
+            // because the order will be transitioned to PaymentSettled during auto capture
+            return;
+        }
         // Any other combination of Mollie status and Vendure status indicates something is wrong.
         throw Error(
             `Unhandled incoming Mollie status '${mollieOrder.status}' for order ${order.code} with status '${order.state}'`,


### PR DESCRIPTION
# Description

When a customer pays with Klarna/pay-later, and autocapture is enabled in the Mollie plugin, an error is thrown: `Failed to process incoming webhook: "Unhandled incoming Mollie status 'completed' for order XXXXXXX with status 'AddingItems'"`

However, this should not be an error, because autocapture makes sure the order is transitioned to PaymentSettled.

This is what happens when a customer pays with Klarna and `autocapture=true` in the Mollie plugin:

1. Customer pays with Klarna
2. Webhook `authorized` comes in from Mollie: The order is transitioned to `PaymentAuthorized`
3. Autocapture is triggered: The payment is settled, then the existing payment for the order is settled, transitioning the order to `PaymentSettled`
4. Within 200ms, we receive a webhook from Mollie with status `completed`, because we settled the payment in Mollie. But, I suspect the previous transaction (the transition to PaymentSettled) isn't committed yet, because the logs will say `"Unhandled incoming Mollie status 'completed' for order XXXXXXX with status 'AddingItems'"`. 

TL;DR: The `completed` webhook comes in before Vendure has transitioned the order to `PaymentSettled`, resulting in the incorrect error while the order is settled as it should.

# Screenshots

![image](https://github.com/vendure-ecommerce/vendure/assets/6604455/293b2e91-b377-45ff-ade3-01a68a7e039d)
Here you can see there is only ~180ms between settlement (`Settled payment for XXX`) and the incoming webhook (`Processing status completed for xx`)

# Checklist

:pushpin: Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

:zap: Most of the time:
- [ ] I have added or updated test cases
- [ ] I have updated the README if needed