### PR TITLE
docs(testing): Fix incorrect docs for resolving port conflict in e2e test.

### DIFF
--- a/docs/docs/guides/developer-guide/testing/index.md
+++ b/docs/docs/guides/developer-guide/testing/index.md
@@ -195,21 +195,24 @@ All that's left is to run your tests to find out whether your code behaves as ex
 
 :::caution
 **Note:** When using **Vitest** with multiple test suites (multiple `.e2e-spec.ts` files), it will attempt to run them in parallel. If all the test servers are running
-on the same port (the default in the `testConfig` is `3050`), then this will cause a port conflict. To avoid this, you can manually set a unique port for each test suite:
+on the same port (the default in the `testConfig` is `3050`), then this will cause a port conflict. To avoid this, you can manually set a unique port for each test suite. Be aware that `mergeConfig` is used here:
 
 ```ts title="src/plugins/my-plugin/e2e/my-plugin.e2e-spec.ts"
 import { createTestEnvironment, testConfig } from '@vendure/testing';
+import { mergeConfig } from "@vendure/core";
 import { describe } from 'vitest';
 import { MyPlugin } from '../my-plugin.ts';
 
 describe('my plugin', () => {
 
-    const {server, adminClient, shopClient} = createTestEnvironment({
-        ...testConfig,
-        // highlight-next-line
-        port: 3051,
+    const {server, adminClient, shopClient} = createTestEnvironment(mergeConfig(testConfig, {
+        // highlight-start
+        apiOptions: {
+            port: 3051,
+        },
+        // highlight-end
         plugins: [MyPlugin],
-    });
+    }));
 
 });
 ```


### PR DESCRIPTION
# Description

Fix incorrect docs for resolving port conflict in e2e test.

# Breaking changes

No

# Screenshots

Just document error fix

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [ ] I have added or updated test cases
- [ ] I have updated the README if needed