### PR TITLE
chore(admin-ui): Tab-bar color tweak

### DIFF
--- a/packages/admin-ui/src/lib/core/src/shared/components/page-header-tabs/page-header-tabs.component.scss
+++ b/packages/admin-ui/src/lib/core/src/shared/components/page-header-tabs/page-header-tabs.component.scss
@@ -5,6 +5,11 @@
 
 .tab-bar {
     display: flex;
+
+    & a:hover {
+        color: var(--color-text-active);
+        border-bottom-color: var(--color-text-active);
+    }
 }
 
 .tab {

--- a/packages/admin-ui/src/lib/static/styles/theme/default.scss
+++ b/packages/admin-ui/src/lib/static/styles/theme/default.scss
@@ -119,7 +119,7 @@
     --color-text-200: var(--clr-global-font-color-secondary);
     --color-text-300: var(--color-grey-400);
     --color-text-inverse: white;
-    --color-text-active: var(--color-primary-600);
+    --color-text-active: var(--color-primary-800);
 
     // Component-specific colors
     --color-scrollbar-bg: var(--color-weight-150);

--- a/packages/admin-ui/src/lib/static/styles/theme/default.scss
+++ b/packages/admin-ui/src/lib/static/styles/theme/default.scss
@@ -119,7 +119,7 @@
     --color-text-200: var(--clr-global-font-color-secondary);
     --color-text-300: var(--color-grey-400);
     --color-text-inverse: white;
-    --color-text-active: var(--color-primary-800);
+    --color-text-active: var(--color-primary-600);
 
     // Component-specific colors
     --color-scrollbar-bg: var(--color-weight-150);


### PR DESCRIPTION
# Description

Vendure blue is great so I did a little color tweak to keep us with this clean feel, without too much color.

# Screenshots

Before:
<img width="633" alt="image" src="https://github.com/vendure-ecommerce/vendure/assets/134155599/4f94daa9-7ff1-471d-aa60-2ffb0815ec4a">

After:
<img width="659" alt="image" src="https://github.com/vendure-ecommerce/vendure/assets/134155599/06a2cdfb-29ce-407e-b2db-10cfa96a8e99">