### PR TITLE
perf(core): Improve hydrator performance for customFields

### DIFF
--- a/packages/core/src/service/helpers/entity-hydrator/entity-hydrator.service.ts
+++ b/packages/core/src/service/helpers/entity-hydrator/entity-hydrator.service.ts
@@ -200,11 +200,16 @@ export class EntityHydrator {
         const missingRelations: string[] = [];
         for (const relation of options.relations.slice().sort()) {
             if (typeof relation === 'string') {
-                const parts = !relation.startsWith('customFields') ? relation.split('.') : [relation];
+                const parts = relation.split('.');
                 let entity: Record<string, any> | undefined = target;
                 const path = [];
                 for (const part of parts) {
                     path.push(part);
+                    // null = the relation has been fetched but was null in the database.
+                    // undefined = the relation has not been fetched.
+                    if (entity && entity[part] === null) {
+                        break;
+                    }
                     if (entity && entity[part]) {
                         entity = Array.isArray(entity[part]) ? entity[part][0] : entity[part];
                     } else {


### PR DESCRIPTION
Remove a workaround that led to refetching relations in customFields. Prevent refetching of customFields during hydration
Fixes #2696

# Description
See #2696. There was some sort of workaround that disabled the check which is in place to prevent reloading the same data over and over. `entity["customFields.xyz"]` will never be set because the data would be in `entity["customFields"]["xyz"]`.
I'm still wondering if there is some edge case that made this workaround necessary but we are running this patch in production for quite some time now and we are using a lot of `customFields`.

# Breaking changes
None I would be aware of. This might have been a workaround for a bug in typeorm maybe.

# Checklist

📌 Always:
- [x I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [ ] I have added or updated test cases
- [ ] I have updated the README if needed
