### PR TITLE
fix(admin-ui): Make registerPageTab work on 'order-list' location (#3173)

### DIFF
--- a/packages/admin-ui/src/lib/order/src/order.routes.ts
+++ b/packages/admin-ui/src/lib/order/src/order.routes.ts
@@ -7,7 +7,6 @@ export const createRoutes = (pageService: PageService): Route[] => [
     {
         path: '',
         component: PageComponent,
-        pathMatch: 'full',
         data: {
             locationId: 'order-list',
             breadcrumb: _('breadcrumb.orders'),


### PR DESCRIPTION
# Description

I got into the issue where I wasn't able to add a custom component to location `order-list` with the `registerPageTab` provider. Found out that the culprit is the router configuration in admin-ui for the order part. Under the more complex paths with subroutes `pathMatch: full` is not used, only on more basic pages like _login_ and _dashboard_.

Issue reference is here: #3173

# Breaking changes

If a user has the same order ID like the tab name, that could cause a race condition I assume, but I think this would be unlikely.

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [ ] I have added or updated test cases
- [ ] I have updated the README if needed
