### PR TITLE
Update DefaultMoneyStrategy.round() Logic

### DIFF
--- a/packages/core/src/config/entity/default-money-strategy.ts
+++ b/packages/core/src/config/entity/default-money-strategy.ts
@@ -1,6 +1,5 @@
 import { ColumnOptions } from 'typeorm';
 
-import { Logger } from '../logger/vendure-logger';
 
 import { MoneyStrategy } from './money-strategy';
 
@@ -19,6 +18,6 @@ export class DefaultMoneyStrategy implements MoneyStrategy {
     readonly precision: number = 2;
 
     round(value: number, quantity = 1): number {
-        return Math.round(value) * quantity;
+        return Math.round(value * quantity);
     }
 }

--- a/packages/core/src/config/entity/money-strategy.ts
+++ b/packages/core/src/config/entity/money-strategy.ts
@@ -88,7 +88,7 @@ export interface MoneyStrategy extends InjectableStrategy {
      * in the {@link DefaultMoneyStrategy} is to round the value, then multiply.
      *
      * ```ts
-     * return Math.round(value) * quantity;
+     * return Math.round(value * quantity);
      * ```
      *
      * However, it may be desirable to instead round only _after_ the unit amount has been


### PR DESCRIPTION
# Description

This PR modifies the DefaultMoneyStrategy.round() method to implement the updated rounding logic as discussed in https://github.com/vendure-ecommerce/vendure/issues/3003. The changes aim to improve the accuracy and consistency of the rounding behavior.

# Breaking changes

NO

# Screenshots

Before: 
![image](https://github.com/user-attachments/assets/d3f8c762-f863-4d8b-88a8-b89cdfd32d08)

Now: 
![image](https://github.com/user-attachments/assets/0bc102e5-2f40-4092-abe7-20fae67407d2)


# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [ ] I have added or updated test cases
- [ ] I have updated the README if needed
