### PR TITLE
Emoji fix for pull_request_template.md

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,11 +12,11 @@ You can add screenshots here if applicable.
 
 # Checklist
 
-:pushpin: Always:
+📌 Always:
 - [ ] I have set a clear title
 - [ ] My PR is small and contains a single feature
 - [ ] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")
 
-:zap: Most of the time:
+👍 Most of the time:
 - [ ] I have added or updated test cases
 - [ ] I have updated the README if needed


### PR DESCRIPTION
For some reason, emojis don't work from templates anymore, you have to use the unicode emojis. And, we definitely need emojis in the PR template