### PR TITLE
fix(cookies): Correctly apply global and per-route middlewares

### DIFF
--- a/packages/core/src/app.module.ts
+++ b/packages/core/src/app.module.ts
@@ -56,10 +56,6 @@ export class AppModule implements NestModule, OnApplicationShutdown {
                 handler: cookieSession({ ...cookieOptions, name: shopApiCookieName }),
                 route: shopApiPath,
             });
-            allMiddleware.push({
-                handler: cookieSession({ ...cookieOptions, name: shopApiCookieName }),
-                route: '/',
-            });
         }
 
         const consumableMiddlewares = allMiddleware.filter(mid => !mid.beforeListen);

--- a/packages/core/src/bootstrap.ts
+++ b/packages/core/src/bootstrap.ts
@@ -412,14 +412,13 @@ export function configureSessionCookies(
 ): void {
     const { cookieOptions } = userConfig.authOptions;
 
-    // If the Admin API and Shop API should have the same cookie name
-    // Else, the specific cookie middlewares are handled in the 'AppModule#configure' method
-    if (typeof cookieOptions?.name === 'string' || cookieOptions?.name === undefined) {
-        app.use(
-            cookieSession({
-                ...cookieOptions,
-                name: cookieOptions?.name ?? DEFAULT_COOKIE_NAME,
-            }),
-        );
-    }
+    // Globally set the cookie session middleware
+    const cookieName =
+        typeof cookieOptions?.name !== 'string' ? cookieOptions.name?.shop : cookieOptions.name;
+    app.use(
+        cookieSession({
+            ...cookieOptions,
+            name: cookieName ?? DEFAULT_COOKIE_NAME,
+        }),
+    );
 }


### PR DESCRIPTION
# Description

In a previous PR, I tried to fix an issue causing some per-route middlewares being broken when using the split cookies for the Admin and Shop APIs.
- #2880 

But since it was released in the `2.2.6`, the cookies split is no longer working at all.

After investigating, it turned out we were still badly applying the per-route middleware:
- We did not set a global middleware in the `bootstrap.ts` file
- We were overriding the per-route middlewares in the `app.modile.ts` file because of the configuration on the `/` route

In this PR, I made sure to:
1. Apply a global cookies middleware, either using the right cookie name:
   - If the cookies have to be split, use the `shop` cookie name
   - Else, use the shared cookie name if provided
   - If not provided, default to `session`
2. Only apply specific `cookieSession` middlewares on the `/shop-api` and `/admin-api` routes

# Breaking changes

No breaking change.

# Screenshots

https://github.com/vendure-ecommerce/vendure/assets/17927632/19fcbb66-513e-4072-bfe7-0b7d85eaa869

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [ ] I have added or updated test cases
- [ ] I have updated the README if needed
