### PR TITLE
fix: solve incorrect type when dealing with value in list

### DIFF
--- a/packages/admin-ui/src/lib/core/src/shared/dynamic-form-inputs/dynamic-form-input/dynamic-form-input.component.ts
+++ b/packages/admin-ui/src/lib/core/src/shared/dynamic-form-inputs/dynamic-form-input/dynamic-form-input.component.ts
@@ -187,6 +187,12 @@ export class DynamicFormInputComponent
         if (this.listItems) {
             for (const item of this.listItems) {
                 if (item.componentRef) {
+                    const { value } = item.control;
+                    const { type } = item.componentRef.instance.config || {};
+                    // fix a bug where the list item of string turns into number which lead to unexpected behavior
+                    if (typeof value === 'number' && type === 'string') {
+                        item.control.setValue(item.control.value?.toString(), { emitEvent: false });
+                    }
                     this.updateBindings(changes, item.componentRef);
                 }
             }
@@ -280,7 +286,7 @@ export class DynamicFormInputComponent
                         ({
                             id: this.listId++,
                             control: new UntypedFormControl(getConfigArgValue(value)),
-                        } as InputListItem),
+                        }) as InputListItem,
                 );
                 this.renderList$.next();
             }

--- a/packages/admin-ui/src/lib/core/src/shared/dynamic-form-inputs/dynamic-form-input/dynamic-form-input.component.ts
+++ b/packages/admin-ui/src/lib/core/src/shared/dynamic-form-inputs/dynamic-form-input/dynamic-form-input.component.ts
@@ -191,7 +191,7 @@ export class DynamicFormInputComponent
                     const { type } = item.componentRef.instance.config || {};
                     // fix a bug where the list item of string turns into number which lead to unexpected behavior
                     if (typeof value === 'number' && type === 'string') {
-                        item.control.setValue(item.control.value?.toString(), { emitEvent: false });
+                        item.control.setValue(item.control.value.toString(), { emitEvent: false });
                     }
                     this.updateBindings(changes, item.componentRef);
                 }

--- a/packages/admin-ui/src/lib/core/src/shared/dynamic-form-inputs/dynamic-form-input/dynamic-form-input.component.ts
+++ b/packages/admin-ui/src/lib/core/src/shared/dynamic-form-inputs/dynamic-form-input/dynamic-form-input.component.ts
@@ -286,7 +286,7 @@ export class DynamicFormInputComponent
                         ({
                             id: this.listId++,
                             control: new UntypedFormControl(getConfigArgValue(value)),
-                        }) as InputListItem,
+                        } as InputListItem),
                 );
                 this.renderList$.next();
             }


### PR DESCRIPTION
# Description

Please include a summary of the changes and the related issues.
This fix solves the [issue 3093](https://github.com/vendure-ecommerce/vendure/issues/3093) where the output coming from the dynamic form input has the wrong type. This lead to weird behaviour when selecting the options and also issue with updating the record on the admin UI.

My fix consists of overriding the value with the correct type, I'm unsure if this is a acceptable solution, but it does solve the issue.

For example. 
I have a list of options from a custom field that contains numbers like calling code.
The options are meant to be strings of options. so it's configured like this
```typescript
{
    name: "supportedNumbers"
    type: "string",
    label: [{ languageCode: LanguageCode.en, value: "Supported Phone Number" }],
    ui: { component: "select-form-input" },
    list: true,
    options: [

        // Usually we get this list from a library, but we 
        // can hard code it for now
        {
            value: "1",
            label: [{ languageCode: LanguageCode.en, value: "US" }]
        },
        {
            value: "60",
            label: [{ languageCode: LanguageCode.en, value: "MY" }]
        },
        {
            value: "61",
            label: [{ languageCode: LanguageCode.en, value: "SG" }]
        }
    ]
}
```
When I select the first option, the output will become like this
```
["1"]
```

The issue arises when my form input is a list, and I want to add the second option, which will cause the first option to turn into a number, so it will become like this
```
[1, "60"].
```

if I change the first input again, it will become like this
```
["61", 60]
```

# Breaking changes

Does this PR include any breaking changes we should be aware of?
I'm not very sure, is there any test that I can run ?

# Screenshots
Before
![image](https://github.com/user-attachments/assets/f7d80940-52dc-4f67-bc1d-c0b2b9d7bd49)
After
![image](https://github.com/user-attachments/assets/8ff7b505-7302-4f51-89f2-5c558b258ec6)

You can add screenshots here if applicable.

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [ ] I have added or updated test cases
- [ ] I have updated the README if needed
