### PR TITLE
fix(core): Fix returning stale data in Role Update Event

### DIFF
--- a/packages/core/src/service/services/role.service.ts
+++ b/packages/core/src/service/services/role.service.ts
@@ -26,7 +26,7 @@ import {
     UserInputError,
 } from '../../common/error/errors';
 import { ListQueryOptions } from '../../common/types/common-types';
-import { assertFound, idsAreEqual } from '../../common/utils';
+import { idsAreEqual } from '../../common/utils';
 import { ConfigService } from '../../config/config.service';
 import { TransactionalConnection } from '../../connection/transactional-connection';
 import { Channel } from '../../entity/channel/channel.entity';
@@ -267,7 +267,7 @@ export class RoleService {
                 input.permissions,
             );
         }
-        const updatedRole = patchEntity(role, {
+        const patchedRole = patchEntity(role, {
             code: input.code,
             description: input.description,
             permissions: input.permissions
@@ -275,11 +275,11 @@ export class RoleService {
                 : undefined,
         });
         if (targetChannels) {
-            updatedRole.channels = targetChannels;
+            patchedRole.channels = targetChannels;
         }
-        await this.connection.getRepository(ctx, Role).save(updatedRole, { reload: false });
-        await this.eventBus.publish(new RoleEvent(ctx, role, 'updated', input));
-        return await assertFound(this.findOne(ctx, role.id));
+        const updatedRole = await this.connection.getRepository(ctx, Role).save(patchedRole);
+        await this.eventBus.publish(new RoleEvent(ctx, updatedRole, 'updated', input));
+        return updatedRole;
     }
 
     async delete(ctx: RequestContext, id: ID): Promise<DeletionResponse> {

--- a/packages/core/src/service/services/role.service.ts
+++ b/packages/core/src/service/services/role.service.ts
@@ -267,7 +267,7 @@ export class RoleService {
                 input.permissions,
             );
         }
-        const patchedRole = patchEntity(role, {
+        patchEntity(role, {
             code: input.code,
             description: input.description,
             permissions: input.permissions
@@ -275,9 +275,9 @@ export class RoleService {
                 : undefined,
         });
         if (targetChannels) {
-            patchedRole.channels = targetChannels;
+            role.channels = targetChannels;
         }
-        await this.connection.getRepository(ctx, Role).save(patchedRole, { reload: false });
+        await this.connection.getRepository(ctx, Role).save(role, { reload: false });
         const updatedRole = await assertFound(this.findOne(ctx, role.id));
         await this.eventBus.publish(new RoleEvent(ctx, updatedRole, 'updated', input));
         return updatedRole;

--- a/packages/core/src/service/services/role.service.ts
+++ b/packages/core/src/service/services/role.service.ts
@@ -277,7 +277,7 @@ export class RoleService {
         if (targetChannels) {
             patchedRole.channels = targetChannels;
         }
-        await this.connection.getRepository(ctx, Role).save(patchedRole);
+        await this.connection.getRepository(ctx, Role).save(patchedRole, { reload: false });
         const updatedRole = await assertFound(this.findOne(ctx, role.id));
         await this.eventBus.publish(new RoleEvent(ctx, updatedRole, 'updated', input));
         return updatedRole;

--- a/packages/core/src/service/services/role.service.ts
+++ b/packages/core/src/service/services/role.service.ts
@@ -26,7 +26,7 @@ import {
     UserInputError,
 } from '../../common/error/errors';
 import { ListQueryOptions } from '../../common/types/common-types';
-import { idsAreEqual } from '../../common/utils';
+import { assertFound, idsAreEqual } from '../../common/utils';
 import { ConfigService } from '../../config/config.service';
 import { TransactionalConnection } from '../../connection/transactional-connection';
 import { Channel } from '../../entity/channel/channel.entity';
@@ -277,7 +277,8 @@ export class RoleService {
         if (targetChannels) {
             patchedRole.channels = targetChannels;
         }
-        const updatedRole = await this.connection.getRepository(ctx, Role).save(patchedRole);
+        await this.connection.getRepository(ctx, Role).save(patchedRole);
+        const updatedRole = await assertFound(this.findOne(ctx, role.id));
         await this.eventBus.publish(new RoleEvent(ctx, updatedRole, 'updated', input));
         return updatedRole;
     }


### PR DESCRIPTION
# Description

Previously it returned `role` which was fetched before(!) applying the update. See definition of `role` in line 253 and then the event bus publishing on line 281. I see that `patchEntity` is mutating the existing object instead of cloning which should be fine for the fields, but then the `updatedAt` is wrong since its not being updated by `patchEntity`. Event subscribers that depend on the `updatedAt` timestamp are receiving a wrong `updatedAt` and or other auto-updated columns.

Also removed the reference returned by `pathEntity` to make it visually clear that it actually mutates the object instead of returning a new one. This way its unambigious.

Note: Have not look at many other services where this might also be the case.

## Question (Edit: solved and reverted)

Edit: Not going through `findOne` fails the `role.e2e-spec.ts` tests so I reverted it. Leaving it for history but the following can be ignored now.

---

I did remove the manual fetch since TypeORM reloads by default. I couldnt come up with an explanation why we are disabling reloading but then refetch manually anyway? I found [the commit](https://github.com/vendure-ecommerce/vendure/commit/3c33f33f94cc582c57934f630cf32d2be15b7afc#diff-34e8cd4891b17e8598f791e633d2500c7e74eef5c6d84fa85150b63213833d12) which disabled the reload 5 years ago but it doesnt make sense to me. The commit says:

> By default, a TypeORM `.save()` operation will also immediately select the saved entity. In the case that the return value is not used, this is redundant and is switched off by passing the `{ reload: false }` option.

Which makes sense, for cases where the return is not used, but in this case we really do want the new value and are refetching it manually via `this.findOne(ctx, role.id)` . Am I missing something? Maybe something with relations? `findOne` does add the `channels` relation in the query but is that relevant? :thinking: 

# Breaking changes

No

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [ ] I have added or updated test cases
- [ ] I have updated the README if needed
