### PR TITLE
feat(email-plugin): Allow specify metadata for EmailSendEvent

### DIFF
--- a/packages/email-plugin/src/email-processor.ts
+++ b/packages/email-plugin/src/email-processor.ts
@@ -75,7 +75,9 @@ export class EmailProcessor {
             };
             const transportSettings = await this.getTransportSettings(ctx);
             await this.emailSender.send(emailDetails, transportSettings);
-            await this.eventBus.publish(new EmailSendEvent(ctx, emailDetails, true));
+            await this.eventBus.publish(
+                new EmailSendEvent(ctx, emailDetails, true, undefined, data.metadata),
+            );
             return true;
         } catch (err: unknown) {
             if (err instanceof Error) {
@@ -84,7 +86,9 @@ export class EmailProcessor {
                 Logger.error(String(err), loggerCtx);
             }
 
-            await this.eventBus.publish(new EmailSendEvent(ctx, emailDetails, false, err as Error));
+            await this.eventBus.publish(
+                new EmailSendEvent(ctx, emailDetails, false, err as Error, data.metadata),
+            );
             throw err;
         }
     }

--- a/packages/email-plugin/src/email-send-event.ts
+++ b/packages/email-plugin/src/email-send-event.ts
@@ -1,6 +1,6 @@
 import { RequestContext, VendureEvent } from '@vendure/core';
 
-import { EmailDetails } from './types';
+import { EmailDetails, EmailMetadata } from './types';
 
 /**
  * @description
@@ -17,6 +17,7 @@ export class EmailSendEvent extends VendureEvent {
         public readonly details: EmailDetails,
         public readonly success: boolean,
         public readonly error?: Error,
+        public readonly metadata?: EmailMetadata,
     ) {
         super();
     }

--- a/packages/email-plugin/src/types.ts
+++ b/packages/email-plugin/src/types.ts
@@ -356,6 +356,7 @@ export type IntermediateEmailDetails = {
     cc?: string;
     bcc?: string;
     replyTo?: string;
+    metadata?: EmailMetadata;
 };
 
 /**
@@ -475,3 +476,16 @@ export interface OptionalAddressFields {
 export type SetOptionalAddressFieldsFn<Event> = (
     event: Event,
 ) => OptionalAddressFields | Promise<OptionalAddressFields>;
+
+/**
+ * @description
+ * A function used to set the {@link EmailMetadata}.
+ *
+ * @since 3.1.0
+ * @docsCategory core plugins/EmailPlugin
+ * @docsPage Email Plugin Types
+ *
+ */
+export type SetMetadataFn<Event> = (event: Event) => EmailMetadata | Promise<EmailMetadata>;
+
+export type EmailMetadata = Record<string, any>;


### PR DESCRIPTION
# Description

Added metadata for `EmailSendEvent` and `setMetadata` function on `EmailEventHandler`
Closes #2849 

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [ ] I have added or updated test cases
- [ ] I have updated the README if needed
