### PR TITLE
fix(admin-ui): Change fragment name to prevent export being ProductListQueryProductFragmentFragment

### DIFF
--- a/packages/admin-ui/src/lib/catalog/src/components/product-list/product-list.graphql.ts
+++ b/packages/admin-ui/src/lib/catalog/src/components/product-list/product-list.graphql.ts
@@ -1,7 +1,7 @@
 import { gql } from 'apollo-angular';
 
 const PRODUCT_LIST_QUERY_PRODUCT_FRAGMENT = gql`
-    fragment ProductListQueryProductFragment on Product {
+    fragment ProductListQueryProduct on Product {
         id
         createdAt
         updatedAt
@@ -29,7 +29,7 @@ export const PRODUCT_LIST_QUERY = gql`
     query ProductListQuery($options: ProductListOptions) {
         products(options: $options) {
             items {
-                ...ProductListQueryProductFragment
+                ...ProductListQueryProduct
             }
             totalItems
         }


### PR DESCRIPTION
Changes a fragment name to prevent export being ProductListQueryProductFragmentFragment

# Description

This is a very minor change to fix an inconsistently named fragment.  

The ProductListQueryFragment currently has to be imported like:

```ts
import { ProductListQueryProductFragmentFragment } from '@vendure/admin-ui/core'
```
Note the double `Fragment` in the name.

This changes that to be consistent with how other fragments are named.

# Breaking changes

Does this PR include any breaking changes we should be aware of?

- This could be a breaking change for users who are currently importing this fragment as ProductListQueryProductFragmentFragment

📌 Always:
- [X] I have set a clear title
- [X] My PR is small and contains a single feature
- [X] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [ ] I have added or updated test cases
- [ ] I have updated the README if needed
