### PR TITLE
fix(core): Deprecation of `lines`, `shipping` and `adjustment` fields in the `RefundOrderInput` input.

### DIFF
--- a/packages/core/src/api/schema/admin-api/order.api.graphql
+++ b/packages/core/src/api/schema/admin-api/order.api.graphql
@@ -111,14 +111,12 @@ input CancelOrderInput {
 }
 
 input RefundOrderInput {
-    lines: [OrderLineInput!]!
-    shipping: Money!
-    adjustment: Money!
+    lines: [OrderLineInput!] @deprecated(reason: "Use the `amount` field instead")
+    shipping: Money @deprecated(reason: "Use the `amount` field instead")
+    adjustment: Money @deprecated(reason: "Use the `amount` field instead")
     """
-    If an amount is specified, this value will be used to create a Refund rather than calculating the
-    amount automatically. This was added in v2.2 and will be the preferred way to specify the refund
-    amount in the future. The `lines`, `shipping` and `adjustment` fields will likely be removed in a future
-    version.
+    The amount to be refunded to this particular payment. This was introduced in v2.2.0 as the preferred way to specify the refund amount.
+    Can be as much as the total amount of the payment minus the sum of all previous refunds.
     """
     amount: Money
     paymentId: ID!
@@ -410,13 +408,13 @@ type ManualPaymentStateError implements ErrorResult {
 
 union TransitionOrderToStateResult = Order | OrderStateTransitionError
 union SettlePaymentResult =
-      Payment
+    | Payment
     | SettlePaymentError
     | PaymentStateTransitionError
     | OrderStateTransitionError
 union CancelPaymentResult = Payment | CancelPaymentError | PaymentStateTransitionError
 union AddFulfillmentToOrderResult =
-      Fulfillment
+    | Fulfillment
     | EmptyOrderLineSelectionError
     | ItemsAlreadyFulfilledError
     | InsufficientStockOnHandError
@@ -424,14 +422,14 @@ union AddFulfillmentToOrderResult =
     | FulfillmentStateTransitionError
     | CreateFulfillmentError
 union CancelOrderResult =
-      Order
+    | Order
     | EmptyOrderLineSelectionError
     | QuantityTooGreatError
     | MultipleOrderError
     | CancelActiveOrderError
     | OrderStateTransitionError
 union RefundOrderResult =
-      Refund
+    | Refund
     | QuantityTooGreatError
     | NothingToRefundError
     | OrderStateTransitionError
@@ -445,7 +443,7 @@ union SettleRefundResult = Refund | RefundStateTransitionError
 union TransitionFulfillmentToStateResult = Fulfillment | FulfillmentStateTransitionError
 union TransitionPaymentToStateResult = Payment | PaymentStateTransitionError
 union ModifyOrderResult =
-      Order
+    | Order
     | NoChangesSpecifiedError
     | OrderModificationStateError
     | PaymentMethodMissingError


### PR DESCRIPTION
# Description

During the refund implementation in my PayPal integration, I noticed that the `RefundOrderInput` can be a little bit confusing for new developers. At first I did not understand how I am able to use the amount instead of the lines, adjustment and shipping properties.

There was no documentation for this specific input, so I reached out to the discord. In my [help thread](https://discord.com/channels/1100672177260478564/1293232023921491999) we came to false conclusions, as we thought it is not possible to just use the `amount` field by itself without `lines` etc.

After some further investigation, I noticed that deprecating the `lines`, `shipping` and `adjustment` fields in the GraphQL schema have no effects on the e2e tests. On this base, I removed those 3 fields and created this PR to make the input less confusing.

I understand that my changes can be a little bit controversial, especially as now no value is required in this input. Sadly I am not experienced enough with GraphQL to say if this is okay if checks still ensure at least one option is set. I understand that the fields may better be changed back.

# Breaking changes

- Deprecation of `lines`, `shipping` and `adjustment` fields in the `RefundOrderInput` input.
- Making the same fields optional and not required anymore.

# Screenshots

You can add screenshots here if applicable.

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [x] I have added or updated test cases
- [x] I have updated the README if needed
