### PR TITLE
fix(core): Truncate db aliases if necessary

### DIFF
--- a/packages/core/src/service/helpers/utils/tree-relations-qb-joiner.ts
+++ b/packages/core/src/service/helpers/utils/tree-relations-qb-joiner.ts
@@ -1,6 +1,6 @@
 import { EntityMetadata, FindOneOptions, SelectQueryBuilder } from 'typeorm';
 import { EntityTarget } from 'typeorm/common/EntityTarget';
-import { FindOptionsRelationByString, FindOptionsRelations } from 'typeorm/find-options/FindOptionsRelations';
+import { DriverUtils } from 'typeorm/driver/DriverUtils';
 
 import { findOptionsObjectToArray } from '../../../connection/find-options-object-to-array';
 import { VendureEntity } from '../../../entity';
@@ -108,7 +108,12 @@ export function joinTreeRelationsDynamically<T extends VendureEntity>(
         if (relationMetadata.isEager) {
             joinConnector = '__';
         }
-        const nextAlias = `${currentAlias}${joinConnector}${part.replace(/\./g, '_')}`;
+        const nextAlias = DriverUtils.buildAlias(
+            qb.connection.driver,
+            { shorten: false },
+            currentAlias,
+            part.replace(/\./g, '_'),
+        );
         const nextPath = parts.join('.');
         const fullPath = [...(parentPath || []), part].join('.');
         if (!qb.expressionMap.joinAttributes.some(ja => ja.alias.name === nextAlias)) {


### PR DESCRIPTION
Fixes #2899

# Description
Postgres truncates long identifiers making them equal if they share the same prefix. For instance if two tables are being joined with a long alias (the names need to be a lot longer in reality) `product_variant_relation_0_relation_1` and `product_variant_relation_0_relation_2` postgres will truncate both aliases to `product_variant_rel` and fail because it's not allowed to have two join statements with the same target alias.

# Breaking changes

None

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [ ] I have added or updated test cases
- [ ] I have updated the README if needed