### PR TITLE
Fix: solve a empty order line with discount modification NaN error

### DIFF
--- a/packages/core/e2e/order-modification.e2e-spec.ts
+++ b/packages/core/e2e/order-modification.e2e-spec.ts
@@ -482,73 +482,6 @@ describe('Order modification', () => {
             expect(modifyOrder.errorCode).toBe(ErrorCode.ORDER_LIMIT_ERROR);
             await assertOrderIsUnchanged(order!);
         });
-
-        it('adjustOrderLines empty quantity with discounts', async () => {
-            const PercentDiscount15Percent = '15PERCENT';
-            await adminClient.query<
-                Codegen.CreatePromotionMutation,
-                Codegen.CreatePromotionMutationVariables
-            >(CREATE_PROMOTION, {
-                input: {
-                    enabled: true,
-                    couponCode: PercentDiscount15Percent,
-                    conditions: [
-                        {
-                            code: 'minimum_order_amount',
-                            arguments: [
-                                {
-                                    name: 'amount',
-                                    value: '0',
-                                },
-                                {
-                                    name: 'taxInclusive',
-                                    value: 'false',
-                                },
-                            ],
-                        },
-                    ],
-                    actions: [
-                        {
-                            code: orderPercentageDiscount.code,
-                            arguments: [{ name: 'discount', value: '50' }],
-                        },
-                    ],
-                    translations: [{ languageCode: LanguageCode.en, name: 'half price' }],
-                },
-            });
-            await shopClient.asUserWithCredentials('trevor_donnelly96@hotmail.com', 'test');
-            await shopClient.query(gql(ADD_ITEM_TO_ORDER_WITH_CUSTOM_FIELDS), {
-                productVariantId: 'T_1',
-                quantity: 1,
-            } as any);
-            await shopClient.query(gql(ADD_ITEM_TO_ORDER_WITH_CUSTOM_FIELDS), {
-                productVariantId: 'T_2',
-                quantity: 1,
-            } as any);
-
-            await proceedToArrangingPayment(shopClient);
-            const order = await addPaymentToOrder(shopClient, testSuccessfulPaymentMethod);
-            orderGuard.assertSuccess(order);
-
-            const transitionOrderToState = await adminTransitionOrderToState(order.id, 'Modifying');
-            orderGuard.assertSuccess(transitionOrderToState);
-
-            expect(transitionOrderToState.state).toBe('Modifying');
-
-            const { modifyOrder } = await adminClient.query<
-                Codegen.ModifyOrderMutation,
-                Codegen.ModifyOrderMutationVariables
-            >(MODIFY_ORDER, {
-                input: {
-                    dryRun: true,
-                    orderId: order.id,
-                    couponCodes: [PercentDiscount15Percent],
-                    adjustOrderLines: [{ orderLineId: order.lines[0].id, quantity: 0 }],
-                },
-            });
-            orderGuard.assertSuccess(modifyOrder);
-            expect(modifyOrder.lines.map(line => line.discounts).flat().length).toBe(2);
-        });
     });
 
     describe('dry run', () => {
@@ -2527,6 +2460,69 @@ describe('Order modification', () => {
             expect(modifyOrder.shippingWithTax).toBe(0);
             expect(modifyOrder.totalWithTax).toBe(getOrderPaymentsTotalWithRefunds(modifyOrder));
             expect(modifyOrder.payments![0].refunds[0].total).toBe(shippingWithTax);
+        });
+
+        it('adjustOrderLines empty quantity with discounts', async () => {
+            const PercentDiscount50Percent = '50PERCENT';
+            await adminClient.query<
+                Codegen.CreatePromotionMutation,
+                Codegen.CreatePromotionMutationVariables
+            >(CREATE_PROMOTION, {
+                input: {
+                    enabled: true,
+                    couponCode: PercentDiscount50Percent,
+                    conditions: [
+                        {
+                            code: 'minimum_order_amount',
+                            arguments: [
+                                { name: 'amount', value: '0' },
+                                { name: 'taxInclusive', value: 'false' },
+                            ],
+                        },
+                    ],
+                    actions: [
+                        {
+                            code: orderPercentageDiscount.code,
+                            arguments: [{ name: 'discount', value: '50' }],
+                        },
+                    ],
+                    translations: [{ languageCode: LanguageCode.en, name: 'half price' }],
+                },
+            });
+            await shopClient.asUserWithCredentials('trevor_donnelly96@hotmail.com', 'test');
+            await shopClient.query(gql(ADD_ITEM_TO_ORDER_WITH_CUSTOM_FIELDS), {
+                productVariantId: 'T_1',
+                quantity: 1,
+            } as any);
+            await shopClient.query(gql(ADD_ITEM_TO_ORDER_WITH_CUSTOM_FIELDS), {
+                productVariantId: 'T_2',
+                quantity: 1,
+            } as any);
+
+            await proceedToArrangingPayment(shopClient);
+            const paidOrder = await addPaymentToOrder(shopClient, testSuccessfulPaymentMethod);
+            orderGuard.assertSuccess(paidOrder);
+
+            const transitionOrderToState = await adminTransitionOrderToState(paidOrder.id, 'Modifying');
+            orderGuard.assertSuccess(transitionOrderToState);
+
+            expect(transitionOrderToState.state).toBe('Modifying');
+
+            // modify order should not throw an error when setting quantity to 0 for a order line
+            const { modifyOrder } = await adminClient.query<
+                Codegen.ModifyOrderMutation,
+                Codegen.ModifyOrderMutationVariables
+            >(MODIFY_ORDER, {
+                input: {
+                    dryRun: true,
+                    orderId: order.id,
+                    couponCodes: [PercentDiscount50Percent],
+                    adjustOrderLines: [{ orderLineId: order.lines[0].id, quantity: 0 }],
+                },
+            });
+
+            orderGuard.assertSuccess(modifyOrder);
+            expect(modifyOrder.id).toBeDefined();
         });
     });
 

--- a/packages/core/e2e/order-modification.e2e-spec.ts
+++ b/packages/core/e2e/order-modification.e2e-spec.ts
@@ -2523,6 +2523,15 @@ describe('Order modification', () => {
 
             orderGuard.assertSuccess(modifyOrder);
             expect(modifyOrder.id).toBeDefined();
+
+            // ensure correct adjustments applied
+            // The first line should have a linePrice of 0 because it has zero quantity
+            expect(modifyOrder.lines[0].linePriceWithTax).toBe(0);
+            expect(modifyOrder.lines[0].proratedLinePriceWithTax).toBe(0);
+            // The second line should have the proratedLinePriceWithTax discounted per the promotion
+            expect(modifyOrder.lines[1].proratedLinePriceWithTax).toBe(
+                modifyOrder.lines[1].discountedLinePriceWithTax / 2,
+            );
         });
     });
 

--- a/packages/core/src/service/helpers/order-calculator/order-calculator.ts
+++ b/packages/core/src/service/helpers/order-calculator/order-calculator.ts
@@ -253,7 +253,7 @@ export class OrderCalculator {
                             .map(l => l.proratedLinePriceWithTax);
                         const distribution = prorate(weights, amount);
                         order.lines.forEach((line, i) => {
-                            const shareOfAmount = distribution[i];
+                            const shareOfAmount = distribution[i] ?? 0;
                             const itemWeights = Array.from({
                                 length: line.quantity,
                             }).map(() => line.unitPrice);

--- a/packages/core/src/service/helpers/order-calculator/order-calculator.ts
+++ b/packages/core/src/service/helpers/order-calculator/order-calculator.ts
@@ -248,12 +248,12 @@ export class OrderCalculator {
                     const adjustment = await promotion.apply(ctx, { order }, state);
                     if (adjustment && adjustment.amount !== 0) {
                         const amount = adjustment.amount;
-                        const weights = order.lines
-                            .filter(l => l.quantity !== 0)
-                            .map(l => l.proratedLinePriceWithTax);
+                        const weights = order.lines.map(l =>
+                            l.quantity !== 0 ? l.proratedLinePriceWithTax : 0,
+                        );
                         const distribution = prorate(weights, amount);
                         order.lines.forEach((line, i) => {
-                            const shareOfAmount = distribution[i] ?? 0;
+                            const shareOfAmount = distribution[i];
                             const itemWeights = Array.from({
                                 length: line.quantity,
                             }).map(() => line.unitPrice);


### PR DESCRIPTION
# Description

Please include a summary of the changes and the related issue.
This PR solves https://github.com/vendure-ecommerce/vendure/issues/3008, where there's an order level discount and we are updating the order to remove an order line by setting the quantity to 0. Currently, it throws a NaN error.

The solution is just to have a fallback of 0, when the `distribution[i]` returns undefined.





# Breaking changes

Does this PR include any breaking changes we should be aware of?
should not break existing functionality.



# Screenshots

### Note: I'm not sure why this test failed on my local machine, my changes shouldn't affect this test
<img width="846" alt="image" src="https://github.com/user-attachments/assets/d040b5c1-b515-45d3-a302-0fe643f1ca7e">


# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [x] I have added or updated test cases
- [x] I have updated the README if needed
