### PR TITLE
feat(core): Return type of `CollectionService.getBreadcrumbs` was missing slug

### DIFF
--- a/packages/core/src/api/resolvers/entity/collection-entity.resolver.ts
+++ b/packages/core/src/api/resolvers/entity/collection-entity.resolver.ts
@@ -78,7 +78,7 @@ export class CollectionEntityResolver {
         @Ctx() ctx: RequestContext,
         @Parent() collection: Collection,
     ): Promise<CollectionBreadcrumb[]> {
-        return this.collectionService.getBreadcrumbs(ctx, collection) as any;
+        return this.collectionService.getBreadcrumbs(ctx, collection);
     }
 
     @ResolveField()

--- a/packages/core/src/service/services/collection.service.ts
+++ b/packages/core/src/service/services/collection.service.ts
@@ -292,7 +292,7 @@ export class CollectionService implements OnModuleInit {
     async getBreadcrumbs(
         ctx: RequestContext,
         collection: Collection,
-    ): Promise<Array<{ name: string; id: ID }>> {
+    ): Promise<Array<{ name: string; id: ID, slug: string }>> {
         const rootCollection = await this.getRootCollection(ctx);
         if (idsAreEqual(collection.id, rootCollection.id)) {
             return [pick(rootCollection, ['id', 'name', 'slug'])];


### PR DESCRIPTION
# Description

I was internally using collectionService.getBreadcrumbs, and notice it was missing the slug in the return type, which in turn cause an unnecessary `as any`.

# Checklist

📌 Always:
- [ ] I have set a clear title
- [ ] My PR is small and contains a single feature
- [ ] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [ ] I have added or updated test cases
- [ ] I have updated the README if needed
