### PR TITLE
fix(core): Disallow deletion of default channel

### DIFF
--- a/packages/core/e2e/channel.e2e-spec.ts
+++ b/packages/core/e2e/channel.e2e-spec.ts
@@ -384,7 +384,7 @@ describe('Channels', () => {
             Codegen.DeleteChannelMutationVariables
         >(DELETE_CHANNEL, { id: defaultChannelId! });
 
-        expect(mutation.deleteChannel.result).toEqual({
+        expect(mutation.deleteChannel).toEqual({
             result: DeletionResult.NOT_DELETED,
             message: 'The default Channel cannot be deleted',
         });

--- a/packages/core/e2e/channel.e2e-spec.ts
+++ b/packages/core/e2e/channel.e2e-spec.ts
@@ -370,6 +370,26 @@ describe('Channels', () => {
         expect(product!.channels.map(c => c.id)).toEqual(['T_1']);
     });
 
+    it('Fail to delete the default channel', async () => {
+        await adminClient.asSuperAdmin();
+
+        const defaultChannelId = (
+            await adminClient.query<Codegen.GetChannelsQuery, Codegen.GetChannelsQueryVariables>(GET_CHANNELS)
+        ).channels.items.find(channel => channel.code === DEFAULT_CHANNEL_CODE)?.id;
+
+        expect(defaultChannelId).not.toBeUndefined();
+
+        const mutation = await adminClient.query<
+            Codegen.DeleteChannelMutation,
+            Codegen.DeleteChannelMutationVariables
+        >(DELETE_CHANNEL, { id: defaultChannelId! });
+
+        expect(mutation.deleteChannel.result).toEqual({
+            result: DeletionResult.NOT_DELETED,
+            message: 'The default Channel cannot be deleted',
+        });
+    });
+
     describe('currencyCode support', () => {
         beforeAll(async () => {
             await adminClient.asSuperAdmin();

--- a/packages/core/src/i18n/messages/de.json
+++ b/packages/core/src/i18n/messages/de.json
@@ -1,6 +1,7 @@
 {
   "error": {
     "cannot-delete-role": "Die Rolle \"{ roleCode }\" kann nicht gelöscht werden",
+    "cannot-delete-default-channel": "Der Standardkanal kann nicht gelöscht werden",
     "cannot-locate-customer-for-user": "Es konnte kein Kunde für den Nutzer gefunden werden",
     "cannot-modify-role": "Die Rolle \"{ roleCode }\" kann nicht geändert werden",
     "cannot-create-sales-for-active-order": "Es kann kein Sale für eine aktive Bestellung erstellt werden",

--- a/packages/core/src/i18n/messages/en.json
+++ b/packages/core/src/i18n/messages/en.json
@@ -4,6 +4,7 @@
     "available-currency-codes-must-include-default": "availableCurrencyCodes must include the defaultCurrencyCode ({ defaultCurrencyCode })",
     "cannot-delete-role": "The role \"{ roleCode }\" cannot be deleted",
     "cannot-delete-sole-superadmin": "The sole SuperAdmin cannot be deleted",
+    "cannot-delete-default-channel": "The default Channel cannot be deleted",
     "cannot-locate-customer-for-user": "Cannot locate a Customer for the user",
     "cannot-modify-role": "The role \"{ roleCode }\" cannot be modified",
     "cannot-move-collection-into-self": "Cannot move a Collection into itself",

--- a/packages/core/src/service/services/channel.service.ts
+++ b/packages/core/src/service/services/channel.service.ts
@@ -457,6 +457,12 @@ export class ChannelService {
 
     async delete(ctx: RequestContext, id: ID): Promise<DeletionResponse> {
         const channel = await this.connection.getEntityOrThrow(ctx, Channel, id);
+        if (channel.code === DEFAULT_CHANNEL_CODE)
+            return {
+                result: DeletionResult.NOT_DELETED,
+                message: ctx.translate('error.cannot-delete-default-channel'),
+            };
+
         const deletedChannel = new Channel(channel);
         await this.connection.getRepository(ctx, Session).delete({ activeChannelId: id });
         await this.connection.getRepository(ctx, Channel).delete(id);


### PR DESCRIPTION
# Description

Deleting the default channel breaks the entire instance since you cant log in anymore.

Fixes #3157 

# Breaking changes

AFAIK none.

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [x] I have added or updated test cases
- [ ] I have updated the README if needed
