### PR TITLE
fix(cookie): Use the shop cookie name for default route

### DIFF
--- a/packages/core/src/bootstrap.ts
+++ b/packages/core/src/bootstrap.ts
@@ -250,7 +250,7 @@ function checkPluginCompatibility(config: RuntimeVendureConfig): void {
             if (!satisfies(VENDURE_VERSION, compatibility, { loose: true, includePrerelease: true })) {
                 Logger.error(
                     `Plugin "${pluginName}" is not compatible with this version of Vendure. ` +
-                        `It specifies a semver range of "${compatibility}" but the current version is "${VENDURE_VERSION}".`,
+                    `It specifies a semver range of "${compatibility}" but the current version is "${VENDURE_VERSION}".`,
                 );
                 throw new InternalServerError(
                     `Plugin "${pluginName}" is not compatible with this version of Vendure.`,
@@ -410,19 +410,21 @@ export function configureSessionCookies(
     userConfig: Readonly<RuntimeVendureConfig>,
 ): void {
     const { cookieOptions } = userConfig.authOptions;
-    app.use(
-        cookieSession({
-            ...cookieOptions,
-            name: typeof cookieOptions?.name === 'string' ? cookieOptions.name : DEFAULT_COOKIE_NAME,
-        }),
-    );
 
     // If the Admin API and Shop API should have specific cookies names
     if (typeof cookieOptions?.name === 'object') {
         const shopApiCookieName = cookieOptions.name.shop;
         const adminApiCookieName = cookieOptions.name.admin;
         const { shopApiPath, adminApiPath } = userConfig.apiOptions;
+        app.use(cookieSession({...cookieOptions, name: shopApiCookieName}));
         app.use(`/${shopApiPath}`, cookieSession({ ...cookieOptions, name: shopApiCookieName }));
         app.use(`/${adminApiPath}`, cookieSession({ ...cookieOptions, name: adminApiCookieName }));
+    } else {
+        app.use(
+            cookieSession({
+                ...cookieOptions,
+                name: cookieOptions?.name ?? DEFAULT_COOKIE_NAME,
+            }),
+        );
     }
 }


### PR DESCRIPTION
# Description

In addition to this PR
https://github.com/vendure-ecommerce/vendure/pull/2482


Here is the cookie naming behavior:

- If not setting the authOptions.cookieOptions.name parameter:
  -  Both the Admin API and Shop API cookies names will be the default one: 'session'
- If setting the authOptions.cookieOptions.name parameter to something like 'cookie-name':
  - Both the Admin API and Shop API cookies names will be the configured one: 'cookie-name'
- If setting the authOptions.cookieOptions.name parameter to something like `{shop: 'cookie-name', admin: 'admin-cookie-name'}`:
  - The Admin API cookie name will be 'admin-cookie-name'
  -  Shop API cookie name will be 'cookie-name'
  - And all the REST endpoints on the `/` route will use the default cookie: 'session' 
    -  context: some systems do not support Graphql and so we have a few REST endpoints. This PR allows to use the same shop cookie name for graphql and REST routes
    

# Breaking changes

I think it's an unintended behaviour that can be released in the next patch

# Screenshots


# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [ ] I have added or updated test cases
- [ ] I have updated the README if needed
