### PR TITLE
fix(product-duplicator): Copy tax category on variants

### DIFF
--- a/packages/core/src/config/entity/entity-duplicators/product-duplicator.ts
+++ b/packages/core/src/config/entity/entity-duplicators/product-duplicator.ts
@@ -104,6 +104,7 @@ export const productDuplicator = new EntityDuplicator({
                     stockLevels: true,
                     facetValues: true,
                     productVariantPrices: true,
+                    taxCategory: true,
                 },
             });
             if (product.optionGroups && product.optionGroups.length) {
@@ -167,13 +168,13 @@ export const productDuplicator = new EntityDuplicator({
                 const price =
                     variant.productVariantPrices.find(p => idsAreEqual(p.channelId, ctx.channelId))?.price ??
                     variant.productVariantPrices[0]?.price;
-
                 return {
                     productId: duplicatedProduct.id,
                     price: price ?? variant.price,
                     sku: `${variant.sku}-copy`,
                     stockOnHand: 1,
                     featuredAssetId: variant.featuredAsset?.id,
+                    taxCategoryId: variant.taxCategory?.id,
                     useGlobalOutOfStockThreshold: variant.useGlobalOutOfStockThreshold,
                     trackInventory: variant.trackInventory,
                     assetIds: variant.assets.map(value => value.assetId),


### PR DESCRIPTION
# Description

When you copy a product, the tax category is not copied, which leads the tax category to default to whatever is the first one.

# Breaking changes

- Product duplicator now copies tax categories from the source variant

# Screenshots

You can add screenshots here if applicable.

# Checklist

📌 Always:
- [ x] I have set a clear title
- [ x] My PR is small and contains a single feature
- [ x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [ x] I have added or updated test cases
- [ x] I have updated the README if needed
