### PR TITLE
fix asset importer assigns asset on default channel when importing on non default channel

### DIFF
--- a/packages/core/src/data-import/providers/populator/populator.ts
+++ b/packages/core/src/data-import/providers/populator/populator.ts
@@ -125,7 +125,7 @@ export class Populator {
         for (const collectionDef of data.collections) {
             const parent = collectionDef.parentName && collectionMap.get(collectionDef.parentName);
             const parentId = parent ? parent.id.toString() : undefined;
-            const { assets } = await this.assetImporter.getAssets(collectionDef.assetPaths || []);
+            const { assets } = await this.assetImporter.getAssets(collectionDef.assetPaths || [], ctx);
             let filters: ConfigurableOperationInput[] = [];
             try {
                 filters = (collectionDef.filters || []).map(filter =>


### PR DESCRIPTION
# Description

Adds RequestContext to asset import for collections. 

The populator loads assets into collections. However, the RequestContext is not passed along. This means that if you import collections on any channel that is not default, the assets get assigned to the default channel only.

As a result a channel specific collection import fails because an empty asset array results that is assumed to be non empty, and referenced.

Resolves issue https://github.com/vendure-ecommerce/vendure/issues/2787

I adjusted test on the populate spec and was surprised that even on the 'populating a non-default channel' the test passed without my changes. On further inspection it seems that that test uses the default channel for its work instead of the intended channel-2. So, it seems to be not validating what it's supposed to validate. That might be because I'm running a filtered test or because the test has a somewhat unique setup that destroys the server after the additional test channel is created. Initially I thought it might a cache refresh issue but later I realized that channel-2 wasn't in the database during the test. So, writing the test became a bit of a rabbit hole and I bailed after a while. Perhaps someone can enlighten me on the test setup and how it's supposed to work.

BTW: after running npm install, testing doesn't work out of the box. had to remove package-lock.json to be able to run tests at all bc of darwin related errors on optional dependencies

# Breaking changes

None

# Screenshots

You can add screenshots here if applicable.

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x ] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [ ] I have added or updated test cases
- [ ] I have updated the README if needed
