### PR TITLE
fix(getAssignedEntityChannels): fix performance problems in v2.2

### DIFF
--- a/packages/core/src/service/services/channel.service.ts
+++ b/packages/core/src/service/services/channel.service.ts
@@ -166,6 +166,7 @@ export class ChannelService {
             .select(`channel.${inverseJunctionColumnName}`, 'channelId')
             .from(junctionTableName, 'channel')
             .where(`channel.${junctionColumnName} = :entityId`, { entityId })
+            .andWhere(`${entityType.name}.id = :entityId`, { entityId })
             .execute();
     }
 


### PR DESCRIPTION
# Description

We have performance problems with the join queries for the `Channels` table.

Example with the join between `customer` and `channels`.
The [getAssignedEntityChannels](https://github.com/vendure-ecommerce/vendure/blob/master/packages/core/src/service/services/channel.service.ts#L138) function will generate this sql query:

```
SELECT "channel"."channelId" AS "channelId" FROM "customer" "Customer", "customer_channels_channel" "channel" WHERE "channel"."customerId" = $1
```

|  Env     |   Rows in the customer table    |    execution time   | 
|---    |:-:    |--:    |
|   test    |   1 500    |    625ms   |     
|   prod    |   1 700 000    |   >40s    |     


Here is the new query to filter the entity table and not retrieve all the rows, which causes performance problems

```
SELECT "channel"."channelId" AS "channelId" FROM "customer" "Customer", "customer_channels_channel" "channel" 
WHERE "channel"."customerId" = $1
and "Customer"."id" = $1;
```

|  Env     |   Rows in the customer table    |    execution time   | 
|---    |:-:    |--:    |
|   test    |   1 500    |    34ms   |     
|   prod    |   1 700 000    |   33ms    |     

In pairs with @ttournie & @gdarchen 

# Breaking changes

No

# Screenshots


# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [ ] I have added or updated test cases
- [ ] I have updated the README if needed
