### PR TITLE
fix(cookies): Apply split cookie session middleware per route

### DIFF
--- a/packages/core/src/app.module.ts
+++ b/packages/core/src/app.module.ts
@@ -1,4 +1,5 @@
 import { MiddlewareConsumer, Module, NestModule, OnApplicationShutdown } from '@nestjs/common';
+import cookieSession from 'cookie-session';
 
 import { ApiModule } from './api/api.module';
 import { Middleware, MiddlewareHandler } from './common';
@@ -26,18 +27,44 @@ import { ServiceModule } from './service/service.module';
     ],
 })
 export class AppModule implements NestModule, OnApplicationShutdown {
-    constructor(private configService: ConfigService, private i18nService: I18nService) {}
+    constructor(
+        private configService: ConfigService,
+        private i18nService: I18nService,
+    ) {}
 
     configure(consumer: MiddlewareConsumer) {
         const { adminApiPath, shopApiPath, middleware } = this.configService.apiOptions;
+        const { cookieOptions } = this.configService.authOptions;
+
         const i18nextHandler = this.i18nService.handle();
         const defaultMiddleware: Middleware[] = [
             { handler: i18nextHandler, route: adminApiPath },
             { handler: i18nextHandler, route: shopApiPath },
         ];
+
         const allMiddleware = defaultMiddleware.concat(middleware);
+
+        // If the Admin API and Shop API should have specific cookies names, we need to create separate cookie sessions
+        if (typeof cookieOptions?.name === 'object') {
+            const shopApiCookieName = cookieOptions.name.shop;
+            const adminApiCookieName = cookieOptions.name.admin;
+            allMiddleware.push({
+                handler: cookieSession({ ...cookieOptions, name: adminApiCookieName }),
+                route: adminApiPath,
+            });
+            allMiddleware.push({
+                handler: cookieSession({ ...cookieOptions, name: shopApiCookieName }),
+                route: shopApiPath,
+            });
+            allMiddleware.push({
+                handler: cookieSession({ ...cookieOptions, name: shopApiCookieName }),
+                route: '/',
+            });
+        }
+
         const consumableMiddlewares = allMiddleware.filter(mid => !mid.beforeListen);
         const middlewareByRoute = this.groupMiddlewareByRoute(consumableMiddlewares);
+
         for (const [route, handlers] of Object.entries(middlewareByRoute)) {
             consumer.apply(...handlers).forRoutes(route);
         }

--- a/packages/core/src/bootstrap.ts
+++ b/packages/core/src/bootstrap.ts
@@ -250,7 +250,7 @@ function checkPluginCompatibility(config: RuntimeVendureConfig): void {
             if (!satisfies(VENDURE_VERSION, compatibility, { loose: true, includePrerelease: true })) {
                 Logger.error(
                     `Plugin "${pluginName}" is not compatible with this version of Vendure. ` +
-                    `It specifies a semver range of "${compatibility}" but the current version is "${VENDURE_VERSION}".`,
+                        `It specifies a semver range of "${compatibility}" but the current version is "${VENDURE_VERSION}".`,
                 );
                 throw new InternalServerError(
                     `Plugin "${pluginName}" is not compatible with this version of Vendure.`,
@@ -411,15 +411,9 @@ export function configureSessionCookies(
 ): void {
     const { cookieOptions } = userConfig.authOptions;
 
-    // If the Admin API and Shop API should have specific cookies names
-    if (typeof cookieOptions?.name === 'object') {
-        const shopApiCookieName = cookieOptions.name.shop;
-        const adminApiCookieName = cookieOptions.name.admin;
-        const { shopApiPath, adminApiPath } = userConfig.apiOptions;
-        app.use(cookieSession({...cookieOptions, name: shopApiCookieName}));
-        app.use(`/${shopApiPath}`, cookieSession({ ...cookieOptions, name: shopApiCookieName }));
-        app.use(`/${adminApiPath}`, cookieSession({ ...cookieOptions, name: adminApiCookieName }));
-    } else {
+    // If the Admin API and Shop API should have the same cookie name
+    // Else, the specific cookie middlewares are handled in the 'AppModule#configure' method
+    if (typeof cookieOptions?.name === 'string') {
         app.use(
             cookieSession({
                 ...cookieOptions,


### PR DESCRIPTION
# Description

When using split cookies to have different cookie name for the `shop-api` and the `admin-api`, we used to apply the `cookieSession()` middleware globally.

However, [Nest Global Middlewares](https://docs.nestjs.com/middleware#global-middleware) can't be applied to specific routes.
By doing Global Middlewares, the last applied `app.use()` middleware was overriding the above-mentioned ones.

Instead, we have to use [Functional Middlewares](https://docs.nestjs.com/middleware#functional-middleware) for the specific paths we like.

As a consequence, for the case when the user wants to split the cookies, we do not do it in the `bootstrap()` function any longer but instead we do it in the `AppModule.configure()` method, where other middlewares route-specific are already applied.

# Breaking changes

There is no breaking change as we just fix a behaviour that was not working.

# Screenshots

N/A

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [ ] I have added or updated test cases
- [ ] I have updated the README if needed
