### PR TITLE
Revert "fix: Use default channel in Stripe webhook calls to reach all orders"

### DIFF
--- a/packages/payments-plugin/src/stripe/stripe.controller.ts
+++ b/packages/payments-plugin/src/stripe/stripe.controller.ts
@@ -1,6 +1,5 @@
 import { Controller, Headers, HttpStatus, Post, Req, Res } from '@nestjs/common';
 import type { PaymentMethod, RequestContext } from '@vendure/core';
-import { ChannelService } from '@vendure/core';
 import {
     InternalServerError,
     LanguageCode,
@@ -32,7 +31,6 @@ export class StripeController {
         private stripeService: StripeService,
         private requestContextService: RequestContextService,
         private connection: TransactionalConnection,
-        private channelService: ChannelService,
     ) {}
 
     @Post('stripe')
@@ -59,7 +57,7 @@ export class StripeController {
         const { metadata: { channelToken, orderCode, orderId } = {} } = paymentIntent;
         const outerCtx = await this.createContext(channelToken, request);
 
-        await this.connection.withTransaction(outerCtx, async (ctx: RequestContext) => {
+        await this.connection.withTransaction(outerCtx, async ctx => {
             const order = await this.orderService.findOneByCode(ctx, orderCode);
 
             if (!order) {
@@ -92,13 +90,8 @@ export class StripeController {
             }
 
             if (order.state !== 'ArrangingPayment') {
-                // Orders can switch channels (e.g., global to UK store), causing lookups by the original
-                // channel to fail. Using a default channel avoids "entity-with-id-not-found" errors.
-                // See https://github.com/vendure-ecommerce/vendure/issues/3072
-                const defaultChannel = await this.channelService.getDefaultChannel(ctx);
-                const ctxWithDefaultChannel = await this.createContext(defaultChannel.token, request);
                 const transitionToStateResult = await this.orderService.transitionToState(
-                    ctxWithDefaultChannel,
+                    ctx,
                     orderId,
                     'ArrangingPayment',
                 );


### PR DESCRIPTION
Reverts vendure-ecommerce/vendure#3076

Issue: https://github.com/vendure-ecommerce/vendure/issues/3072

Hello!

Id like to reopen this issue because the above fix is causing issues when using default channel context to switch order state to ArrangingPayment but then using the channel specific context to add a payment method. If the bug is around being able to find the right order number from the correct channel, it should not be using this hack to get around it as it has other unintended consequences.

My scenario: In a multi-vendor marketplace where each store is its own channel the user is shopping within a channel and the cart is only showing items in that channel and only allows for checkouts within the context of that channel.

If the arranging payments part is done with the default context then when Vendure tries to apply the payment method it fails with this error: Error adding payment to order: ORDER_PAYMENT_STATE_ERROR. Doing everything with the channel specific context works correctly without any errors.

```js
const paymentMethod = await this.getPaymentMethod(ctx);
            const addPaymentToOrderResult = await this.orderService.addPaymentToOrder(ctx, orderId, {
                method: paymentMethod.code,
                metadata: {
                    paymentIntentAmountReceived: paymentIntent.amount_received,
                    paymentIntentId: paymentIntent.id,
                },
            });
if (!(addPaymentToOrderResult instanceof core_2.Order)) {
                core_2.Logger.error(`Error adding payment to order ${orderCode}: ${addPaymentToOrderResult.message}`, constants_1.loggerCtx);
                return;
            }
```