### PR TITLE
feat(payments-plugin): Allow mollie orders with $0

### DIFF
--- a/packages/payments-plugin/e2e/graphql/admin-queries.ts
+++ b/packages/payments-plugin/e2e/graphql/admin-queries.ts
@@ -114,3 +114,14 @@ export const CREATE_CHANNEL = gql`
         }
     }
 `;
+
+export const CREATE_COUPON = gql`
+    mutation CreatePromotion($input: CreatePromotionInput!) {
+        createPromotion(input: $input) {
+            ... on ErrorResult {
+                errorCode
+            }
+            __typename
+        }
+    }
+`;

--- a/packages/payments-plugin/e2e/graphql/shop-queries.ts
+++ b/packages/payments-plugin/e2e/graphql/shop-queries.ts
@@ -50,6 +50,17 @@ export const TEST_ORDER_FRAGMENT = gql`
                 type
             }
         }
+        shippingAddress {
+            fullName
+            company
+            streetLine1
+            streetLine2
+            city
+            province
+            postalCode
+            country
+            phoneNumber
+        }
         shippingLines {
             shippingMethod {
                 id
@@ -104,17 +115,7 @@ export const SET_SHIPPING_ADDRESS = gql`
     mutation SetShippingAddress($input: CreateAddressInput!) {
         setOrderShippingAddress(input: $input) {
             ... on Order {
-                shippingAddress {
-                    fullName
-                    company
-                    streetLine1
-                    streetLine2
-                    city
-                    province
-                    postalCode
-                    country
-                    phoneNumber
-                }
+                ...TestOrderFragment
             }
             ... on ErrorResult {
                 errorCode
@@ -122,6 +123,7 @@ export const SET_SHIPPING_ADDRESS = gql`
             }
         }
     }
+    ${TEST_ORDER_FRAGMENT}
 `;
 
 export const GET_ELIGIBLE_SHIPPING_METHODS = gql`
@@ -217,6 +219,19 @@ export const GET_ACTIVE_ORDER = gql`
     query GetActiveOrder {
         activeOrder {
             ...TestOrderFragment
+        }
+    }
+    ${TEST_ORDER_FRAGMENT}
+`;
+
+export const APPLY_COUPON_CODE = gql`
+    mutation ApplyCouponCode($couponCode: String!) {
+        applyCouponCode(couponCode: $couponCode) {
+            ...TestOrderFragment
+            ... on ErrorResult {
+                errorCode
+                message
+            }
         }
     }
     ${TEST_ORDER_FRAGMENT}

--- a/packages/payments-plugin/e2e/payment-helpers.ts
+++ b/packages/payments-plugin/e2e/payment-helpers.ts
@@ -1,10 +1,21 @@
 import { ID } from '@vendure/common/lib/shared-types';
-import { ChannelService, OrderService, PaymentService, RequestContext } from '@vendure/core';
+import {
+    ChannelService,
+    ErrorResult,
+    OrderService,
+    PaymentService,
+    RequestContext,
+    assertFound,
+} from '@vendure/core';
 import { SimpleGraphQLClient, TestServer } from '@vendure/testing';
 import gql from 'graphql-tag';
 
-import { REFUND_ORDER } from './graphql/admin-queries';
-import { RefundFragment, RefundOrderMutation, RefundOrderMutationVariables } from './graphql/generated-admin-types';
+import { CREATE_COUPON, REFUND_ORDER } from './graphql/admin-queries';
+import {
+    RefundFragment,
+    RefundOrderMutation,
+    RefundOrderMutationVariables,
+} from './graphql/generated-admin-types';
 import {
     GetShippingMethodsQuery,
     SetShippingMethodMutation,
@@ -21,7 +32,7 @@ import {
 } from './graphql/shop-queries';
 
 export async function setShipping(shopClient: SimpleGraphQLClient): Promise<void> {
-    await shopClient.query(SET_SHIPPING_ADDRESS, {
+    const { setOrderShippingAddress: order } = await shopClient.query(SET_SHIPPING_ADDRESS, {
         input: {
             fullName: 'name',
             streetLine1: '12 the street',
@@ -33,9 +44,17 @@ export async function setShipping(shopClient: SimpleGraphQLClient): Promise<void
     const { eligibleShippingMethods } = await shopClient.query<GetShippingMethodsQuery>(
         GET_ELIGIBLE_SHIPPING_METHODS,
     );
-    await shopClient.query<SetShippingMethodMutation, SetShippingMethodMutationVariables>(SET_SHIPPING_METHOD, {
-        id: eligibleShippingMethods[1].id,
-    });
+    if (!eligibleShippingMethods?.length) {
+        throw Error(
+            `No eligible shipping methods found for order '${String(order.code)}' with a total of '${String(order.totalWithTax)}'`,
+        );
+    }
+    await shopClient.query<SetShippingMethodMutation, SetShippingMethodMutationVariables>(
+        SET_SHIPPING_METHOD,
+        {
+            id: eligibleShippingMethods[1].id,
+        },
+    );
 }
 
 export async function proceedToArrangingPayment(shopClient: SimpleGraphQLClient): Promise<ID> {
@@ -78,16 +97,96 @@ export async function addManualPayment(server: TestServer, orderId: ID, amount: 
         authorizedAsOwnerOnly: false,
         channel: await server.app.get(ChannelService).getDefaultChannel(),
     });
-    const order = await server.app.get(OrderService).findOne(ctx, orderId);
+    const order = await assertFound(server.app.get(OrderService).findOne(ctx, orderId));
     // tslint:disable-next-line:no-non-null-assertion
-    await server.app.get(PaymentService).createManualPayment(ctx, order!, amount, {
+    await server.app.get(PaymentService).createManualPayment(ctx, order, amount, {
         method: 'Gift card',
-        // tslint:disable-next-line:no-non-null-assertion
-        orderId: order!.id,
+        orderId: order.id,
         metadata: {
             bogus: 'test',
         },
     });
+}
+
+/**
+ * Create a coupon with the given code and discount amount.
+ */
+export async function createFixedDiscountCoupon(
+    adminClient: SimpleGraphQLClient,
+    amount: number,
+    couponCode: string,
+): Promise<void> {
+    const { createPromotion } = await adminClient.query(CREATE_COUPON, {
+        input: {
+            conditions: [],
+            actions: [
+                {
+                    code: 'order_fixed_discount',
+                    arguments: [
+                        {
+                            name: 'discount',
+                            value: String(amount),
+                        },
+                    ],
+                },
+            ],
+            couponCode,
+            startsAt: null,
+            endsAt: null,
+            perCustomerUsageLimit: null,
+            usageLimit: null,
+            enabled: true,
+            translations: [
+                {
+                    languageCode: 'en',
+                    name: `Coupon ${couponCode}`,
+                    description: '',
+                    customFields: {},
+                },
+            ],
+            customFields: {},
+        },
+    });
+    if (createPromotion.__typename === 'ErrorResult') {
+        throw new Error(`Error creating coupon: ${(createPromotion as ErrorResult).errorCode}`);
+    }
+}
+/**
+ * Create a coupon with the given code and discount amount.
+ */
+export async function createFreeShippingCoupon(
+    adminClient: SimpleGraphQLClient,
+    couponCode: string,
+): Promise<void> {
+    const { createPromotion } = await adminClient.query(CREATE_COUPON, {
+        input: {
+            conditions: [],
+            actions: [
+                {
+                    code: 'free_shipping',
+                    arguments: [],
+                },
+            ],
+            couponCode,
+            startsAt: null,
+            endsAt: null,
+            perCustomerUsageLimit: null,
+            usageLimit: null,
+            enabled: true,
+            translations: [
+                {
+                    languageCode: 'en',
+                    name: `Coupon ${couponCode}`,
+                    description: '',
+                    customFields: {},
+                },
+            ],
+            customFields: {},
+        },
+    });
+    if (createPromotion.__typename === 'ErrorResult') {
+        throw new Error(`Error creating coupon: ${(createPromotion as ErrorResult).errorCode}`);
+    }
 }
 
 export const CREATE_MOLLIE_PAYMENT_INTENT = gql`
@@ -105,9 +204,10 @@ export const CREATE_MOLLIE_PAYMENT_INTENT = gql`
 `;
 
 export const CREATE_STRIPE_PAYMENT_INTENT = gql`
-    mutation createStripePaymentIntent{
+    mutation createStripePaymentIntent {
         createStripePaymentIntent
-    }`;
+    }
+`;
 
 export const GET_MOLLIE_PAYMENT_METHODS = gql`
     query molliePaymentMethods($input: MolliePaymentMethodsInput!) {

--- a/packages/payments-plugin/src/mollie/mollie.handler.ts
+++ b/packages/payments-plugin/src/mollie/mollie.handler.ts
@@ -1,4 +1,9 @@
-import createMollieClient, { OrderEmbed, PaymentStatus, RefundStatus } from '@mollie/api-client';
+import createMollieClient, {
+    OrderEmbed,
+    PaymentStatus,
+    RefundStatus,
+    Order as MollieOrder,
+} from '@mollie/api-client';
 import { LanguageCode } from '@vendure/common/lib/generated-types';
 import {
     CreatePaymentErrorResult,
@@ -57,13 +62,13 @@ export const molliePaymentHandler = new PaymentMethodHandler({
     init(injector) {
         mollieService = injector.get(MollieService);
     },
-    createPayment: async (
+    createPayment: (
         ctx,
         order,
-        _amount, // Don't use this amount, but the amount from the metadata
+        _amount, // Don't use this amount, but the amount from the metadata, because that has the actual paid amount from Mollie
         args,
         metadata,
-    ): Promise<CreatePaymentResult | CreatePaymentErrorResult> => {
+    ): CreatePaymentResult | CreatePaymentErrorResult => {
         // Only Admins and internal calls should be allowed to settle and authorize payments
         if (ctx.apiType !== 'admin' && ctx.apiType !== 'custom') {
             throw Error(`CreatePayment is not allowed for apiType '${ctx.apiType}'`);


### PR DESCRIPTION
# Description

Transition orders to PaymentSettled when the total is $0. The payment intent returns the given thank-you/confirmation page instead of the link to Mollie, because we don't need to redirect the customer to the Mollie platform.

Closes #2821

# Checklist

📌 Always:
- [ ] I have set a clear title
- [ ] My PR is small and contains a single feature
- [ ] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [ ] I have added or updated test cases
- [ ] I have updated the README if needed
