### PR TITLE
fix: product soft delete check deletedAt option group before trying to delete

### DIFF
--- a/packages/core/src/service/services/product.service.ts
+++ b/packages/core/src/service/services/product.service.ts
@@ -287,14 +287,16 @@ export class ProductService {
             return variantResult;
         }
         for (const optionGroup of product.optionGroups) {
-            const groupResult = await this.productOptionGroupService.deleteGroupAndOptionsFromProduct(
-                ctx,
-                optionGroup.id,
-                productId,
-            );
-            if (groupResult.result === DeletionResult.NOT_DELETED) {
-                await this.connection.rollBackTransaction(ctx);
-                return groupResult;
+            if (!optionGroup.deletedAt) {
+                const groupResult = await this.productOptionGroupService.deleteGroupAndOptionsFromProduct(
+                    ctx,
+                    optionGroup.id,
+                    productId,
+                );
+                if (groupResult.result === DeletionResult.NOT_DELETED) {
+                    await this.connection.rollBackTransaction(ctx);
+                    return groupResult;
+                }
             }
         }
         return {


### PR DESCRIPTION
# Description

Ran into an issue where an _OptionGroup_ which was already deleted was attempted to be deleted again.
`getEntityOrThrow` inside the `deleteGroupAndOptionsFromProduct` failed the `softDelete` call on _ProductService_.
