### PR TITLE
fix(core): Fix merging order with conflicting products

### DIFF
--- a/packages/core/e2e/order-merge.e2e-spec.ts
+++ b/packages/core/e2e/order-merge.e2e-spec.ts
@@ -193,6 +193,25 @@ describe('Order merging', () => {
         ).toEqual([{ productVariantId: 'T_5', quantity: 3 }]);
     });
 
+    it('UseGuestStrategy with conflicting lines', async () => {
+        const result = await testMerge({
+            strategy: new UseGuestStrategy(),
+            customerEmailAddress: customers[8].emailAddress,
+            existingOrderLines: [
+                { productVariantId: 'T_7', quantity: 1 },
+                { productVariantId: 'T_8', quantity: 1 },
+            ],
+            guestOrderLines: [{ productVariantId: 'T_8', quantity: 3 }],
+        });
+
+        expect(
+            (result?.lines || []).sort(sortById).map(line => ({
+                productVariantId: line.productVariant.id,
+                quantity: line.quantity,
+            })),
+        ).toEqual([{ productVariantId: 'T_8', quantity: 3 }]);
+    });
+
     it('UseGuestIfExistingEmptyStrategy with empty existing', async () => {
         const result = await testMerge({
             strategy: new UseGuestIfExistingEmptyStrategy(),

--- a/packages/core/src/service/services/order.service.ts
+++ b/packages/core/src/service/services/order.service.ts
@@ -1619,6 +1619,15 @@ export class OrderService {
         if (orderToDelete) {
             await this.deleteOrder(ctx, orderToDelete);
         }
+        if (order && linesToDelete) {
+            const orderId = order.id;
+            for (const line of linesToDelete) {
+                const result = await this.removeItemFromOrder(ctx, orderId, line.orderLineId);
+                if (!isGraphQlErrorResult(result)) {
+                    order = result;
+                }
+            }
+        }
         if (order && linesToInsert) {
             const orderId = order.id;
             for (const line of linesToInsert) {
@@ -1644,15 +1653,6 @@ export class OrderService {
                     line.quantity,
                     line.customFields,
                 );
-                if (!isGraphQlErrorResult(result)) {
-                    order = result;
-                }
-            }
-        }
-        if (order && linesToDelete) {
-            const orderId = order.id;
-            for (const line of linesToDelete) {
-                const result = await this.removeItemFromOrder(ctx, orderId, line.orderLineId);
                 if (!isGraphQlErrorResult(result)) {
                     order = result;
                 }


### PR DESCRIPTION
# Description
Merging the guest with the existing order delete any products that would be in both orders. A relevant test was missing.
[related issue](https://github.com/vendure-ecommerce/vendure/issues/3153)

# Breaking changes

Don't think so but we have to ensure it does not affects other merging strategies.


# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [x] I have added or updated test cases
- [ ] I have updated the README if needed
