### PR TITLE
feat(admin-ui): Add location id and description to custom routes

### DIFF
--- a/docs/docs/guides/extending-the-admin-ui/defining-routes/index.md
+++ b/docs/docs/guides/extending-the-admin-ui/defining-routes/index.md
@@ -482,6 +482,7 @@ export default [
     registerRouteComponent({
         component: TestComponent,
         title: 'Test',
+        locationId: 'my-location-id'
         // highlight-next-line
         breadcrumb: 'Test',
     }),

--- a/docs/docs/guides/extending-the-admin-ui/page-tabs/index.md
+++ b/docs/docs/guides/extending-the-admin-ui/page-tabs/index.md
@@ -23,6 +23,22 @@ export default [
 
 ![./ui-extensions-tabs.webp](./ui-extensions-tabs.webp)
 
+If you want to add page tabs to a custom admin page, specify the `locationId` property:
+
+```ts title="src/plugins/my-plugin/ui/routes.ts"
+import { registerRouteComponent } from '@vendure/admin-ui/core';
+import { TestComponent } from './components/test/test.component';
+
+export default [
+    registerRouteComponent({
+        component: TestComponent,
+        title: 'Test',
+        // highlight-next-line
+        locationId: 'my-location-id'
+    }),
+];
+```
+
 :::note
 Currently it is only possible to define new tabs using Angular components.
 :::

--- a/docs/docs/reference/admin-ui-api/routes/register-route-component.md
+++ b/docs/docs/reference/admin-ui-api/routes/register-route-component.md
@@ -11,7 +11,7 @@ import MemberDescription from '@site/src/components/MemberDescription';
 
 ## registerRouteComponent
 
-<GenerationInfo sourceFile="packages/admin-ui/src/lib/core/src/extension/register-route-component.ts" sourceLine="77" packageName="@vendure/admin-ui" />
+<GenerationInfo sourceFile="packages/admin-ui/src/lib/core/src/extension/register-route-component.ts" sourceLine="79" packageName="@vendure/admin-ui" />
 
 Registers an Angular standalone component to be rendered in a route.
 

--- a/packages/admin-ui/src/lib/core/src/extension/register-route-component.ts
+++ b/packages/admin-ui/src/lib/core/src/extension/register-route-component.ts
@@ -25,6 +25,8 @@ export type RegisterRouteComponentOptions<
 > = {
     component: Type<Component> | Component;
     title?: string;
+    locationId?: string;
+    description?: string;
     breadcrumb?: BreadcrumbValue;
     path?: string;
     query?: T;
@@ -81,7 +83,7 @@ export function registerRouteComponent<
     Field extends keyof ResultOf<T>,
     R extends Field,
 >(options: RegisterRouteComponentOptions<Component, Entity, T, Field, R>) {
-    const { query, entityKey, variables, getBreadcrumbs } = options;
+    const { query, entityKey, variables, getBreadcrumbs, locationId, description } = options;
 
     const breadcrumbSubject$ = new BehaviorSubject<BreadcrumbValue>(options.breadcrumb ?? '');
     const titleSubject$ = new BehaviorSubject<string | undefined>(options.title);
@@ -129,6 +131,8 @@ export function registerRouteComponent<
         ...(options.routeConfig ?? {}),
         resolve: { ...(resolveFn ? { detail: resolveFn } : {}), ...(options.routeConfig?.resolve ?? {}) },
         data: {
+            locationId,
+            description,
             breadcrumb: breadcrumbSubject$,
             ...(options.routeConfig?.data ?? {}),
             ...(getBreadcrumbs && query && entityKey

--- a/packages/dev-server/example-plugins/ui-extensions-library/ui/providers.ts
+++ b/packages/dev-server/example-plugins/ui-extensions-library/ui/providers.ts
@@ -1,4 +1,5 @@
-import { addNavMenuSection } from '@vendure/admin-ui/core';
+import { PageLocationId, addNavMenuSection, registerPageTab } from '@vendure/admin-ui/core';
+import { AngularUiComponent } from './angular-components/angular-ui/angular-ui.component';
 
 export default [
     addNavMenuSection({
@@ -16,5 +17,35 @@ export default [
                 routerLink: ['/extensions/ui-library/angular-ui'],
             },
         ],
+    }),
+    //Testing page tabs on custom angular components
+    registerPageTab({
+        location: 'angular-ui' as PageLocationId,
+        tab: 'Example Tab 1',
+        route: '/extensions/ui-library/angular-ui',
+        tabIcon: 'star',
+        component: AngularUiComponent,
+    }),
+    registerPageTab({
+        location: 'angular-ui' as PageLocationId,
+        tab: 'Example Tab 2',
+        route: '/extensions/ui-library/angular-ui2',
+        tabIcon: 'star',
+        component: AngularUiComponent,
+    }),
+
+    registerPageTab({
+        location: 'react-ui' as PageLocationId,
+        tab: 'Example Tab 1',
+        route: '/extensions/ui-library/angular-ui',
+        tabIcon: 'star',
+        component: AngularUiComponent,
+    }),
+    registerPageTab({
+        location: 'react-ui' as PageLocationId,
+        tab: 'Example Tab 2',
+        route: '/extensions/ui-library/angular-ui2',
+        tabIcon: 'star',
+        component: AngularUiComponent,
     }),
 ];

--- a/packages/dev-server/example-plugins/ui-extensions-library/ui/providers.ts
+++ b/packages/dev-server/example-plugins/ui-extensions-library/ui/providers.ts
@@ -33,7 +33,6 @@ export default [
         tabIcon: 'star',
         component: AngularUiComponent,
     }),
-
     registerPageTab({
         location: 'react-ui' as PageLocationId,
         tab: 'Example Tab 1',

--- a/packages/dev-server/example-plugins/ui-extensions-library/ui/routes.ts
+++ b/packages/dev-server/example-plugins/ui-extensions-library/ui/routes.ts
@@ -9,10 +9,22 @@ export default [
         path: 'react-ui',
         component: ReactUi,
         title: 'React UI',
+        description: "Test description",
+        locationId: "react-ui"
     }),
     registerRouteComponent({
         path: 'angular-ui',
         component: AngularUiComponent,
         title: 'Angular UI',
+        locationId: "angular-ui",
+        description: "Test description 2"
     }),
-];
+    //Test page tabs on angular components
+    registerRouteComponent({
+        path: 'angular-ui2',
+        component: AngularUiComponent,
+        title: 'Angular UI 2',
+        locationId: "angular-ui",
+        description: "Test description 2"
+    })
+]


### PR DESCRIPTION
# Description

Add `description` and `locationId` to `registerRouteComponent` and `registerReactRouteComponent` so that users can define custom description and page tabs to their custom routes vis the `registerPageTab` API.

# Breaking changes

Does this PR include any breaking changes we should be aware of?
no

# Screenshots
<img width="877" alt="image" src="https://github.com/vendure-ecommerce/vendure/assets/72182093/c870d11d-a72c-4bb6-b77b-eb3237918bcc">

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [x] I have added or updated test cases
- [x] I have updated the README if needed
