### PR TITLE
fix(admin-ui): Change max height to min height for channel assignment block

### DIFF
--- a/packages/admin-ui/src/lib/catalog/src/components/product-detail/product-detail.component.scss
+++ b/packages/admin-ui/src/lib/catalog/src/components/product-detail/product-detail.component.scss
@@ -53,7 +53,7 @@ vdr-action-bar clr-toggle-wrapper {
 
 .channel-assignment {
     flex-wrap: wrap;
-    min-height: 144px;
+    min-height: 24px;
 }
 
 .pagination-row {

--- a/packages/admin-ui/src/lib/catalog/src/components/product-detail/product-detail.component.scss
+++ b/packages/admin-ui/src/lib/catalog/src/components/product-detail/product-detail.component.scss
@@ -53,7 +53,7 @@ vdr-action-bar clr-toggle-wrapper {
 
 .channel-assignment {
     flex-wrap: wrap;
-    max-height: 144px;
+    min-height: 144px;
 }
 
 .pagination-row {


### PR DESCRIPTION
# Description

Updated the block height for the Channel block `.channel-assignment`. Because there was a fixed height there, a large number of channels simply did not fit and the button to add new channels was hidden

# Breaking changes

Does this PR include any breaking changes we should be aware of?
* no

# Screenshots
Before
<img width="1797" alt="image" src="https://github.com/user-attachments/assets/77e2ec3e-099d-4cd1-ac27-db1bf3ebebab">
After
<img width="1711" alt="image" src="https://github.com/user-attachments/assets/1c919def-5850-4c38-8776-24a3464b0520">

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [ ] I have added or updated test cases
- [ ] I have updated the README if needed
