### PR TITLE
test(core): Add default search plugin tests

### DIFF
--- a/e2e-common/vitest.config.bench.ts
+++ b/e2e-common/vitest.config.bench.ts
@@ -1,0 +1,36 @@
+import path from 'path';
+import swc from 'unplugin-swc';
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+    test: {
+        include: ['**/*.bench.ts'],
+        /**
+         * For local debugging of the e2e tests, we set a very long timeout value otherwise tests will
+         * automatically fail for going over the 5 second default timeout.
+         */
+        testTimeout: process.env.E2E_DEBUG ? 1800 * 1000 : process.env.CI ? 30 * 1000 : 15 * 1000,
+        // threads: false,
+        // singleThread: true,
+        // reporters: ['verbose'],
+        typecheck: {
+            tsconfig: path.join(__dirname, 'tsconfig.e2e.json'),
+        },
+        // In jobs-queue.e2e-spec.ts, we use `it.only()` for sqljs, so we need this
+        // set to true to avoid failures in CI.
+        allowOnly: true,
+    },
+    plugins: [
+        // SWC required to support decorators used in test plugins
+        // See https://github.com/vitest-dev/vitest/issues/708#issuecomment-1118628479
+        // Vite plugin
+        swc.vite({
+            jsc: {
+                transform: {
+                    // See https://github.com/vendure-ecommerce/vendure/issues/2099
+                    useDefineForClassFields: false,
+                },
+            },
+        }),
+    ],
+});

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "lerna": "^7.1.5",
     "lint-staged": "^10.5.4",
     "prettier": "^2.2.1",
+    "tinybench": "^2.5.1",
     "ts-node": "^10.9.1",
     "typescript": "4.9.5",
     "unplugin-swc": "^1.3.2",

--- a/packages/core/e2e/default-search-plugin.bench.ts
+++ b/packages/core/e2e/default-search-plugin.bench.ts
@@ -1,0 +1,77 @@
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
+import { DefaultJobQueuePlugin, DefaultSearchPlugin, mergeConfig } from '@vendure/core';
+import { createTestEnvironment, registerInitializer, SqljsInitializer } from '@vendure/testing';
+import path from 'path';
+import { afterAll, beforeAll, bench, describe, expect } from 'vitest';
+
+import { initialData } from '../../../e2e-common/e2e-initial-data';
+import { testConfig, TEST_SETUP_TIMEOUT_MS } from '../../../e2e-common/test-config';
+
+import {
+    SearchProductsShopQuery,
+    SearchProductsShopQueryVariables,
+} from './graphql/generated-e2e-shop-types';
+import { SEARCH_PRODUCTS_SHOP } from './graphql/shop-definitions';
+import { awaitRunningJobs } from './utils/await-running-jobs';
+
+registerInitializer('sqljs', new SqljsInitializer(path.join(__dirname, '__data__'), 1000));
+
+interface SearchProductsShopQueryVariablesExt extends SearchProductsShopQueryVariables {
+    input: SearchProductsShopQueryVariables['input'] & {
+        // This input field is dynamically added only when the `indexStockStatus` init option
+        // is set to `true`, and therefore not included in the generated type. Therefore
+        // we need to manually patch it here.
+        inStock?: boolean;
+    };
+}
+
+const { server, adminClient, shopClient } = createTestEnvironment(
+    mergeConfig(testConfig(), {
+        plugins: [DefaultSearchPlugin.init({ indexStockStatus: true }), DefaultJobQueuePlugin],
+    }),
+);
+
+beforeAll(async () => {
+    await server.init({
+        initialData,
+        productsCsvPath: path.join(__dirname, 'fixtures/e2e-products-default-search.csv'),
+        customerCount: 1,
+    });
+    await adminClient.asSuperAdmin();
+    await awaitRunningJobs(adminClient);
+}, TEST_SETUP_TIMEOUT_MS);
+
+afterAll(async () => {
+    await server.destroy();
+});
+
+const isDevelopment = process.env.NODE_ENV === 'development';
+describe.skipIf(isDevelopment)('Default search plugin - benchmark', () => {
+    bench(
+        'group by product',
+        async () => {
+            await shopClient.query<SearchProductsShopQuery, SearchProductsShopQueryVariablesExt>(
+                SEARCH_PRODUCTS_SHOP,
+                {
+                    input: {
+                        groupByProduct: true,
+                    },
+                },
+            );
+        },
+        {
+            warmupTime: 0,
+            warmupIterations: 1,
+            time: 0,
+            iterations: 1000,
+            setup: (task, mode) => {
+                if (mode === 'run') {
+                    task.addEventListener('complete', e => {
+                        const taskResult = e.task.result;
+                        expect(taskResult?.mean).toBeLessThan(15);
+                    });
+                }
+            },
+        },
+    );
+});

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -27,6 +27,7 @@
         "test": "vitest --config ./vitest.config.ts --run",
         "e2e": "cross-env PACKAGE=core vitest --config ../../e2e-common/vitest.config.ts --run",
         "e2e:watch": "cross-env PACKAGE=core vitest --config ../../e2e-common/vitest.config.ts",
+        "bench": "cross-env PACKAGE=core vitest bench --config ../../e2e-common/vitest.config.ts --run",
         "ci": "yarn build"
     },
     "publishConfig": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -27,7 +27,7 @@
         "test": "vitest --config ./vitest.config.ts --run",
         "e2e": "cross-env PACKAGE=core vitest --config ../../e2e-common/vitest.config.ts --run",
         "e2e:watch": "cross-env PACKAGE=core vitest --config ../../e2e-common/vitest.config.ts",
-        "bench": "cross-env PACKAGE=core vitest bench --config ../../e2e-common/vitest.config.ts --run",
+        "bench": "cross-env PACKAGE=core vitest --config ../../e2e-common/vitest.config.bench.ts --run",
         "ci": "yarn build"
     },
     "publishConfig": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -17706,6 +17706,11 @@ tinybench@^2.5.0:
   resolved "https://registry.yarnpkg.com/tinybench/-/tinybench-2.5.0.tgz#4711c99bbf6f3e986f67eb722fed9cddb3a68ba5"
   integrity sha512-kRwSG8Zx4tjF9ZiyH4bhaebu+EDz1BOx9hOigYHlUW4xxI/wKIUQUqo018UlU4ar6ATPBsaMrdbKZ+tmPdohFA==
 
+tinybench@^2.5.1:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/tinybench/-/tinybench-2.5.1.tgz#3408f6552125e53a5a48adee31261686fd71587e"
+  integrity sha512-65NKvSuAVDP/n4CqH+a9w2kTlLReS9vhsAP06MWx+/89nMinJyB2icyl58RIcqCmIggpojIGeuJGhjU1aGMBSg==
+
 tinypool@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/tinypool/-/tinypool-0.7.0.tgz#88053cc99b4a594382af23190c609d93fddf8021"


### PR DESCRIPTION
# Description

Add default search plugin tests:
- Improve and fix tests
- Add benchmark tests
  - Vitest [benchmark](https://vitest.dev/guide/features.html#benchmarking-experimental) testing is currently an experimental feature. Test failures are not yet handled properly. However, using the underlying `tinybench` package directly with Vitest e2e tests ensures that failing tests are handled properly.

# Breaking changes

# Screenshots

# Checklist

:pushpin: Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [ ] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

:zap: Most of the time:
- [x] I have added or updated test cases
- [ ] I have updated the README if needed