### PR TITLE
fix(core): Handle nullable relations in EntityHydrator

### DIFF
--- a/packages/core/src/service/helpers/entity-hydrator/entity-hydrator.service.ts
+++ b/packages/core/src/service/helpers/entity-hydrator/entity-hydrator.service.ts
@@ -252,6 +252,8 @@ export class EntityHydrator {
                         visit(item, parts.slice());
                     }
                 }
+            } else if (target === null) {
+                result.push(target);
             } else {
                 if (parts.length === 0) {
                     result.push(target);


### PR DESCRIPTION
Fixes #2682

# Description
I already described the issue in #2682. The EntityHydrator crashes if a nested relation should be hydrated but the parent is nullable.

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [x] I have added or updated test cases
- [ ] I have updated the README if needed
