### PR TITLE
fix(core): Remove empty customFields relations from getMissingRelations in entity-hydrator

### DIFF
--- a/packages/core/src/service/helpers/entity-hydrator/entity-hydrator.service.ts
+++ b/packages/core/src/service/helpers/entity-hydrator/entity-hydrator.service.ts
@@ -221,7 +221,7 @@ export class EntityHydrator {
                 }
             }
         }
-        return unique(missingRelations);
+        return unique(missingRelations.filter(relation => !relation.endsWith('.customFields')));
     }
 
     private getRequiredProductVariantRelations<Entity extends VendureEntity>(


### PR DESCRIPTION
# Description

This fix removes all found links that end with `lines.customFields` because now such links cannot be used. If they are present in relations they may not be added to customFields in the queryBuilder because of them.

# Breaking changes

no

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [x] I have added or updated test cases
- [x] I have updated the README if needed
