### PR TITLE
fix(admin-ui): Too long transactionId causes style issues

### DIFF
--- a/packages/admin-ui/src/lib/order/src/components/order-payment-card/order-payment-card.component.scss
+++ b/packages/admin-ui/src/lib/order/src/components/order-payment-card/order-payment-card.component.scss
@@ -3,6 +3,7 @@
     display: flex;
     justify-content: space-between;
     align-items: center;
+    line-break: anywhere;
 }
 
 .refund-icon {


### PR DESCRIPTION
# Screenshots
Before:
<img width="432" alt="image" src="https://github.com/vendure-ecommerce/vendure/assets/134155599/4555909b-7911-4b54-9688-8805e2772ee9">

After:
<img width="402" alt="image" src="https://github.com/vendure-ecommerce/vendure/assets/134155599/0d1775bb-cebb-4998-a8aa-7bd09edffce3">