### PR TITLE
fix(core): Add surcharge taxLines to taxSummary

### DIFF
--- a/packages/core/src/testing/order-test-utils.ts
+++ b/packages/core/src/testing/order-test-utils.ts
@@ -3,6 +3,7 @@ import { Omit } from '@vendure/common/lib/omit';
 import { ID } from '@vendure/common/lib/shared-types';
 
 import { RequestContext } from '../api/common/request-context';
+import { Surcharge } from '../entity';
 import { Channel } from '../entity/channel/channel.entity';
 import { Order } from '../entity/order/order.entity';
 import { OrderLine } from '../entity/order-line/order-line.entity';
@@ -130,13 +131,14 @@ export class MockTaxRateService {
 }
 
 export function createOrder(
-    orderConfig: Partial<Omit<Order, 'lines'>> & {
+    orderConfig: Partial<Omit<Order, 'lines', 'surcharges'>> & {
         ctx: RequestContext;
         lines: Array<{
             listPrice: number;
             taxCategory: TaxCategory;
             quantity: number;
         }>;
+        surcharges?: Surcharge[];
     },
 ): Order {
     const lines = orderConfig.lines.map(
@@ -156,7 +158,7 @@ export function createOrder(
         couponCodes: [],
         lines,
         shippingLines: [],
-        surcharges: [],
+        surcharges: orderConfig.surcharges || [],
         modifications: [],
     });
 }


### PR DESCRIPTION
# Description

This change adds the `taxLines` of the orders surcharges to the `taxSummary`. Fixes #2797.

# Breaking changes

Since this fix changes the output of the `taxSummary` resolver it could be a breaking change for users which use the `taxSummary` in there storefront.

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [x] I have added or updated test cases
- [x] I have updated the README if needed
