### PR TITLE
Fix broken product image URLs in order confirmation email

### DIFF
--- a/packages/core/src/api/resolvers/admin/order.resolver.ts
+++ b/packages/core/src/api/resolvers/admin/order.resolver.ts
@@ -69,7 +69,15 @@ export class OrderResolver {
         @Relations({ entity: Order, omit: ['aggregateOrder', 'sellerOrders'] })
         relations: RelationPaths<Order>,
     ): Promise<Order | undefined> {
-        return this.orderService.findOne(ctx, args.id, relations);
+        return this.orderService.findOne(ctx, args.id, relations ?? [
+            'lines',
+            'lines.productVariant',
+            'lines.productVariant.productVariantPrices',
+            'lines.featuredAsset', // Add this line
+            'shippingLines',
+            'surcharges',
+            'customer',
+        ]);
     }
 
     @Transaction()

--- a/packages/core/src/service/services/order.service.ts
+++ b/packages/core/src/service/services/order.service.ts
@@ -1678,6 +1678,7 @@ export class OrderService {
                 'lines',
                 'lines.productVariant',
                 'lines.productVariant.productVariantPrices',
+                'lines.featuredAsset',
                 'shippingLines',
                 'surcharges',
                 'customer',


### PR DESCRIPTION
Fixes #3130

Update the order service and resolver to include the `lines.featuredAsset` relation.

* **Order Service**
  - Add `lines.featuredAsset` to the relations array in the `findOne` method in `packages/core/src/service/services/order.service.ts`.

* **Order Resolver**
  - Add `lines.featuredAsset` to the relations array in the `order` query in `packages/core/src/api/resolvers/admin/order.resolver.ts`.

