### PR TITLE
Enhance AuthOptions.sessionCacheTTL by allowing string expressions (zeit/ms)

### DIFF
--- a/docs/docs/reference/typescript-api/auth/auth-options.md
+++ b/docs/docs/reference/typescript-api/auth/auth-options.md
@@ -78,7 +78,7 @@ Sets the header property which will be used to send the auth token when using th
 Session duration, i.e. the time which must elapse from the last authenticated request
 after which the user must re-authenticate.
 
-Expressed as a string describing a time span per
+If passed as a number should represent milliseconds and if passed as a string describes a time span per
 [zeit/ms](https://github.com/zeit/ms.js).  Eg: `60`, `'2 days'`, `'10h'`, `'7d'`
 ### sessionCacheStrategy
 
@@ -110,7 +110,7 @@ they receive in their email. See the `registerCustomerAccount` mutation for more
 
 Sets the length of time that a verification token is valid for, after which the verification token must be refreshed.
 
-Expressed as a string describing a time span per
+If passed as a number should represent milliseconds and if passed as a string describes a time span per
 [zeit/ms](https://github.com/zeit/ms.js).  Eg: `60`, `'2 days'`, `'10h'`, `'7d'`
 ### superadminCredentials
 

--- a/docs/docs/reference/typescript-api/auth/auth-options.md
+++ b/docs/docs/reference/typescript-api/auth/auth-options.md
@@ -89,11 +89,13 @@ in-memory caching strategy which is suitable for development and low-traffic, si
 deployments.
 ### sessionCacheTTL
 
-<MemberInfo kind="property" type={`number`} default={`300`}   />
+<MemberInfo kind="property" type={`string | number`} default={`300`} />
 
-The "time to live" of a given item in the session cache. This determines the length of time (in seconds)
-that a cache entry is kept before being considered "stale" and being replaced with fresh data
-taken from the database.
+The "time to live" of a given item in the session cache. This determines the length of time that a cache entry 
+is kept before being considered "stale" and being replaced with fresh data taken from the database.
+
+If passed as a number should represent seconds and if passed as a string describes a time span per
+[zeit/ms](https://github.com/zeit/ms.js). Eg: `60`, `'2 days'`, `'10h'`, `'7d'`
 ### requireVerification
 
 <MemberInfo kind="property" type={`boolean`} default={`true`}   />

--- a/packages/core/src/config/vendure-config.ts
+++ b/packages/core/src/config/vendure-config.ts
@@ -374,7 +374,7 @@ export interface AuthOptions {
      * Session duration, i.e. the time which must elapse from the last authenticated request
      * after which the user must re-authenticate.
      *
-     * Expressed as a string describing a time span per
+     * If passed as a number should represent milliseconds and if passed as a string describes a time span per
      * [zeit/ms](https://github.com/zeit/ms.js).  Eg: `60`, `'2 days'`, `'10h'`, `'7d'`
      *
      * @default '1y'
@@ -414,7 +414,7 @@ export interface AuthOptions {
      * @description
      * Sets the length of time that a verification token is valid for, after which the verification token must be refreshed.
      *
-     * Expressed as a string describing a time span per
+     * If passed as a number should represent milliseconds and if passed as a string describes a time span per
      * [zeit/ms](https://github.com/zeit/ms.js).  Eg: `60`, `'2 days'`, `'10h'`, `'7d'`
      *
      * @default '7d'

--- a/packages/core/src/config/vendure-config.ts
+++ b/packages/core/src/config/vendure-config.ts
@@ -391,13 +391,15 @@ export interface AuthOptions {
     sessionCacheStrategy?: SessionCacheStrategy;
     /**
      * @description
-     * The "time to live" of a given item in the session cache. This determines the length of time (in seconds)
-     * that a cache entry is kept before being considered "stale" and being replaced with fresh data
-     * taken from the database.
+     * The "time to live" of a given item in the session cache. This determines the length of time that a cache entry
+     * is kept before being considered "stale" and being replaced with fresh data taken from the database.
+     *
+     * If passed as a number should represent seconds and if passed as a string describes a time span per
+     * [zeit/ms](https://github.com/zeit/ms.js). Eg: `60`, `'2 days'`, `'10h'`, `'7d'`
      *
      * @default 300
      */
-    sessionCacheTTL?: number;
+    sessionCacheTTL?: string | number;
     /**
      * @description
      * Determines whether new User accounts require verification of their email address.

--- a/packages/core/src/service/services/session.service.ts
+++ b/packages/core/src/service/services/session.service.ts
@@ -146,8 +146,11 @@ export class SessionService implements EntitySubscriberInterface {
      * Serializes a {@link Session} instance into a simplified plain object suitable for caching.
      */
     serializeSession(session: AuthenticatedSession | AnonymousSession): CachedSession {
-        const expiry =
-            Math.floor(new Date().getTime() / 1000) + this.configService.authOptions.sessionCacheTTL;
+        const { sessionCacheTTL } = this.configService.authOptions;
+        const sessionCacheTTLSeconds =
+            typeof sessionCacheTTL === 'string' ? ms(sessionCacheTTL) / 1000 : sessionCacheTTL;
+
+        const expiry = Math.floor(new Date().getTime() / 1000) + sessionCacheTTLSeconds;
         const serializedSession: CachedSession = {
             cacheExpiry: expiry,
             id: session.id,

--- a/packages/core/src/service/services/session.service.ts
+++ b/packages/core/src/service/services/session.service.ts
@@ -150,7 +150,7 @@ export class SessionService implements EntitySubscriberInterface {
         const sessionCacheTTLSeconds =
             typeof sessionCacheTTL === 'string' ? ms(sessionCacheTTL) / 1000 : sessionCacheTTL;
 
-        const expiry = Math.floor(new Date().getTime() / 1000) + sessionCacheTTLSeconds;
+        const expiry = new Date().getTime() / 1000 + sessionCacheTTLSeconds;
         const serializedSession: CachedSession = {
             cacheExpiry: expiry,
             id: session.id,


### PR DESCRIPTION
# Description

- Support string expressions (as per `zeit/ms`) for `AuthOptions.sessionCacheTTL` just like for `sessionDuration` and `verificationTokenDuration` (conversion result needs to be divided by 1000 to receive seconds)

- Update documentation and jsDoc to better explain how these properties can be supplied as numbers (seconds/milliseconds) or string expressions (as per `zeit/ms`)

# Breaking changes

No

# Screenshots

Not applicable.

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [ ] I have added or updated test cases
- [ ] I have updated the README if needed
