### PR TITLE
Fix missing shipping lines in partial order after payment

### DIFF
--- a/packages/core/src/service/helpers/order-splitter/order-splitter.ts
+++ b/packages/core/src/service/helpers/order-splitter/order-splitter.ts
@@ -39,7 +39,13 @@ export class OrderSplitter {
             }
             const shippingLines: ShippingLine[] = [];
             for (const shippingLine of partialOrder.shippingLines) {
-                shippingLines.push(await this.duplicateShippingLine(ctx, shippingLine));
+                const newShippingLine = await this.duplicateShippingLine(ctx, shippingLine);
+                lines.map((line) => {
+                    if(shippingLine.id === line.shippingLineId) {
+                        line.shippingLineId = newShippingLine.id;
+                    }
+                })
+                shippingLines.push(newShippingLine);
             }
             const sellerOrder = await this.connection.getRepository(ctx, Order).save(
                 new Order({


### PR DESCRIPTION
# Description
We encountered an issue regarding the absence of shipping methods in the order generated after payment completion. This problem occurred due to the duplication of shipping method items without assigning new IDs to the orderLines that had the shippingLineId attribute.
