### PR TITLE
fix(core): Do not include deleted variants when indexing productInStock

### DIFF
--- a/packages/core/src/plugin/default-search-plugin/indexer/indexer.controller.ts
+++ b/packages/core/src/plugin/default-search-plugin/indexer/indexer.controller.ts
@@ -481,6 +481,7 @@ export class IndexerController {
                                         loadEagerRelations: false,
                                         where: {
                                             productId: variant.productId,
+                                            deletedAt: IsNull(),
                                         },
                                     })
                                     .then(_variants =>


### PR DESCRIPTION
# Description

This fixes https://github.com/vendure-ecommerce/vendure/issues/3109

# Breaking changes

-

# Screenshots

-

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [ ] I have added or updated test cases
- [ ] I have updated the README if needed
