### PR TITLE
Update channel-detail.component.html defaultShippingZoneId is Required

### DIFF
--- a/packages/admin-ui/src/lib/settings/src/components/channel-detail/channel-detail.component.html
+++ b/packages/admin-ui/src/lib/settings/src/components/channel-detail/channel-detail.component.html
@@ -162,7 +162,7 @@
                         </vdr-form-field>
                         <clr-alert
                             *ngIf="detailForm.value.code && !detailForm.value.defaultShippingZoneId"
-                            clrAlertType="warning"
+                            clrAlertType="danger"
                             [clrAlertClosable]="false"
                         >
                             <clr-alert-item>


### PR DESCRIPTION
# Description
Default Shipping Zone Id is required field. Alert dialog should be danger instead of warning. 
Also translations need to be changed. Instead of "this may cause errors" it should be  "which will cause errors' like the tax alert

# Breaking changes

NO

# Screenshots

<img width="1064" alt="Screenshot 2024-03-06 at 12 33 08 AM" src="https://github.com/vendure-ecommerce/vendure/assets/48218623/a23e6b29-d17f-4adf-b4c2-87e16bf47772">


# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [x] I have added or updated test cases
- [x] I have updated the README if needed
