### PR TITLE
chore(repo): Add VSCode recommended extension for conventional commits with pre-defined scopes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,6 @@ docs/static/intro.js*
 docs/static/intro.css*
 docs/public
 docs/data/build.json
-.vscode/
 yarn-error.log
 e2e-common/ports.json
 

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+    "recommendations": [
+        "vivaxy.vscode-conventional-commits"
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,22 @@
+{
+    "conventionalCommits.scopes": [
+        "admin-ui",
+        "admin-ui-plugin",
+        "asset-server-plugin",
+        "cli",
+        "common",
+        "core",
+        "create",
+        "dev-server",
+        "elasticsearch-plugin",
+        "email-plugin",
+        "harden-plugin",
+        "job-queue-plugin",
+        "sentry-plugin",
+        "stellate-plugin",
+        "testing",
+        "ui-devkit",
+        "repo"
+    ],
+    "conventionalCommits.gitmoji": false
+}

--- a/packages/core/src/api/config/configure-graphql-module.ts
+++ b/packages/core/src/api/config/configure-graphql-module.ts
@@ -100,6 +100,7 @@ async function createGraphQLOptions(
         path: '/' + options.apiPath,
         typeDefs: printSchema(builtSchema),
         include: [options.resolverModule],
+        inheritResolversFromInterfaces: true,
         fieldResolverEnhancers: ['guards'],
         resolvers,
         // We no longer rely on the upload facility bundled with Apollo Server, and instead

--- a/packages/core/src/api/config/configure-graphql-module.ts
+++ b/packages/core/src/api/config/configure-graphql-module.ts
@@ -100,7 +100,6 @@ async function createGraphQLOptions(
         path: '/' + options.apiPath,
         typeDefs: printSchema(builtSchema),
         include: [options.resolverModule],
-        inheritResolversFromInterfaces: true,
         fieldResolverEnhancers: ['guards'],
         resolvers,
         // We no longer rely on the upload facility bundled with Apollo Server, and instead


### PR DESCRIPTION
# Description

Adds VSCode `settings.json` with an extension recommendation for conventional commits and pre-defined scopes, that are based on the package names.

# Breaking changes

none

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [ ] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [ ] I have added or updated test cases
- [ ] I have updated the README if needed
