### PR TITLE
refactor(job-queue-plugin): Use multiple BullMQ queues instead of one

### DIFF
--- a/packages/core/src/job-queue/job-queue.service.ts
+++ b/packages/core/src/job-queue/job-queue.service.ts
@@ -54,7 +54,10 @@ export class JobQueueService implements OnModuleDestroy {
         return this.configService.jobQueueOptions.jobQueueStrategy;
     }
 
-    constructor(private configService: ConfigService, private jobBufferService: JobBufferService) {}
+    constructor(
+        private configService: ConfigService,
+        private jobBufferService: JobBufferService,
+    ) {}
 
     /** @internal */
     onModuleDestroy() {
@@ -152,6 +155,13 @@ export class JobQueueService implements OnModuleDestroy {
      */
     flush(...forBuffers: Array<JobBuffer<any> | string>): Promise<Job[]> {
         return this.jobBufferService.flush(forBuffers);
+    }
+
+    /**
+     * @description Returns the raw objects representing the JobQueues.
+     */
+    getRawJobQueues() {
+        return this.queues;
     }
 
     /**


### PR DESCRIPTION
# Description

Refactors the `bullmq-job-queue-strategy` to use a separate BullMQ queue for every Vendure job queue. This should improve the stability and issues with horizontally scaled worker instances.   

Resolves #2419 and #1726

# Breaking changes

There is no breaking change.


# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature

👍 Most of the time:
- [ ] I have added or updated test cases
- [ ] I have updated the README if needed
