### PR TITLE
fix(default-search-plugin): Fix channels swapping and not swapping back in saveVariants when working with multiple channels

### DIFF
--- a/packages/core/src/plugin/default-search-plugin/indexer/indexer.controller.ts
+++ b/packages/core/src/plugin/default-search-plugin/indexer/indexer.controller.ts
@@ -405,7 +405,9 @@ export class IndexerController {
         await this.removeSyntheticVariants(ctx, variants);
         const productMap = new Map<ID, Product>();
 
+        const originalChannel = ctx.channel;
         for (const variant of variants) {
+            ctx.setChannel(originalChannel);
             let product = productMap.get(variant.productId);
             if (!product) {
                 product = await this.getProductInChannelQueryBuilder(ctx, variant.productId, ctx.channel);
@@ -496,6 +498,7 @@ export class IndexerController {
                 }
             }
         }
+        ctx.setChannel(originalChannel);
 
         await this.queue.push(() =>
             this.connection.getRepository(ctx, SearchIndexItem).save(items, { chunk: 2500 }),


### PR DESCRIPTION
Relates to #3012.

# Description

While indexing variants, a product for a specific variant is queried. However, somewhere in the code the channels are being swapped if multiple channels exist, and they are not being swapped back, which is resulting in the product not being found for that channel as they don't exist, which is making the indexing fail. that's why I have added a line in the code that swaps the channels back to the original one at the start of every loop, and a line at the end of the loop.
