### PR TITLE
chore(admin-ui): Link color tweak

### DIFF
--- a/packages/admin-ui/src/lib/catalog/src/components/collection-detail/collection-detail.component.scss
+++ b/packages/admin-ui/src/lib/catalog/src/components/collection-detail/collection-detail.component.scss
@@ -17,6 +17,9 @@ clr-checkbox-wrapper {
         font-size: 0.65rem;
         display: inline-block;
         margin-inline-end: 10px;
+        &:last-child {
+            font-weight: 600;
+        }
     }
     li:not(:last-child)::after {
         content: '›';

--- a/packages/admin-ui/src/lib/static/styles/global/_sass-overrides.scss
+++ b/packages/admin-ui/src/lib/static/styles/global/_sass-overrides.scss
@@ -1,3 +1,8 @@
 // Note: variables defined in this file should use the !default flag so they can be
 // overridden by custom Admin UI applications
 $clr-sidenav-width: 10.8rem !default;
+
+$clr-link-visited-color: var(--color-weight-700) !default;
+$clr-link-hover-color: var(--color-weight-700) !default;
+$clr-link-active-color: var(--color-weight-700) !default;
+$clr-link-color: var(--color-weight-700) !default;

--- a/packages/admin-ui/src/lib/static/styles/theme/dark.scss
+++ b/packages/admin-ui/src/lib/static/styles/theme/dark.scss
@@ -107,10 +107,10 @@
 
     --clr-popover-box-shadow-color: hsla(0, 0%, 0%, 0.5);
 
-    --clr-link-active-color: hsl(198, 65%, 57%);
-    --clr-link-color: hsl(198, 65%, 57%);
-    --clr-link-hover-color: hsl(198, 65%, 57%);
-    --clr-link-visited-color: hsl(228, 55%, 75%);
+    --clr-link-visited-color: var(--color-weight-700);
+    --clr-link-hover-color: var(--color-weight-700);
+    --clr-link-active-color: var(--color-weight-700);
+    --clr-link-color: var(--color-weight-700);
 
     --clr-theme-alert-font-color: hsl(210, 16%, 93%);
     --clr-theme-app-alert-font-color: hsl(0, 0%, 0%);

--- a/packages/admin-ui/src/lib/static/styles/theme/default.scss
+++ b/packages/admin-ui/src/lib/static/styles/theme/default.scss
@@ -236,4 +236,10 @@
 
     // spacing
     --space-unit: 8px;
+
+    // clarity styles
+    --clr-link-visited-color: var(--color-weight-700);
+    --clr-link-hover-color: var(--color-weight-700);
+    --clr-link-active-color: var(--color-weight-700);
+    --clr-link-color: var(--color-weight-700);
 }


### PR DESCRIPTION
# Description

Tweak the color of the breadcrumbs/links and keep the style of the two breadcrumbs/links consistent. Under the premise of modifying `default.scss` and `dark.scss`, you still need to add values to `_sass-overrides.scss`.

# Screenshots

Before:
<img width="778" alt="image" src="https://github.com/vendure-ecommerce/vendure/assets/134155599/7a6982cd-f525-4042-a682-d67bbcf7731d">
<img width="747" alt="image" src="https://github.com/vendure-ecommerce/vendure/assets/134155599/8d6e29ca-1b2d-423e-abbf-289bc9d910f2">

After:
<img width="755" alt="image" src="https://github.com/vendure-ecommerce/vendure/assets/134155599/c49d99fc-317d-4e9c-8029-1752986477f9">
<img width="776" alt="image" src="https://github.com/vendure-ecommerce/vendure/assets/134155599/63b17e82-be9d-4b9c-b0c7-8f87f380939a">