### PR TITLE
fix(core): Remove original entityTable from channels sql request

### DIFF
--- a/packages/core/src/service/services/channel.service.ts
+++ b/packages/core/src/service/services/channel.service.ts
@@ -162,7 +162,7 @@ export class ChannelService {
 
         return await this.connection
             .getRepository(ctx, entityType)
-            .createQueryBuilder()
+            .manager.createQueryBuilder()
             .select(`channel.${inverseJunctionColumnName}`, 'channelId')
             .from(junctionTableName, 'channel')
             .where(`channel.${junctionColumnName} = :entityId`, { entityId })


### PR DESCRIPTION
# Description

This fisk is necessary because typeorm does not remove the original table from the `from` query when creating the qb. In order to do this it was necessary to use manager.

Now a SQL request looking like this 
```sql
‌SELECT "channel"."channelId" AS "channelId" FROM "public"."product_channels_channel" "channel" WHERE "channel"."productId" = $1
```
Prev:
```sql
SELECT "channel"."channelId" AS "channelId" FROM "public"."asset" "Asset", "public"."asset_channels_channel" "channel" WHERE "channel"."assetId" = $1
```

# Breaking changes

Does this PR include any breaking changes we should be aware of?
 * no

# Screenshots
![telegram-cloud-photo-size-2-5258359367533714224-y](https://github.com/vendure-ecommerce/vendure/assets/13255191/491c6a7f-5e86-48fa-8d1e-02cdaac45a46)

# Checklist

📌 Always:
- [ ] I have set a clear title
- [ ] My PR is small and contains a single feature
- [ ] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [ ] I have added or updated test cases
- [ ] I have updated the README if needed
