### PR TITLE
perf(core): upgrade sql requests for more performant memory usage with big datasets

### DIFF
--- a/packages/core/src/service/services/product-option-group.service.ts
+++ b/packages/core/src/service/services/product-option-group.service.ts
@@ -133,6 +133,8 @@ export class ProductOptionGroupService {
      */
     async deleteGroupAndOptionsFromProduct(ctx: RequestContext, id: ID, productId: ID) {
         const optionGroup = await this.connection.getEntityOrThrow(ctx, ProductOptionGroup, id, {
+            relationLoadStrategy: 'query',
+            loadEagerRelations: false,
             relations: ['options', 'product'],
         });
         const deletedOptionGroup = new ProductOptionGroup(optionGroup);
@@ -165,6 +167,8 @@ export class ProductOptionGroupService {
             // hard delete
 
             const product = await this.connection.getRepository(ctx, Product).findOne({
+                relationLoadStrategy: 'query',
+                loadEagerRelations: false,
                 where: { id: productId },
                 relations: ['optionGroups'],
             });

--- a/packages/core/src/service/services/product.service.ts
+++ b/packages/core/src/service/services/product.service.ts
@@ -271,6 +271,8 @@ export class ProductService {
 
     async softDelete(ctx: RequestContext, productId: ID): Promise<DeletionResponse> {
         const product = await this.connection.getEntityOrThrow(ctx, Product, productId, {
+            relationLoadStrategy: 'query',
+            loadEagerRelations: false,
             channelId: ctx.channelId,
             relations: ['variants', 'optionGroups'],
         });
@@ -449,6 +451,8 @@ export class ProductService {
 
     private async getProductWithOptionGroups(ctx: RequestContext, productId: ID): Promise<Product> {
         const product = await this.connection.getRepository(ctx, Product).findOne({
+            relationLoadStrategy: 'query',
+            loadEagerRelations: false,
             where: { id: productId, deletedAt: IsNull() },
             relations: ['optionGroups', 'variants', 'variants.options'],
         });


### PR DESCRIPTION
# Description

This upgrade is needed if you want to remove a product with more than 200 variants and 7 languages. If you leave this data in one SQL query, the memory consumption on the server for data processing reaches 10k MB in the test environment more than 800mb. The presented improvement reduces memory consumption to 1-5mb

# Breaking changes

Does this PR include any breaking changes we should be aware of?

# Screenshots
### Before
![image](https://github.com/vendure-ecommerce/vendure/assets/13255191/cdde6ed4-68a7-44c4-b6a6-084619036a42)
### After
<img width="1203" alt="Screenshot 2024-03-14 at 16 43 42" src="https://github.com/vendure-ecommerce/vendure/assets/13255191/9e3c937d-0b38-42c6-979e-2a9aa20dea7a">

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [x] I have added or updated test cases
- [x] I have updated the README if needed
