### PR TITLE
fix(core): It is possible for featuredAsset to resolve to {id: ID}

### DIFF
--- a/packages/core/src/api/resolvers/entity/order-line-entity.resolver.ts
+++ b/packages/core/src/api/resolvers/entity/order-line-entity.resolver.ts
@@ -31,10 +31,13 @@ export class OrderLineEntityResolver {
         @Ctx() ctx: RequestContext,
         @Parent() orderLine: OrderLine,
     ): Promise<Asset | undefined> {
-        if (orderLine.featuredAsset !== undefined) {
-            return orderLine.featuredAsset;
-        } else {
+        // In some scenarios (e.g. modifying an order to add a new item), orderLine.featuredAsset is an object
+        // with only an `id`. Since the resolver expects the featuredAsset to be a full Asset object, we need to
+        // fetch the full Asset object if it's not already populated.
+        if (!orderLine.featuredAsset?.preview) {
             return this.assetService.getFeaturedAsset(ctx, orderLine);
+        } else {
+            return orderLine.featuredAsset;
         }
     }
 


### PR DESCRIPTION
# Description

We experienced an issue with trying to add products to an existing order; when we added a new product which was not previously in the order, the featuredAsset would resolve to an object with an ID and nothing else.  We have this fix locally as a resolver, but it's simple and innocuous enough I thought I'd submit it for your consideration to help others.

If this isn't the right way to do this I apologize; we're still new-ish to this project. Let me know how to do it better and I'll fix it =]

# Breaking changes

None

# Screenshots

N/A

# Checklist

📌 Always:
- [X] I have set a clear title
- [X] My PR is small and contains a single feature
- [X] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [ ] I have added or updated test cases
       - (this might not be a bad idea, but I don't know how to reproduce it with a test case)
- [ ] I have updated the README if needed N/A
