### PR TITLE
fix: Make featuredAsset optional on collection duplicator

### DIFF
--- a/packages/core/src/config/entity/entity-duplicators/collection-duplicator.ts
+++ b/packages/core/src/config/entity/entity-duplicators/collection-duplicator.ts
@@ -51,7 +51,7 @@ export const collectionDuplicator = new EntityDuplicator({
             };
         });
         const collectionInput: CreateCollectionInput = {
-            featuredAssetId: collection.featuredAsset.id,
+            featuredAssetId: collection.featuredAsset?.id,
             isPrivate: true,
             assetIds: collection.assets.map(value => value.assetId),
             parentId: collection.parentId,


### PR DESCRIPTION
# Description

Makes featuredAsset om copied collection

Fixes https://github.com/vendure-ecommerce/vendure/issues/2823

# Breaking changes

No

# Screenshots



# Checklist

📌 Always:
- [ x] I have set a clear title
- [x ] My PR is small and contains a single feature
- [ x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [ ] I have added or updated test cases
- [ ] I have updated the README if needed
