### PR TITLE
fix(core): Adding usage check of nested custom property filters in ListQueryBuilder

### DIFF
--- a/packages/core/src/service/helpers/list-query-builder/list-query-builder.ts
+++ b/packages/core/src/service/helpers/list-query-builder/list-query-builder.ts
@@ -427,7 +427,19 @@ export class ListQueryBuilder implements OnApplicationBootstrap {
     }
 
     private customPropertyIsBeingUsed(property: string, options: ListQueryOptions<any>): boolean {
-        return !!(options.sort?.[property] || options.filter?.[property]);
+        return !!(options.sort?.[property] || this.isPropertyUsedInFilter(property, options.filter));
+    }
+
+    private isPropertyUsedInFilter(
+        property: string,
+        filter?: NullOptionals<FilterParameter<any>> | null,
+    ): boolean {
+        return !!(
+            filter &&
+            (filter[property] ||
+                filter._and?.some(nestedFilter => this.isPropertyUsedInFilter(property, nestedFilter)) ||
+                filter._or?.some(nestedFilter => this.isPropertyUsedInFilter(property, nestedFilter)))
+        );
     }
 
     /**


### PR DESCRIPTION
# Description

This pull request fixes an issue in the `ListQueryBuilder` class where the method `customPropertyIsBeingUsed` did not properly account for nested filters when checking for custom property usage. 


# Breaking changes

No breaking changes

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [ ] I have added or updated test cases
- [ ] I have updated the README if needed
