### PR TITLE
Move `typescript` to dev dependencies

### DIFF
--- a/packages/create/src/helpers.ts
+++ b/packages/create/src/helpers.ts
@@ -261,11 +261,14 @@ export function getDependencies(
         `@vendure/email-plugin${vendurePkgVersion}`,
         `@vendure/asset-server-plugin${vendurePkgVersion}`,
         `@vendure/admin-ui-plugin${vendurePkgVersion}`,
-        'dotenv',
         dbDriverPackage(dbType),
+    ];
+    const devDependencies = [
+        `@vendure/cli${vendurePkgVersion}`,
+        'concurrently',
+        'dotenv',
         `typescript@${TYPESCRIPT_VERSION}`,
     ];
-    const devDependencies = ['concurrently', `@vendure/cli${vendurePkgVersion}`];
     return { dependencies, devDependencies };
 }
 

--- a/packages/create/src/helpers.ts
+++ b/packages/create/src/helpers.ts
@@ -261,12 +261,12 @@ export function getDependencies(
         `@vendure/email-plugin${vendurePkgVersion}`,
         `@vendure/asset-server-plugin${vendurePkgVersion}`,
         `@vendure/admin-ui-plugin${vendurePkgVersion}`,
+        'dotenv',
         dbDriverPackage(dbType),
     ];
     const devDependencies = [
         `@vendure/cli${vendurePkgVersion}`,
         'concurrently',
-        'dotenv',
         `typescript@${TYPESCRIPT_VERSION}`,
     ];
     return { dependencies, devDependencies };


### PR DESCRIPTION
# Description

During the bootstrapping process of `@vendure/create`, the `typescript` package is installed as a regular dependency, I moved it to the dev dependencies. 

~~Regarding `dotenv`, it appears it's only used in the CLI, dev server, and in E2E tests for the payments plugin, please let me know if I missed something and it should be kept as a prod dep.~~

# Breaking changes

No

# Screenshots

N/A

# Checklist

- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")
