### PR TITLE
Check type of durations before passing to 'ms' function

### DIFF
--- a/packages/core/src/service/helpers/verification-token-generator/verification-token-generator.ts
+++ b/packages/core/src/service/helpers/verification-token-generator/verification-token-generator.ts
@@ -28,15 +28,16 @@ export class VerificationTokenGenerator {
      * as specified in the VendureConfig.
      */
     verifyVerificationToken(token: string): boolean {
-        const duration =
-            typeof this.configService.authOptions.verificationTokenDuration === 'string'
-                ? ms(this.configService.authOptions.verificationTokenDuration)
-                : this.configService.authOptions.verificationTokenDuration;
+        const { verificationTokenDuration } = this.configService.authOptions;
+        const verificationTokenDurationInMs =
+            typeof verificationTokenDuration === 'string'
+                ? ms(verificationTokenDuration)
+                : verificationTokenDuration;
 
         const [generatedOn] = token.split('_');
         const dateString = Buffer.from(generatedOn, 'base64').toString();
         const date = new Date(dateString);
         const elapsed = +new Date() - +date;
-        return elapsed < duration;
+        return elapsed < verificationTokenDurationInMs;
     }
 }

--- a/packages/core/src/service/helpers/verification-token-generator/verification-token-generator.ts
+++ b/packages/core/src/service/helpers/verification-token-generator/verification-token-generator.ts
@@ -28,7 +28,11 @@ export class VerificationTokenGenerator {
      * as specified in the VendureConfig.
      */
     verifyVerificationToken(token: string): boolean {
-        const duration = ms(this.configService.authOptions.verificationTokenDuration as string);
+        const duration =
+            typeof this.configService.authOptions.verificationTokenDuration === 'string'
+                ? ms(this.configService.authOptions.verificationTokenDuration)
+                : this.configService.authOptions.verificationTokenDuration;
+
         const [generatedOn] = token.split('_');
         const dateString = Buffer.from(generatedOn, 'base64').toString();
         const date = new Date(dateString);

--- a/packages/core/src/service/services/session.service.ts
+++ b/packages/core/src/service/services/session.service.ts
@@ -37,7 +37,11 @@ export class SessionService implements EntitySubscriberInterface {
         private orderService: OrderService,
     ) {
         this.sessionCacheStrategy = this.configService.authOptions.sessionCacheStrategy;
-        this.sessionDurationInMs = ms(this.configService.authOptions.sessionDuration as string);
+        this.sessionDurationInMs =
+            typeof this.configService.authOptions.sessionDuration === 'string'
+                ? ms(this.configService.authOptions.sessionDuration)
+                : this.configService.authOptions.sessionDuration;
+
         // This allows us to register this class as a TypeORM Subscriber while also allowing
         // the injection on dependencies. See https://docs.nestjs.com/techniques/database#subscribers
         this.connection.rawConnection.subscribers.push(this);

--- a/packages/core/src/service/services/session.service.ts
+++ b/packages/core/src/service/services/session.service.ts
@@ -37,10 +37,10 @@ export class SessionService implements EntitySubscriberInterface {
         private orderService: OrderService,
     ) {
         this.sessionCacheStrategy = this.configService.authOptions.sessionCacheStrategy;
+
+        const { sessionDuration } = this.configService.authOptions;
         this.sessionDurationInMs =
-            typeof this.configService.authOptions.sessionDuration === 'string'
-                ? ms(this.configService.authOptions.sessionDuration)
-                : this.configService.authOptions.sessionDuration;
+            typeof sessionDuration === 'string' ? ms(sessionDuration) : sessionDuration;
 
         // This allows us to register this class as a TypeORM Subscriber while also allowing
         // the injection on dependencies. See https://docs.nestjs.com/techniques/database#subscribers


### PR DESCRIPTION
# Description

Check if the type of `authOptions.sessionDuration` and `authOptions.verificationTokenDuration` is `string` before passing the values to the `ms` function for conversion from a string expression to milliseconds (number). If the type is not a string, it is already expected to be milliseconds so can be used right away.

Fixes #3078 

# Breaking changes

No breaking changes.

# Screenshots

Not applicable.

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [ ] I have added or updated test cases
- [ ] I have updated the README if needed
