### PR TITLE
fix: Handle empty state for product and variant id filter of collections

### DIFF
--- a/packages/core/src/config/catalog/default-collection-filters.ts
+++ b/packages/core/src/config/catalog/default-collection-filters.ts
@@ -212,15 +212,19 @@ export const variantIdCollectionFilter = new CollectionFilter({
     code: 'variant-id-filter',
     description: [{ languageCode: LanguageCode.en, value: 'Manually select product variants' }],
     apply: (qb, args) => {
-        if (args.variantIds.length === 0) {
-            return qb;
-        }
+        const emptyIds = args.variantIds.length === 0;
         const variantIdsKey = randomSuffix('variantIds');
         const clause = `productVariant.id IN (:...${variantIdsKey})`;
         const params = { [variantIdsKey]: args.variantIds };
         if (args.combineWithAnd === false) {
+            if (emptyIds) {
+                return qb;
+            }
             return qb.orWhere(clause, params);
         } else {
+            if (emptyIds) {
+                return qb.andWhere('1 = 0');
+            }
             return qb.andWhere(clause, params);
         }
     },
@@ -242,15 +246,19 @@ export const productIdCollectionFilter = new CollectionFilter({
     code: 'product-id-filter',
     description: [{ languageCode: LanguageCode.en, value: 'Manually select products' }],
     apply: (qb, args) => {
-        if (args.productIds.length === 0) {
-            return qb;
-        }
+        const emptyIds = args.productIds.length === 0;
         const productIdsKey = randomSuffix('productIds');
         const clause = `productVariant.productId IN (:...${productIdsKey})`;
         const params = { [productIdsKey]: args.productIds };
         if (args.combineWithAnd === false) {
+            if (emptyIds) {
+                return qb;
+            }
             return qb.orWhere(clause, params);
         } else {
+            if (emptyIds) {
+                return qb.andWhere('1 = 0');
+            }
             return qb.andWhere(clause, params);
         }
     },


### PR DESCRIPTION
# Description

When a collection uses a `product-id-filter` or a `variant-id-filter` and the selected IDs are empty, it gets assigned to every product or product variant in the catalog. 

# Breaking changes

No


# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [ ] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

