### PR TITLE
docs: identifier and emailAddress should be equal

### DIFF
--- a/docs/docs/guides/core-concepts/auth/index.md
+++ b/docs/docs/guides/core-concepts/auth/index.md
@@ -546,7 +546,7 @@ export class KeycloakAuthenticationStrategy implements AuthenticationStrategy<Ke
         return this.externalAuthenticationService.createAdministratorAndUser(ctx, {
             strategy: this.name,
             externalIdentifier: userInfo.sub,
-            // identifier and emailAddress should be equal [#1489](https://github.com/vendure-ecommerce/vendure/issues/1489)
+            // identifier and emailAddress should be equal
             identifier: userInfo.email,
             emailAddress: userInfo.email,
             firstName: userInfo.given_name,

--- a/docs/docs/guides/core-concepts/auth/index.md
+++ b/docs/docs/guides/core-concepts/auth/index.md
@@ -546,7 +546,8 @@ export class KeycloakAuthenticationStrategy implements AuthenticationStrategy<Ke
         return this.externalAuthenticationService.createAdministratorAndUser(ctx, {
             strategy: this.name,
             externalIdentifier: userInfo.sub,
-            identifier: userInfo.preferred_username,
+            // identifier and emailAddress should be equal [#1489](https://github.com/vendure-ecommerce/vendure/issues/1489)
+            identifier: userInfo.email,
             emailAddress: userInfo.email,
             firstName: userInfo.given_name,
             lastName: userInfo.family_name,


### PR DESCRIPTION
# Description

Fixes https://github.com/vendure-ecommerce/vendure/issues/1489 where the identifier and emailAddress should be equal. If they are not equal, you will encounter a `no user with id <not found>` error

# Breaking changes

No breaking change. Docs change only.

# Screenshots

N/A

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [ ] I have added or updated test cases
- [ ] I have updated the README if needed
