### PR TITLE
fix: typo in custom-fields documentation

### DIFF
--- a/docs/docs/guides/developer-guide/custom-fields/index.md
+++ b/docs/docs/guides/developer-guide/custom-fields/index.md
@@ -104,7 +104,7 @@ mutation {
 The custom fields will also extend the filter and sort options available to the `products` list query:
 
 ```graphql
-mutation {
+query {
     products(options: {
         // highlight-start
         filter: {


### PR DESCRIPTION
# Description

Fixes the typo in the docs for customfields

# Breaking changes

Does this PR include any breaking changes we should be aware of? No

# Screenshots

You can add screenshots here if applicable.

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

