### PR TITLE
feat(admin-ui): Preset filters should preserve query parameters

### DIFF
--- a/packages/admin-ui/src/lib/core/src/shared/components/data-table-filter-presets/data-table-filter-presets.component.html
+++ b/packages/admin-ui/src/lib/core/src/shared/components/data-table-filter-presets/data-table-filter-presets.component.html
@@ -19,7 +19,7 @@
             </div>
             <a
                 [routerLink]="['./']"
-                [queryParams]="preset.value === serializedActiveFilters ? {} : { filters: preset.value, page: 1 }"
+                [queryParams]="getQueryParamsForPreset(preset.value, serializedActiveFilters)"
             >
                 <div>{{ preset.name }}</div>
             </a>

--- a/packages/admin-ui/src/lib/core/src/shared/components/data-table-filter-presets/data-table-filter-presets.component.ts
+++ b/packages/admin-ui/src/lib/core/src/shared/components/data-table-filter-presets/data-table-filter-presets.component.ts
@@ -51,6 +51,28 @@ export class DataTableFilterPresetsComponent implements OnInit, OnDestroy {
         this.filterPresets$ = this.filterPresetService.presetChanges$.pipe(
             startWith(this.filterPresetService.getFilterPresets(this.dataTableId)),
         );
+        // When any query param changes, we want to trigger change detection
+        // so that the links for each preset are updated.
+        this.route.queryParamMap
+            .pipe(takeUntil(this.destroy$))
+            .subscribe(() => this.changeDetectorRef.markForCheck());
+    }
+
+    getQueryParamsForPreset(preset: string, serializedActiveFilters: string): Record<string, string> {
+        // Clone the current query params to avoid mutating them directly
+        const currentParams = { ...this.route.snapshot.queryParams };
+
+        if (preset === serializedActiveFilters) {
+            // Toggling off: remove 'filters' and 'page' params
+            delete currentParams['filters'];
+            delete currentParams['page'];
+        } else {
+            // Toggling on: set 'filters' and 'page' params
+            currentParams['filters'] = preset;
+            currentParams['page'] = 1;
+        }
+
+        return currentParams;
     }
 
     ngOnDestroy() {


### PR DESCRIPTION
# Description

Any page that uses data-table2 with presets, when the presets change they lose any query parameters. This includes the currently set "display per page". This can be very frustrating if you use presets to switch quickly between groups of items which number more than 10 because you have to keep moving down and turning it back up.

This fix causes it to keep any existing query parameters except the "filters" and "page" parameters, which are the ones that it uses.

# Breaking changes

No, just changed behavior

# Screenshots

![image](https://github.com/user-attachments/assets/71341800-3f6a-451d-be4c-1b90a8c2b21c)

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [x] I have added or updated test cases - Not applicable, AFAIK
- [x] I have updated the README if needed - Not applicable, AFAIK
