### PR TITLE
feat(core): Add maxDiscountAmount to PromotionItemAction

### DIFF
--- a/packages/core/src/config/promotion/promotion-action.ts
+++ b/packages/core/src/config/promotion/promotion-action.ts
@@ -199,6 +199,14 @@ export interface PromotionItemActionConfig<T extends ConfigArgs, U extends Promo
      * the OrderLine, i.e. the number should be negative.
      */
     execute: ExecutePromotionItemActionFn<T, U>;
+
+    /**
+     * @description
+     * The maximum discount amount that can be applied to this action.
+     *
+     * @default 0
+     */
+    maxDiscountAmount?: ExecutePromotionItemActionFn<T, U>;
 }
 
 /**
@@ -321,10 +329,15 @@ export class PromotionItemAction<
     T extends ConfigArgs = ConfigArgs,
     U extends Array<PromotionCondition<any>> = [],
 > extends PromotionAction<T, U> {
+    /** @internal */
     private readonly executeFn: ExecutePromotionItemActionFn<T, U>;
+    /** @internal */
+    private readonly maxDiscountAmountFn: ExecutePromotionItemActionFn<T, U>;
+
     constructor(config: PromotionItemActionConfig<T, U>) {
         super(config);
         this.executeFn = config.execute;
+        this.maxDiscountAmountFn = config.maxDiscountAmount || (() => 0);
     }
 
     /** @internal */
@@ -342,6 +355,34 @@ export class PromotionItemAction<
               )
             : {};
         return this.executeFn(
+            ctx,
+            orderLine,
+            this.argsArrayToHash(args),
+            actionState as ConditionState<U>,
+            promotion,
+        );
+    }
+    
+    /**
+     * @description
+     * The maximum discount amount that can be applied to this action.
+     *
+     * @default 0
+     */
+    maxDiscountAmount(
+        ctx: RequestContext,
+        orderLine: OrderLine,
+        args: ConfigArg[],
+        state: PromotionState,
+        promotion: Promotion,
+    ) {
+        const actionState = this.conditions
+            ? pick(
+                  state,
+                  this.conditions.map(c => c.code),
+              )
+            : {};
+        return this.maxDiscountAmountFn(
             ctx,
             orderLine,
             this.argsArrayToHash(args),

--- a/packages/core/src/entity/promotion/promotion.entity.ts
+++ b/packages/core/src/entity/promotion/promotion.entity.ts
@@ -150,9 +150,17 @@ export class Promotion
             if (promotionAction instanceof PromotionItemAction) {
                 if (this.isOrderItemArg(args)) {
                     const { orderLine } = args;
-                    amount += roundMoney(
+                    const discountAmount = roundMoney(
                         await promotionAction.execute(ctx, orderLine, action.args, state, this),
-                    );
+                        ) * orderLine.quantity;
+                    const maxDiscountAmount =
+                        roundMoney(
+                            await promotionAction.maxDiscountAmount(ctx, orderLine, action.args, state, this),
+                        );
+                    amount +=
+                        maxDiscountAmount && maxDiscountAmount > discountAmount
+                            ? maxDiscountAmount
+                            : discountAmount;
                 }
             } else if (promotionAction instanceof PromotionOrderAction) {
                 if (this.isOrderArg(args)) {

--- a/packages/core/src/service/helpers/order-calculator/order-calculator.ts
+++ b/packages/core/src/service/helpers/order-calculator/order-calculator.ts
@@ -199,7 +199,6 @@ export class OrderCalculator {
                     // for (const item of line.items) {
                     const adjustment = await promotion.apply(ctx, { orderLine: line }, state);
                     if (adjustment) {
-                        adjustment.amount = adjustment.amount * line.quantity;
                         line.addAdjustment(adjustment);
                         priceAdjusted = true;
                     }


### PR DESCRIPTION
# Description

In the case of PromotionItemAction, there is an issue where the maximum discount amount cannot be specified because the orderLine quantity is multiplied after executing the apply function of the Promotion Entity.

To address this, we have added a maxDiscountAmount method to the PromotionItemAction class, which takes the same arguments as the execute method, allowing customization of the maximum discount amount. Additionally, we have modified the PromotionItemAction apply process to compare the discount amount with the maxDiscountAmount and apply the maximum discount amount if necessary.

The maxDiscountAmount is optional and will not conflict with existing Promotion Actions.

- [Issue](https://github.com/vendure-ecommerce/vendure/issues/2465)


# Checklist

📌 Always:
- [X] I have set a clear title
- [X] My PR is small and contains a single feature
- [X] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")
