### PR TITLE
fix(default-search-plugin, elasticsearch-plugin) Adding StockMovement…

### DIFF
--- a/license/signatures/version1/cla.json
+++ b/license/signatures/version1/cla.json
@@ -199,6 +199,14 @@
       "created_at": "2024-10-05T13:21:30Z",
       "repoId": 136938012,
       "pullRequestNo": 3110
+    },
+    {
+      "name": "LeftoversTodayAppAdmin",
+      "id": 139936478,
+      "comment_id": 2395622489,
+      "created_at": "2024-10-06T23:06:02Z",
+      "repoId": 136938012,
+      "pullRequestNo": 3112
     }
   ]
 }

--- a/license/signatures/version1/cla.json
+++ b/license/signatures/version1/cla.json
@@ -191,6 +191,14 @@
       "created_at": "2024-09-30T12:27:50Z",
       "repoId": 136938012,
       "pullRequestNo": 3096
+    },
+    {
+      "name": "kyunal",
+      "id": 33372279,
+      "comment_id": 2395056311,
+      "created_at": "2024-10-05T13:21:30Z",
+      "repoId": 136938012,
+      "pullRequestNo": 3110
     }
   ]
 }

--- a/packages/core/src/plugin/default-search-plugin/default-search-plugin.ts
+++ b/packages/core/src/plugin/default-search-plugin/default-search-plugin.ts
@@ -19,6 +19,7 @@ import { JobQueueService } from '../../job-queue/job-queue.service';
 import { PluginCommonModule } from '../plugin-common.module';
 import { VendurePlugin } from '../vendure-plugin';
 
+import { StockMovementEvent } from '../../event-bus/events/stock-movement-event';
 import { stockStatusExtension } from './api/api-extensions';
 import { AdminFulltextSearchResolver, ShopFulltextSearchResolver } from './api/fulltext-search.resolver';
 import { BUFFER_SEARCH_INDEX_UPDATES, PLUGIN_INIT_OPTIONS } from './constants';
@@ -164,6 +165,13 @@ export class DefaultSearchPlugin implements OnApplicationBootstrap, OnApplicatio
                     event.channelId,
                 );
             }
+        });
+
+        this.eventBus.ofType(StockMovementEvent).subscribe(event => {
+            return this.searchIndexService.updateVariants(
+                event.ctx,
+                event.stockMovements.map(m => m.productVariant),
+            );
         });
 
         // TODO: Remove this buffering logic because because we have dedicated buffering based on #1137

--- a/packages/elasticsearch-plugin/src/plugin.ts
+++ b/packages/elasticsearch-plugin/src/plugin.ts
@@ -15,6 +15,7 @@ import {
     ProductVariantChannelEvent,
     ProductVariantEvent,
     SearchJobBufferService,
+    StockMovementEvent,
     TaxRateModificationEvent,
     Type,
     VendurePlugin,
@@ -347,6 +348,13 @@ export class ElasticsearchPlugin implements OnApplicationBootstrap {
                     event.channelId,
                 );
             }
+        });
+
+        this.eventBus.ofType(StockMovementEvent).subscribe(event => {
+            return this.elasticsearchIndexService.updateVariants(
+                event.ctx,
+                event.stockMovements.map(m => m.productVariant),
+            );
         });
 
         // TODO: Remove this buffering logic because because we have dedicated buffering based on #1137


### PR DESCRIPTION
Adding StockMovementEvent to search

# Description

Using ElasticSearch or the defaultsearch plugin as the search backend and when I use Stripe Plugin to successfully complete a purchase, the search index for that product variant is not updated. As a result, the search results still have the inStock value set to true and shows an out of stock item in the search results. The products API shows the correct stock level immediately after the transaction and when the stock is allocated.

https://github.com/vendure-ecommerce/vendure/issues/3066

# Breaking changes

Does this PR include any breaking changes we should be aware of?
No, it does not have any breaking changes.

# Screenshots

You can add screenshots here if applicable.
![image](https://github.com/user-attachments/assets/350a4db7-f419-435a-b23a-6b1ee137cd71)
![image](https://github.com/user-attachments/assets/b9709552-5ffb-4a5d-a618-ab9991b4a7c9)

# Checklist

📌 Always:
[✅] I have set a clear title
[✅] My PR is small and contains a single feature
[✅] I have [checked my own PR](https://github.com/vendure-ecommerce/vendure/pull/3112##)

👍 Most of the time:
- [ ] I have added or updated test cases
- [ ] I have updated the README if needed
