### PR TITLE
fix(core): Add channels to asset entities on admin api

### DIFF
--- a/packages/core/src/api/schema/admin-api/asset-admin.type.graphql
+++ b/packages/core/src/api/schema/admin-api/asset-admin.type.graphql
@@ -1,0 +1,3 @@
+type Asset implements Node {
+    channels: [Channel!]!
+}


### PR DESCRIPTION
# Description

I found that the channel-aware asset entities obviously have a `channels` field but its actually not exposed in the admin api. It got added in https://github.com/vendure-ecommerce/vendure/pull/700 but cant be queried.

Please note: I purposefully have not included re-generated types to make this PR as concise and review-able as possible.

For finishing this PR it should probably include this newly exposed field in the e2e-tests! Note that you'll need to look into the following when running:

```gql
mutation assign {
  assignAssetsToChannel(input: { assetIds: ["50"], channelId: "2" }) {
    name
    channels {
      id
      code
    }
  }
}
```

You'll see a 

```json
{
  "errors": [
    {
      "message": "Cannot return null for non-nullable field Asset.channels.",
      "locations": [
        {
          "line": 37,
          "column": 5
        }
      ],
      "path": [
        "assignAssetsToChannel",
        0,
        "channels"
      ]
    }
  ],
  "data": null
}
```

eventhough the mutation will go through and work!

```json
{
  "data": {
    "asset": {
      "name": "kari-shea-398668-unsplash.jpg",
      "channels": [
        {
          "id": "1",
          "token": "pxmu1fra2nrky6xivt",
          "code": "__default_channel__"
        },
        {
          "id": "2",
          "token": "example",
          "code": "Example"
        }
      ]
    }
  }
}
```

Please someone feel free to take over this PR, I just wanted to create this as the starting point for fixing https://github.com/vendure-ecommerce/vendure/issues/2478 but theres more to do there for example maybe a `removeAssetsFromChannel` mutation and ui which I dont want to do because of Angular & RxJs :smile: 

# Breaking changes

Should be none AFAIK

# Screenshots

You can add screenshots here if applicable.

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [ ] I have added or updated test cases
- [ ] I have updated the README if needed
