### PR TITLE
fix(core/utils): Allow null on idsAreEqual function

### DIFF
--- a/packages/core/src/common/utils.ts
+++ b/packages/core/src/common/utils.ts
@@ -35,8 +35,8 @@ export function assertFound<T>(promise: Promise<T | undefined | null>): Promise<
  * Compare ID values for equality, taking into account the fact that they may not be of matching types
  * (string or number).
  */
-export function idsAreEqual(id1?: ID, id2?: ID): boolean {
-    if (id1 === undefined || id2 === undefined) {
+export function idsAreEqual(id1?: ID | null, id2?: ID | null): boolean {
+    if (id1 == null || id2 == null) {
         return false;
     }
     return id1.toString() === id2.toString();


### PR DESCRIPTION
# Description

I've been getting errors when following multivendor example due to this function. ID sometimes seems to be `null` type, causing unexpected errors. This PR adds null support for `idsAreEqual` function to prevent this issue.

# Breaking changes

This PR shouldn't break existing features.

# Screenshots

N/A

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [ ] I have added or updated test cases
- [ ] I have updated the README if needed
