### PR TITLE
feat(core): Create PromotionLineAction

### DIFF
--- a/packages/core/e2e/fixtures/test-money-strategy.ts
+++ b/packages/core/e2e/fixtures/test-money-strategy.ts
@@ -1,0 +1,7 @@
+import { DefaultMoneyStrategy } from '@vendure/core';
+
+export class TestMoneyStrategy extends DefaultMoneyStrategy {
+    round(value: number, quantity = 1): number {
+        return Math.round(value * quantity);
+    }
+}

--- a/packages/core/e2e/order-promotion.e2e-spec.ts
+++ b/packages/core/e2e/order-promotion.e2e-spec.ts
@@ -28,7 +28,9 @@ import { initialData } from '../../../e2e-common/e2e-initial-data';
 import { testConfig, TEST_SETUP_TIMEOUT_MS } from '../../../e2e-common/test-config';
 import { freeShipping } from '../src/config/promotion/actions/free-shipping-action';
 import { orderFixedDiscount } from '../src/config/promotion/actions/order-fixed-discount-action';
+import { orderLineFixedDiscount } from '../src/config/promotion/actions/order-line-fixed-discount-action';
 
+import { TestMoneyStrategy } from './fixtures/test-money-strategy';
 import { testSuccessfulPaymentMethod } from './fixtures/test-payment-methods';
 import { CurrencyCode, HistoryEntryType, LanguageCode } from './graphql/generated-e2e-admin-types';
 import * as Codegen from './graphql/generated-e2e-admin-types';
@@ -65,6 +67,9 @@ describe('Promotions applied to Orders', () => {
             dbConnectionOptions: { logging: true },
             paymentOptions: {
                 paymentMethodHandlers: [testSuccessfulPaymentMethod],
+            },
+            entityOptions: {
+                moneyStrategy: new TestMoneyStrategy(),
             },
         }),
     );
@@ -834,6 +839,58 @@ describe('Promotions applied to Orders', () => {
             });
         });
 
+        describe('orderLineFixedDiscount', () => {
+            const couponCode = '1000_off_order_line';
+            let promotion: Codegen.PromotionFragment;
+
+            beforeAll(async () => {
+                promotion = await createPromotion({
+                    enabled: true,
+                    name: '$1000 discount on order line',
+                    couponCode,
+                    conditions: [],
+                    actions: [
+                        {
+                            code: orderLineFixedDiscount.code,
+                            arguments: [{ name: 'discount', value: '1000' }],
+                        },
+                    ],
+                });
+            });
+
+            afterAll(async () => {
+                await deletePromotion(promotion.id);
+            });
+
+            it('prices exclude tax', async () => {
+                await shopClient.asAnonymousUser();
+                const { addItemToOrder } = await shopClient.query<
+                    CodegenShop.AddItemToOrderMutation,
+                    CodegenShop.AddItemToOrderMutationVariables
+                >(ADD_ITEM_TO_ORDER, {
+                    productVariantId: getVariantBySlug('item-1000').id,
+                    quantity: 3,
+                });
+                orderResultGuard.assertSuccess(addItemToOrder);
+                expect(addItemToOrder.discounts.length).toBe(0);
+                expect(addItemToOrder.lines[0].discounts.length).toBe(0);
+                expect(addItemToOrder.total).toBe(3000);
+                expect(addItemToOrder.totalWithTax).toBe(3600);
+
+                const { applyCouponCode } = await shopClient.query<
+                    CodegenShop.ApplyCouponCodeMutation,
+                    CodegenShop.ApplyCouponCodeMutationVariables
+                >(APPLY_COUPON_CODE, {
+                    couponCode,
+                });
+                orderResultGuard.assertSuccess(applyCouponCode);
+
+                expect(applyCouponCode.total).toBe(2000);
+                expect(applyCouponCode.totalWithTax).toBe(2400);
+                expect(applyCouponCode.lines[0].discounts.length).toBe(1);
+            });
+        });
+
         describe('discountOnItemWithFacets', () => {
             const couponCode = '50%_off_sale_items';
             let promotion: Codegen.PromotionFragment;
@@ -925,9 +982,8 @@ describe('Promotions applied to Orders', () => {
                 expect(removeCouponCode!.total).toBe(2200);
                 expect(removeCouponCode!.totalWithTax).toBe(2640);
 
-                const { activeOrder } = await shopClient.query<CodegenShop.GetActiveOrderQuery>(
-                    GET_ACTIVE_ORDER,
-                );
+                const { activeOrder } =
+                    await shopClient.query<CodegenShop.GetActiveOrderQuery>(GET_ACTIVE_ORDER);
                 expect(getItemSale1Line(activeOrder!.lines).discounts.length).toBe(0);
                 expect(activeOrder!.total).toBe(2200);
                 expect(activeOrder!.totalWithTax).toBe(2640);
@@ -986,9 +1042,8 @@ describe('Promotions applied to Orders', () => {
                 expect(removeCouponCode!.total).toBe(2200);
                 expect(removeCouponCode!.totalWithTax).toBe(2640);
 
-                const { activeOrder } = await shopClient.query<CodegenShop.GetActiveOrderQuery>(
-                    GET_ACTIVE_ORDER,
-                );
+                const { activeOrder } =
+                    await shopClient.query<CodegenShop.GetActiveOrderQuery>(GET_ACTIVE_ORDER);
                 expect(getItemSale1Line(activeOrder!.lines).discounts.length).toBe(0);
                 expect(activeOrder!.total).toBe(2200);
                 expect(activeOrder!.totalWithTax).toBe(2640);
@@ -1534,9 +1589,8 @@ describe('Promotions applied to Orders', () => {
 
                 await addGuestCustomerToOrder();
 
-                const { activeOrder } = await shopClient.query<CodegenShop.GetActiveOrderQuery>(
-                    GET_ACTIVE_ORDER,
-                );
+                const { activeOrder } =
+                    await shopClient.query<CodegenShop.GetActiveOrderQuery>(GET_ACTIVE_ORDER);
                 expect(activeOrder!.couponCodes).toEqual([]);
                 expect(activeOrder!.totalWithTax).toBe(6000);
             });
@@ -1627,9 +1681,8 @@ describe('Promotions applied to Orders', () => {
 
                 await logInAsRegisteredCustomer();
 
-                const { activeOrder } = await shopClient.query<CodegenShop.GetActiveOrderQuery>(
-                    GET_ACTIVE_ORDER,
-                );
+                const { activeOrder } =
+                    await shopClient.query<CodegenShop.GetActiveOrderQuery>(GET_ACTIVE_ORDER);
                 expect(activeOrder!.totalWithTax).toBe(6000);
                 expect(activeOrder!.couponCodes).toEqual([]);
             });
@@ -1883,9 +1936,8 @@ describe('Promotions applied to Orders', () => {
         expect(addItemToOrder.discounts.length).toBe(1);
         expect(addItemToOrder.discounts[0].description).toBe('Test Promo');
 
-        const { activeOrder: check1 } = await shopClient.query<CodegenShop.GetActiveOrderQuery>(
-            GET_ACTIVE_ORDER,
-        );
+        const { activeOrder: check1 } =
+            await shopClient.query<CodegenShop.GetActiveOrderQuery>(GET_ACTIVE_ORDER);
         expect(check1!.discounts.length).toBe(1);
         expect(check1!.discounts[0].description).toBe('Test Promo');
 
@@ -1899,9 +1951,8 @@ describe('Promotions applied to Orders', () => {
         orderResultGuard.assertSuccess(removeOrderLine);
         expect(removeOrderLine.discounts.length).toBe(0);
 
-        const { activeOrder: check2 } = await shopClient.query<CodegenShop.GetActiveOrderQuery>(
-            GET_ACTIVE_ORDER,
-        );
+        const { activeOrder: check2 } =
+            await shopClient.query<CodegenShop.GetActiveOrderQuery>(GET_ACTIVE_ORDER);
         expect(check2!.discounts.length).toBe(0);
     });
 
@@ -2043,9 +2094,8 @@ describe('Promotions applied to Orders', () => {
                 quantity: 1,
             });
 
-            const { activeOrder: check1 } = await shopClient.query<CodegenShop.GetActiveOrderQuery>(
-                GET_ACTIVE_ORDER,
-            );
+            const { activeOrder: check1 } =
+                await shopClient.query<CodegenShop.GetActiveOrderQuery>(GET_ACTIVE_ORDER);
 
             expect(check1!.lines[0].discountedUnitPriceWithTax).toBe(0);
             expect(check1!.totalWithTax).toBe(0);
@@ -2055,9 +2105,8 @@ describe('Promotions applied to Orders', () => {
                 CodegenShop.ApplyCouponCodeMutationVariables
             >(APPLY_COUPON_CODE, { couponCode: couponCode2 });
 
-            const { activeOrder: check2 } = await shopClient.query<CodegenShop.GetActiveOrderQuery>(
-                GET_ACTIVE_ORDER,
-            );
+            const { activeOrder: check2 } =
+                await shopClient.query<CodegenShop.GetActiveOrderQuery>(GET_ACTIVE_ORDER);
             expect(check2!.lines[0].discountedUnitPriceWithTax).toBe(0);
             expect(check2!.totalWithTax).toBe(0);
         });
@@ -2080,9 +2129,8 @@ describe('Promotions applied to Orders', () => {
                 quantity: 1,
             });
 
-            const { activeOrder: check1 } = await shopClient.query<CodegenShop.GetActiveOrderQuery>(
-                GET_ACTIVE_ORDER,
-            );
+            const { activeOrder: check1 } =
+                await shopClient.query<CodegenShop.GetActiveOrderQuery>(GET_ACTIVE_ORDER);
 
             expect(check1!.lines[0].discountedUnitPriceWithTax).toBe(0);
             expect(check1!.totalWithTax).toBe(0);
@@ -2092,9 +2140,8 @@ describe('Promotions applied to Orders', () => {
                 CodegenShop.ApplyCouponCodeMutationVariables
             >(APPLY_COUPON_CODE, { couponCode: couponCode2 });
 
-            const { activeOrder: check2 } = await shopClient.query<CodegenShop.GetActiveOrderQuery>(
-                GET_ACTIVE_ORDER,
-            );
+            const { activeOrder: check2 } =
+                await shopClient.query<CodegenShop.GetActiveOrderQuery>(GET_ACTIVE_ORDER);
             expect(check2!.lines[0].discountedUnitPriceWithTax).toBe(0);
             expect(check2!.totalWithTax).toBe(0);
         });

--- a/packages/core/src/config/promotion/actions/order-line-fixed-discount-action.ts
+++ b/packages/core/src/config/promotion/actions/order-line-fixed-discount-action.ts
@@ -1,0 +1,19 @@
+import { LanguageCode } from '@vendure/common/lib/generated-types';
+
+import { PromotionLineAction } from '../promotion-action';
+
+export const orderLineFixedDiscount = new PromotionLineAction({
+    code: 'order_line_fixed_discount',
+    args: {
+        discount: {
+            type: 'int',
+            ui: {
+                component: 'currency-form-input',
+            },
+        },
+    },
+    execute(ctx, orderLine, args) {
+        return -args.discount;
+    },
+    description: [{ languageCode: LanguageCode.en, value: 'Discount orderLine by fixed amount' }],
+});

--- a/packages/core/src/config/promotion/index.ts
+++ b/packages/core/src/config/promotion/index.ts
@@ -2,6 +2,7 @@ import { buyXGetYFreeAction } from './actions/buy-x-get-y-free-action';
 import { discountOnItemWithFacets } from './actions/facet-values-percentage-discount-action';
 import { freeShipping } from './actions/free-shipping-action';
 import { orderFixedDiscount } from './actions/order-fixed-discount-action';
+import { orderLineFixedDiscount } from './actions/order-line-fixed-discount-action';
 import { orderPercentageDiscount } from './actions/order-percentage-discount-action';
 import { productsPercentageDiscount } from './actions/product-percentage-discount-action';
 import { buyXGetYFreeCondition } from './conditions/buy-x-get-y-free-condition';
@@ -27,6 +28,7 @@ export * from './utils/facet-value-checker';
 
 export const defaultPromotionActions = [
     orderFixedDiscount,
+    orderLineFixedDiscount,
     orderPercentageDiscount,
     discountOnItemWithFacets,
     productsPercentageDiscount,

--- a/packages/core/src/config/promotion/promotion-action.ts
+++ b/packages/core/src/config/promotion/promotion-action.ts
@@ -64,12 +64,28 @@ export type ConditionState<
 /**
  * @description
  * The function which is used by a PromotionItemAction to calculate the
- * discount on the OrderLine.
+ * discount on the OrderLine for each item.
  *
  * @docsCategory promotions
  * @docsPage promotion-action
  */
 export type ExecutePromotionItemActionFn<T extends ConfigArgs, U extends Array<PromotionCondition<any>>> = (
+    ctx: RequestContext,
+    orderLine: OrderLine,
+    args: ConfigArgValues<T>,
+    state: ConditionState<U>,
+    promotion: Promotion,
+) => number | Promise<number>;
+
+/**
+ * @description
+ * The function which is used by a PromotionLineAction to calculate the
+ * discount on the OrderLine.
+ *
+ * @docsCategory promotions
+ * @docsPage promotion-action
+ */
+export type ExecutePromotionLineActionFn<T extends ConfigArgs, U extends Array<PromotionCondition<any>>> = (
     ctx: RequestContext,
     orderLine: OrderLine,
     args: ConfigArgValues<T>,
@@ -203,6 +219,24 @@ export interface PromotionItemActionConfig<T extends ConfigArgs, U extends Promo
 
 /**
  * @description
+ * Configuration for a {@link PromotionLineAction}
+ *
+ * @docsCategory promotions
+ * @docsPage promotion-action
+ */
+export interface PromotionLineActionConfig<T extends ConfigArgs, U extends PromotionCondition[]>
+    extends PromotionActionConfig<T, U> {
+    /**
+     * @description
+     * The function which contains the promotion calculation logic.
+     * Should resolve to a number which represents the amount by which to discount
+     * the OrderLine, i.e. the number should be negative.
+     */
+    execute: ExecutePromotionLineActionFn<T, U>;
+}
+
+/**
+ * @description
  *
  * @docsCategory promotions
  * @docsPage promotion-action
@@ -323,6 +357,61 @@ export class PromotionItemAction<
 > extends PromotionAction<T, U> {
     private readonly executeFn: ExecutePromotionItemActionFn<T, U>;
     constructor(config: PromotionItemActionConfig<T, U>) {
+        super(config);
+        this.executeFn = config.execute;
+    }
+
+    /** @internal */
+    execute(
+        ctx: RequestContext,
+        orderLine: OrderLine,
+        args: ConfigArg[],
+        state: PromotionState,
+        promotion: Promotion,
+    ) {
+        const actionState = this.conditions
+            ? pick(
+                  state,
+                  this.conditions.map(c => c.code),
+              )
+            : {};
+        return this.executeFn(
+            ctx,
+            orderLine,
+            this.argsArrayToHash(args),
+            actionState as ConditionState<U>,
+            promotion,
+        );
+    }
+}
+
+/**
+ * @description
+ * Represents a PromotionAction which applies to individual {@link OrderLine}s.
+ * The difference from PromotionItemAction is that it applies regardless of the Quantity of the OrderLine.
+ *
+ * @example
+ * ```ts
+ * // Applies a percentage discount to each OrderLine
+ * const linePercentageDiscount = new PromotionLineAction({
+ *     code: 'line_percentage_discount',
+ *     args: { discount: 'percentage' },
+ *     execute(ctx, orderLine, args) {
+ *         return -orderLine.linePrice * (args.discount / 100);
+ *     },
+ *     description: 'Discount every line by { discount }%',
+ * });
+ * ```
+ *
+ * @docsCategory promotions
+ * @docsPage promotion-action
+ */
+export class PromotionLineAction<
+    T extends ConfigArgs = ConfigArgs,
+    U extends Array<PromotionCondition<any>> = [],
+> extends PromotionAction<T, U> {
+    private readonly executeFn: ExecutePromotionLineActionFn<T, U>;
+    constructor(config: PromotionLineActionConfig<T, U>) {
         super(config);
         this.executeFn = config.execute;
     }

--- a/packages/core/src/entity/promotion/promotion.entity.ts
+++ b/packages/core/src/entity/promotion/promotion.entity.ts
@@ -159,9 +159,10 @@ export class Promotion
             if (promotionAction instanceof PromotionItemAction) {
                 if (this.isOrderItemArg(args)) {
                     const { orderLine } = args;
-                    amount +=
-                        roundMoney(await promotionAction.execute(ctx, orderLine, action.args, state, this)) *
-                        orderLine.quantity;
+                    amount += roundMoney(
+                        await promotionAction.execute(ctx, orderLine, action.args, state, this),
+                        orderLine.quantity,
+                    );
                 }
             } else if (promotionAction instanceof PromotionLineAction) {
                 if (this.isOrderLineArg(args)) {

--- a/packages/core/src/entity/promotion/promotion.entity.ts
+++ b/packages/core/src/entity/promotion/promotion.entity.ts
@@ -159,9 +159,9 @@ export class Promotion
             if (promotionAction instanceof PromotionItemAction) {
                 if (this.isOrderItemArg(args)) {
                     const { orderLine } = args;
-                    amount += roundMoney(
-                        await promotionAction.execute(ctx, orderLine, action.args, state, this),
-                    );
+                    amount +=
+                        roundMoney(await promotionAction.execute(ctx, orderLine, action.args, state, this)) *
+                        orderLine.quantity;
                 }
             } else if (promotionAction instanceof PromotionLineAction) {
                 if (this.isOrderLineArg(args)) {

--- a/packages/core/src/entity/promotion/promotion.entity.ts
+++ b/packages/core/src/entity/promotion/promotion.entity.ts
@@ -12,6 +12,7 @@ import { HasCustomFields } from '../../config/custom-field/custom-field-types';
 import {
     PromotionAction,
     PromotionItemAction,
+    PromotionLineAction,
     PromotionOrderAction,
     PromotionShippingAction,
 } from '../../config/promotion/promotion-action';
@@ -25,6 +26,10 @@ import { ShippingLine } from '../shipping-line/shipping-line.entity';
 import { PromotionTranslation } from './promotion-translation.entity';
 
 export interface ApplyOrderItemActionArgs {
+    orderLine: OrderLine;
+}
+
+export interface ApplyOrderLineActionArgs {
     orderLine: OrderLine;
 }
 
@@ -49,7 +54,7 @@ export type PromotionTestResult = boolean | PromotionState;
  * will be applied to an Order.
  *
  * Each assigned {@link PromotionCondition} is checked against the Order, and if they all return `true`,
- * then each assign {@link PromotionItemAction} / {@link PromotionOrderAction} is applied to the Order.
+ * then each assign {@link PromotionItemAction} / {@link PromotionLineAction} / {@link PromotionOrderAction} / {@link PromotionShippingAction} is applied to the Order.
  *
  * @docsCategory entities
  */
@@ -61,7 +66,11 @@ export class Promotion
     type = AdjustmentType.PROMOTION;
     private readonly allConditions: { [code: string]: PromotionCondition } = {};
     private readonly allActions: {
-        [code: string]: PromotionItemAction | PromotionOrderAction | PromotionShippingAction;
+        [code: string]:
+            | PromotionItemAction
+            | PromotionLineAction
+            | PromotionOrderAction
+            | PromotionShippingAction;
     } = {};
 
     constructor(
@@ -154,6 +163,13 @@ export class Promotion
                         await promotionAction.execute(ctx, orderLine, action.args, state, this),
                     );
                 }
+            } else if (promotionAction instanceof PromotionLineAction) {
+                if (this.isOrderLineArg(args)) {
+                    const { orderLine } = args;
+                    amount += roundMoney(
+                        await promotionAction.execute(ctx, orderLine, action.args, state, this),
+                    );
+                }
             } else if (promotionAction instanceof PromotionOrderAction) {
                 if (this.isOrderArg(args)) {
                     const { order } = args;
@@ -235,6 +251,12 @@ export class Promotion
         value: ApplyOrderItemActionArgs | ApplyOrderActionArgs | ApplyShippingActionArgs,
     ): value is ApplyOrderActionArgs {
         return !this.isOrderItemArg(value) && !this.isShippingArg(value);
+    }
+
+    private isOrderLineArg(
+        value: ApplyOrderLineActionArgs | ApplyOrderActionArgs | ApplyShippingActionArgs,
+    ): value is ApplyOrderLineActionArgs {
+        return value.hasOwnProperty('orderLine');
     }
 
     private isOrderItemArg(

--- a/packages/core/src/service/helpers/order-calculator/order-calculator.ts
+++ b/packages/core/src/service/helpers/order-calculator/order-calculator.ts
@@ -167,7 +167,6 @@ export class OrderCalculator {
      */
     private async applyPromotions(ctx: RequestContext, order: Order, promotions: Promotion[]): Promise<void> {
         await this.applyOrderItemPromotions(ctx, order, promotions);
-        await this.applyOrderLinePromotions(ctx, order, promotions);
         await this.applyOrderPromotions(ctx, order, promotions);
         return;
     }
@@ -177,6 +176,8 @@ export class OrderCalculator {
      * Applies promotions to OrderItems. This is a quite complex function, due to the inherent complexity
      * of applying the promotions, and also due to added complexity in the name of performance
      * optimization. Therefore, it is heavily annotated so that the purpose of each step is clear.
+     * Additionally, this is used in both promotionItemAction and promotionLineAction,
+     * as it is difficult to separate action types at this stage.
      */
     private async applyOrderItemPromotions(
         ctx: RequestContext,
@@ -198,49 +199,6 @@ export class OrderCalculator {
                 if (applicableOrState) {
                     const state = typeof applicableOrState === 'object' ? applicableOrState : undefined;
                     // for (const item of line.items) {
-                    const adjustment = await promotion.apply(ctx, { orderLine: line }, state);
-                    if (adjustment) {
-                        adjustment.amount = adjustment.amount * line.quantity;
-                        line.addAdjustment(adjustment);
-                        priceAdjusted = true;
-                    }
-                    if (priceAdjusted) {
-                        this.calculateOrderTotals(order);
-                        priceAdjusted = false;
-                    }
-                    this.addPromotion(order, promotion);
-                }
-            }
-            this.calculateOrderTotals(order);
-        }
-        return;
-    }
-
-    /**
-     * @description
-     * Applies a promotion to the OrderLine.
-     * Unlike applyOrderItemPromotions, which applies promotions to OrderItems based on Quantity,
-     * this was created to apply promotions to the OrderLine regardless of Quantity.
-     */
-    private async applyOrderLinePromotions(
-        ctx: RequestContext,
-        order: Order,
-        promotions: Promotion[],
-    ): Promise<void> {
-        for (const line of order.lines) {
-            // Must be re-calculated for each line, since the previous lines may have triggered promotions
-            // which affected the order price.
-            const applicablePromotions = await filterAsync(promotions, p => p.test(ctx, order).then(Boolean));
-            line.clearAdjustments();
-
-            for (const promotion of applicablePromotions) {
-                let priceAdjusted = false;
-                // We need to test the promotion *again*, even though we've tested them for the line.
-                // This is because the previous Promotions may have adjusted the Order in such a way
-                // as to render later promotions no longer applicable.
-                const applicableOrState = await promotion.test(ctx, order);
-                if (applicableOrState) {
-                    const state = typeof applicableOrState === 'object' ? applicableOrState : undefined;
                     const adjustment = await promotion.apply(ctx, { orderLine: line }, state);
                     if (adjustment) {
                         line.addAdjustment(adjustment);


### PR DESCRIPTION
# Description
To address the issue mentioned in the previous PR, I modified the return type of the `execute` method in `PromotionItemAction` to return either a `Number` or `ExecutePromotionActionResult`, allowing the inclusion of `discountMode`.

However, to maintain code consistency, I have added `PromotionLineAction` and adjusted all `PromotionActions` to return a `Number` type.

Other tasks follow the contents of the attached previous PR.

- [Issue](https://github.com/vendure-ecommerce/vendure/issues/2956)
- [Previous PR](https://github.com/vendure-ecommerce/vendure/pull/2964)

# Checklist

📌 Always:
- [X] I have set a clear title
- [X] My PR is small and contains a single feature
- [X] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [X] I have added or updated test cases
- [ ] I have updated the README if needed
