### PR TITLE
Fix crash when Administrator has custom field that is `internal` but not `readonly`

### DIFF
--- a/packages/core/src/api/config/__snapshots__/graphql-custom-fields.spec.ts.snap
+++ b/packages/core/src/api/config/__snapshots__/graphql-custom-fields.spec.ts.snap
@@ -250,6 +250,15 @@ scalar JSON
 scalar DateTime"
 `;
 
+exports[`addGraphQLCustomFields() > uses JSON scalar in UpdateActiveAdministratorInput if only internal custom fields defined on Administrator 1`] = `
+"scalar JSON
+
+input UpdateActiveAdministratorInput {
+  placeholder: String
+  customFields: JSON
+}"
+`;
+
 exports[`addOrderLineCustomFieldsInput() > Modifies the schema when the addItemToOrder & adjustOrderLine mutation is present 1`] = `
 "type Mutation {
   addItemToOrder(id: ID!, quantity: Int!, customFields: OrderLineCustomFieldsInput = null): Boolean

--- a/packages/core/src/api/config/graphql-custom-fields.ts
+++ b/packages/core/src/api/config/graphql-custom-fields.ts
@@ -256,7 +256,7 @@ export function addServerConfigCustomFields(
     const customFieldTypeDefs = `
             """
             This type is deprecated in v2.2 in favor of the EntityCustomFields type,
-            which allows custom fields to be defined on user-supplies entities.
+            which allows custom fields to be defined on user-supplied entities.
             """
             type CustomFields {
                 ${Object.keys(customFieldConfig).reduce(
@@ -288,7 +288,9 @@ export function addActiveAdministratorCustomFields(
     administratorCustomFields: CustomFieldConfig[],
 ) {
     const schema = typeof typeDefsOrSchema === 'string' ? buildSchema(typeDefsOrSchema) : typeDefsOrSchema;
-    const writableCustomFields = administratorCustomFields?.filter(field => field.readonly !== true);
+    const writableCustomFields = administratorCustomFields?.filter(
+        field => field.readonly !== true && field.internal !== true,
+    );
     const extension = `
         extend input UpdateActiveAdministratorInput {
             customFields: ${


### PR DESCRIPTION
# Description

This fixes #3158.

Previously, the `addActiveAdministratorCustomFields` function, which adds the custom fields for the Administrator entity into the input type for the `updateActiveAdministrator` mutation, would assume that the `UpdateAdministratorCustomFieldsInput` type exists if there are any non-`readonly` custom fields, even if those custom fields are `internal`. This was incorrect, since `internal` custom fields will not appear in mutation input types, any more than ones that are `readonly`. So, the schema produced would reference that input type, causing a crash if it did not exist, which happened every time there were `internal`, non-`readonly` custom fields.

I also added a test to confirm that the `UpdateAdministratorCustomFieldsInput` type is not referenced when the Administrator entity has only an `internal` custom field.

Also, an irrelevant typo is fixed.

# Breaking changes

Does this PR include any breaking changes we should be aware of?

Nope.

# Checklist

📌 Always:
- [X] I have set a clear title
- [X] My PR is small and contains a single feature
- [X] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [X] I have added or updated test cases
- [ ] I have updated the README if needed
