### PR TITLE
fix(admin-ui): Add missing translation of breadcrumb tooltips

### DIFF
--- a/packages/admin-ui/src/lib/core/src/components/breadcrumb/breadcrumb.component.html
+++ b/packages/admin-ui/src/lib/core/src/components/breadcrumb/breadcrumb.component.html
@@ -1,6 +1,9 @@
 <nav role="navigation">
     <ul class="breadcrumbs">
-        <li *ngFor="let breadcrumb of breadcrumbs$ | async; let isLast = last" [title]="breadcrumb.label">
+        <li
+            *ngFor="let breadcrumb of breadcrumbs$ | async; let isLast = last"
+            [title]="breadcrumb.label | translate"
+        >
             <a [routerLink]="breadcrumb.link" *ngIf="!isLast">{{ breadcrumb.label | translate }}</a>
             <ng-container *ngIf="!isLast"
                 ><clr-icon shape="caret right" class="color-weight-400 mx-1"></clr-icon


### PR DESCRIPTION
# Description

The hover-over tooltips didnt work. Now they do. See screenshots. :handshake: 

# Breaking changes

None

# Screenshots

| Before | After |
|--------|--------|
| ![image](https://github.com/vendure-ecommerce/vendure/assets/14810858/5483c2d1-1546-44e0-978e-b9cca0fa0ce9) | ![image](https://github.com/vendure-ecommerce/vendure/assets/14810858/a249b831-69d3-47a1-a990-2a8e4a0f1c41) | 

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [ ] I have added or updated test cases
- [ ] I have updated the README if needed
