### PR TITLE
Properly replace umlauts and Eszett for German lang

### DIFF
--- a/packages/common/src/normalize-string.spec.ts
+++ b/packages/common/src/normalize-string.spec.ts
@@ -37,4 +37,13 @@ describe('normalizeString()', () => {
         expect(normalizeString('Capture d’écran')).toBe('capture decran');
         expect(normalizeString('Capture d‘écran')).toBe('capture decran');
     });
+
+    it('replaces eszett with double-s digraph', () => {
+        expect(normalizeString('KONGREẞ im Straßennamen')).toBe('kongress im strassennamen');
+    });
+
+    // works for German language, might not work for e.g. Finnish language
+    it('replaces combining diaeresis with e', () => {
+        expect(normalizeString('Ja quäkt Schwyz Pöbel vor Gmünd')).toBe('ja quaekt schwyz poebel vor gmuend');
+    });
 });

--- a/packages/common/src/normalize-string.ts
+++ b/packages/common/src/normalize-string.ts
@@ -7,6 +7,7 @@ export function normalizeString(input: string, spaceReplacer = ' '): string {
     return (input || '')
         .normalize('NFD')
         .replace(/[\u00df]/g, 'ss')
+        .replace(/[\u1e9e]/g, 'SS')
         .replace(/[\u0308]/g, 'e')
         .replace(/[\u0300-\u036f]/g, '')
         .toLowerCase()

--- a/packages/common/src/normalize-string.ts
+++ b/packages/common/src/normalize-string.ts
@@ -6,6 +6,8 @@
 export function normalizeString(input: string, spaceReplacer = ' '): string {
     return (input || '')
         .normalize('NFD')
+        .replace(/[\u00df]/g, 'ss')
+        .replace(/[\u0308]/g, 'e')
         .replace(/[\u0300-\u036f]/g, '')
         .toLowerCase()
         .replace(/[!"£$%^&*()+[\]{};:@#~?\\/,|><`¬'=‘’©®™]/g, '')

--- a/packages/core/e2e/collection.e2e-spec.ts
+++ b/packages/core/e2e/collection.e2e-spec.ts
@@ -253,7 +253,7 @@ describe('Collection resolver', () => {
                 'accessories',
             );
             expect(createCollection.translations.find(t => t.languageCode === LanguageCode.de)?.slug).toBe(
-                'zubehor',
+                'zubehoer',
             );
         });
 

--- a/packages/core/e2e/collection.e2e-spec.ts
+++ b/packages/core/e2e/collection.e2e-spec.ts
@@ -285,7 +285,7 @@ describe('Collection resolver', () => {
                 'accessories-2',
             );
             expect(createCollection.translations.find(t => t.languageCode === LanguageCode.de)?.slug).toBe(
-                'zubehor-2',
+                'zubehoer-2',
             );
         });
 
@@ -317,7 +317,7 @@ describe('Collection resolver', () => {
                 'accessories',
             );
             expect(createCollection.translations.find(t => t.languageCode === LanguageCode.de)?.slug).toBe(
-                'zubehor',
+                'zubehoer',
             );
         });
 


### PR DESCRIPTION
I propose this change to properly replace umlauts and Eszett for German language strings. It replaces `ß` with `ss` and any combining diaeresis `◌̈` with `e`, i.e. `ä` becomes `ae`, `ö` `oe` and `ü` `ue`, which appears to be the SEO-friendliest replacement. This might be incorrect for other languages, as e.g. Finnish seems to replace `ä` with `a` and `ö` with `o`, so it might be sensible to add i18n to this function.