### PR TITLE
Fix broken link in example multi-vendor plugin readme

### DIFF
--- a/packages/dev-server/example-plugins/multivendor-plugin/README.md
+++ b/packages/dev-server/example-plugins/multivendor-plugin/README.md
@@ -2,7 +2,7 @@
 
 This is an example plugin which demonstrates how to build a multi-vendor marketplace with Vendure. It uses new APIs and features introduced in Vendure v2.0.
 
-The parts of the plugin are documented with explanations, and the overall guide can be found in the [Multi-vendor marketplace](https://docs.vendure.io/developer-guide/multi-vendor-marketplaces/) section of the Vendure docs.
+The parts of the plugin are documented with explanations, and the overall guide can be found in the [Multi-vendor marketplace](https://docs.vendure.io/guides/how-to/multi-vendor-marketplaces/) section of the Vendure docs.
 
 ## Setup
 


### PR DESCRIPTION
# Description

This fixes the link in the readme for the example multi-vendor plugin.

# Breaking changes

Does this PR include any breaking changes we should be aware of?

No.

# Checklist

📌 Always:
- [X] I have set a clear title
- [X] My PR is small and contains a single feature
- [X] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [ ] I have added or updated test cases
- [X] I have updated the README if needed
