### PR TITLE
feat(admin-ui): React useProseMirror hook

### DIFF
--- a/packages/admin-ui/src/lib/react/src/react-hooks/use-prose-mirror.ts
+++ b/packages/admin-ui/src/lib/react/src/react-hooks/use-prose-mirror.ts
@@ -1,0 +1,63 @@
+import { useEffect, useRef } from 'react';
+import { Injector } from '@angular/core';
+
+import { CreateEditorViewOptions, ProsemirrorService, ContextMenuService } from '@vendure/admin-ui/core';
+import { useInjector } from './use-injector';
+
+/**
+ * @description
+ * Provides access to the ProseMirror editor instance.
+ *
+ * @example
+ * ```ts
+ * import { useProseMirror } from '\@vendure/admin-ui/react';
+ * import React from 'react';
+ *
+ * export function Component() {
+ *     const { ref, editor } = useProseMirror({
+ *        attributes: { class: '' },
+ *        onTextInput: (text) => console.log(text),
+ *        isReadOnly: () => false,
+ *     });
+ *
+ *     return <div className="w-full" ref={ref} />
+ * }
+ * ```
+ *
+ * @docsCategory react-hooks
+ */
+export interface UseProseMirrorOptions extends Omit<CreateEditorViewOptions, 'element'> {
+    /**
+     * @description
+     * Control the DOM attributes of the editable element. May be either an object or a function going from an editor state to an object.
+     * By default, the element will get a class "ProseMirror", and will have its contentEditable attribute determined by the editable prop.
+     * Additional classes provided here will be added to the class. For other attributes, the value provided first (as in someProp) will be used.
+     * Copied from real property description.
+     */
+    attributes?: Record<string, string>;
+}
+
+export const useProseMirror = ({ attributes, onTextInput, isReadOnly }: UseProseMirrorOptions) => {
+    const injector = useInjector(Injector);
+    const ref = useRef<HTMLDivElement>(null);
+    const prosemirror = new ProsemirrorService(injector, useInjector(ContextMenuService));
+
+    useEffect(() => {
+        if (!ref.current) return;
+        prosemirror.createEditorView({
+            element: ref.current,
+            isReadOnly,
+            onTextInput,
+        });
+        const readOnly = isReadOnly();
+        prosemirror.editorView.setProps({
+            attributes,
+            editable: readOnly ? () => false : () => true,
+        });
+        return () => {
+            prosemirror.destroy();
+        };
+    }, [ref.current]);
+
+    return { ref, editor: prosemirror };
+};


### PR DESCRIPTION
# Description

Adding `useProseMirror` for React plugins.

# Screenshots

![image](https://github.com/vendure-ecommerce/vendure/assets/86482559/c38ec777-21ec-46a8-8651-6791bbc9acb8)

# Checklist

📌 Always:
- [X] I have set a clear title
- [X] My PR is small and contains a single feature
- [X] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [ ] I have added or updated test cases
- [ ] I have updated the README if needed

PS. I am not pretty sure how to add it into `docs` (not sure about section where it should live) but if someone will pass me some instructions I can add it too :). But we should inform about `missing` css which need to be added into plugin to make prosemirror looking like everywhere.