### PR TITLE
fix(admin-ui): Fix Variant Quick-Select Menu

### DIFF
--- a/packages/admin-ui/src/lib/catalog/src/components/product-variant-quick-jump/product-variant-quick-jump.component.ts
+++ b/packages/admin-ui/src/lib/catalog/src/components/product-variant-quick-jump/product-variant-quick-jump.component.ts
@@ -31,14 +31,17 @@ export class ProductVariantQuickJumpComponent implements OnInit {
     @Input() productId: string;
     selectedVariantId: string | undefined;
     variants$: Observable<NonNullable<GetProductVariantsQuickJumpQuery['product']>['variants']>;
-    constructor(private dataService: DataService, private router: Router) {}
+    constructor(
+        private dataService: DataService,
+        private router: Router,
+    ) {}
 
     ngOnInit() {
         this.variants$ = this.dataService
             .query(GetProductVariantsQuickJumpDocument, {
                 id: this.productId,
             })
-            .mapSingle(data => data.product?.variants ?? []);
+            .mapStream(data => data.product?.variants ?? []);
     }
 
     searchFn = (


### PR DESCRIPTION
# Description

Fixes #3143, in which the product variant quick select menu was always empty. It appears that this was because the Observable that yielded the variants that should be shown in that menu was created with `mapSingle`, but it needed to be unpacked multiple times by the `async` pipe in the component template.

If there is some test case that should be added for it, please let me know.

# Breaking changes

Nope.

# Screenshots

Here it is, working:

![image](https://github.com/user-attachments/assets/43ee144a-881a-43b4-b0a3-acc7de966f77)

# Checklist

📌 Always:
- [X] I have set a clear title
- [X] My PR is small and contains a single feature
- [X] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [ ] I have added or updated test cases
- [ ] I have updated the README if needed
