### PR TITLE
fix: Update translations parent `updatedAt` column.

### DIFF
--- a/packages/core/src/service/helpers/translatable-saver/translatable-saver.ts
+++ b/packages/core/src/service/helpers/translatable-saver/translatable-saver.ts
@@ -105,6 +105,8 @@ export class TranslatableSaver {
             new entityType({ ...input, translations: existingTranslations }),
             diff,
         );
+        entity.updatedAt = new Date();
+
         const updatedEntity = patchEntity(entity as any, omit(input, ['translations']));
         if (typeof beforeSave === 'function') {
             await beforeSave(entity);


### PR DESCRIPTION
# Description

Previously when updating translations for a entity, it would only set the `updatedAt` for the translation itself. But now it will also update it for the parent (e.g. a product). Closes #1464

/claim #1464

# Breaking changes

# Screenshots

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [ ] I have added or updated test cases
- [ ] I have updated the README if needed