### PR TITLE
fix(product-variant-entity-resolver): Add product translation

### DIFF
--- a/packages/core/src/api/resolvers/entity/product-variant-entity.resolver.ts
+++ b/packages/core/src/api/resolvers/entity/product-variant-entity.resolver.ts
@@ -80,8 +80,13 @@ export class ProductVariantEntityResolver {
         @Parent() productVariant: ProductVariant,
     ): Promise<Product | undefined> {
         if (productVariant.product) {
-            return productVariant.product;
+            return this.requestContextCache.get(
+                ctx,
+                `ProductVariantEntityResolver.product(${productVariant.productId})`,
+                () => this.productVariantService.translateProduct(ctx, productVariant.product),
+            );
         }
+
         return this.requestContextCache.get(
             ctx,
             `ProductVariantEntityResolver.product(${productVariant.productId})`,

--- a/packages/core/src/service/services/product-variant.service.ts
+++ b/packages/core/src/service/services/product-variant.service.ts
@@ -364,6 +364,10 @@ export class ProductVariantService {
         return stockOnHand;
     }
 
+    translateProduct(ctx: RequestContext, product: Product) {
+        return this.translator.translate(product, ctx);
+    }
+
     async create(
         ctx: RequestContext,
         input: CreateProductVariantInput[],


### PR DESCRIPTION
Fix (#2171)

# Description

The product variant entity resolver is not translating the product when its given productVariant argument has product already defined. 

productVariant [gets its product property from a call to listQueryBuilder](https://github.com/vendure-ecommerce/vendure/blob/master/packages/core/src/service/services/product-variant.service.ts#L214), which means its not translated.

# Breaking changes

No breaking changes

# Screenshots

You can add screenshots here if applicable.

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [ ] I have added or updated test cases
- [ ] I have updated the README if needed
