### PR TITLE
fix(core): Fix custom field relation for ProductVariant when value is null

### DIFF
--- a/packages/core/e2e/custom-field-relations.e2e-spec.ts
+++ b/packages/core/e2e/custom-field-relations.e2e-spec.ts
@@ -343,6 +343,43 @@ describe('Custom field relations', () => {
         });
     });
 
+    it('ProductVariant without a specified property value returns null', async () => {
+        const { createProduct } = await adminClient.query(gql`
+            mutation {
+                createProduct(
+                    input: {
+                        translations: [
+                            {
+                                languageCode: en
+                                name: "Product with empty custom fields"
+                                description: ""
+                                slug: "product-with-empty-custom-fields"
+                            }
+                        ]
+                    }
+                ) {
+                    id
+                }
+            }
+        `);
+
+        const { product } = await adminClient.query(gql`
+            query {
+                product(id: "${createProduct.id}") {
+                    id
+                    customFields {
+                        cfProductVariant{
+                            price
+                            currencyCode
+                            priceWithTax
+                        }
+                    }
+                }
+            }`);
+
+        expect(product.customFields.cfProductVariant).toEqual(null);
+    });
+
     describe('entity-specific implementation', () => {
         function assertCustomFieldIds(customFields: any, single: string, multi: string[]) {
             expect(customFields.single).toEqual({ id: single });

--- a/packages/core/src/api/common/custom-field-relation-resolver.service.ts
+++ b/packages/core/src/api/common/custom-field-relation-resolver.service.ts
@@ -63,6 +63,8 @@ export class CustomFieldRelationResolverService {
         result: VendureEntity | VendureEntity[] | null,
         fieldDef: RelationCustomFieldConfig,
     ) {
+        if (result == null) return null;
+
         if (fieldDef.entity === ProductVariant) {
             if (Array.isArray(result)) {
                 await Promise.all(result.map(r => this.applyVariantPrices(ctx, r as any)));


### PR DESCRIPTION
# Description

Fixes https://github.com/vendure-ecommerce/vendure/issues/2723
The reason was that we are calling `applyVariantPrices` even when the entity is null. And it happens only for `ProductVariant`.

# Breaking changes

No

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [x] I have added or updated test cases
- [x] I have updated the README if needed
