### PR TITLE
Docs: `requireVerification=true` does accept password

### DIFF
--- a/packages/core/src/config/vendure-config.ts
+++ b/packages/core/src/config/vendure-config.ts
@@ -402,7 +402,7 @@ export interface AuthOptions {
      * Determines whether new User accounts require verification of their email address.
      *
      * If set to "true", the customer will be required to verify their email address using a verification token
-     * they receive in their email. See {@link registerCustomerAccount}.
+     * they receive in their email. See the `registerCustomerAccount` mutation for more details on the verification behavior.
      *
      * @default true
      */

--- a/packages/core/src/config/vendure-config.ts
+++ b/packages/core/src/config/vendure-config.ts
@@ -401,9 +401,8 @@ export interface AuthOptions {
      * @description
      * Determines whether new User accounts require verification of their email address.
      *
-     * If set to "true", when registering via the `registerCustomerAccount` mutation, one should *not* set the
-     * `password` property - doing so will result in an error. Instead, the password is set at a later stage
-     * (once the email with the verification token has been opened) via the `verifyCustomerAccount` mutation.
+     * If set to "true", the customer will be required to verify their email address using a verification token
+     * they receive in their email. See {@link registerCustomerAccount}.
      *
      * @default true
      */


### PR DESCRIPTION
# Description

The [requireVerification docs](https://docs.vendure.io/reference/typescript-api/auth/auth-options#requireverification) are conflicting with the [registerCustomerAccount docs](https://docs.vendure.io/reference/graphql-api/shop/mutations#registercustomeraccount)

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [ ] I have added or updated test cases
- [x] I have updated the README if needed
