### PR TITLE
Fix filepath typo.

### DIFF
--- a/docs/docs/guides/developer-guide/plugins/index.mdx
+++ b/docs/docs/guides/developer-guide/plugins/index.mdx
@@ -189,7 +189,7 @@ We'll start by creating a new directory to house our plugin, add create the main
             ├── wishlist.plugin.ts
 ```
 
-```ts title="src/plugins/reviews-plugin/wishlist.plugin.ts"
+```ts title="src/plugins/wishlist-plugin/wishlist.plugin.ts"
 import { PluginCommonModule, VendurePlugin } from '@vendure/core';
 
 @VendurePlugin({


### PR DESCRIPTION
# Description

A typo in the plugins developer guide. The filepath *src/plugins/reviews-plugin/wishlist.plugin.ts* should say *src/plugins/wishlist-plugin/wishlist.plugin.ts*

# Breaking changes

This PR does not include any breaking changes.

# Screenshots

![firstcontribution](https://github.com/vendure-ecommerce/vendure/assets/75552260/7d81afbd-8915-4339-a126-39b7e094921f)


# Checklist

📌 Always:
- [ ] I have set a clear title
- [ ] My PR is small and contains a single feature
- [ ] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [ ] I have added or updated test cases
- [ ] I have updated the README if needed
