### PR TITLE
fix(payments-plugin): Mollie ignore order states

### DIFF
--- a/packages/payments-plugin/src/mollie/mollie.service.ts
+++ b/packages/payments-plugin/src/mollie/mollie.service.ts
@@ -12,6 +12,7 @@ import {
     Logger,
     Order,
     OrderService,
+    OrderState,
     OrderStateTransitionError,
     PaymentMethod,
     PaymentMethodService,
@@ -226,14 +227,15 @@ export class MollieService {
                 `Unable to find order ${mollieOrder.orderNumber}, unable to process Mollie order ${mollieOrder.id}`,
             );
         }
-        if (
-            order.state === 'PaymentSettled' ||
-            order.state === 'Cancelled' ||
-            order.state === 'Shipped' ||
-            order.state === 'PartiallyShipped' ||
-            order.state === 'Delivered' ||
-            order.state === 'PartiallyDelivered'
-        ) {
+        const statesThatRequireAction: OrderState[] = [
+            'AddingItems',
+            'ArrangingPayment',
+            'ArrangingAdditionalPayment',
+            'PaymentAuthorized',
+            'Draft',
+        ];
+        if (!statesThatRequireAction.includes(order.state)) {
+            // If order is not in one of these states, we don't need to handle the Mollie webhook
             Logger.info(
                 `Order ${order.code} is already '${order.state}', no need for handling Mollie status '${mollieOrder.status}'`,
                 loggerCtx,

--- a/packages/payments-plugin/src/mollie/mollie.service.ts
+++ b/packages/payments-plugin/src/mollie/mollie.service.ts
@@ -226,7 +226,14 @@ export class MollieService {
                 `Unable to find order ${mollieOrder.orderNumber}, unable to process Mollie order ${mollieOrder.id}`,
             );
         }
-        if (order.state === 'PaymentSettled' || order.state === 'Shipped' || order.state === 'Delivered') {
+        if (
+            order.state === 'PaymentSettled' ||
+            order.state === 'Cancelled' ||
+            order.state === 'Shipped' ||
+            order.state === 'PartiallyShipped' ||
+            order.state === 'Delivered' ||
+            order.state === 'PartiallyDelivered'
+        ) {
             Logger.info(
                 `Order ${order.code} is already '${order.state}', no need for handling Mollie status '${mollieOrder.status}'`,
                 loggerCtx,


### PR DESCRIPTION
# Description

In [this PR](https://github.com/vendure-ecommerce/vendure/pull/2657) we introduced order states that can be ingored when a Mollie webhook comes in, but we missed a few: Cancelled, PartiallyDelivered and partiallyShipped

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [ ] I have added or updated test cases
- [ ] I have updated the README if needed
