### PR TITLE
feat(payments-plugin): Allow use of Stripe-Account header

### DIFF
--- a/docs/docs/reference/core-plugins/payments-plugin/stripe-plugin.md
+++ b/docs/docs/reference/core-plugins/payments-plugin/stripe-plugin.md
@@ -199,6 +199,11 @@ interface StripePluginOptions {
         ctx: RequestContext,
         order: Order,
     ) => AdditionalPaymentIntentCreateParams | Promise<AdditionalPaymentIntentCreateParams>;
+    requestOptions?: (
+      injector: Injector,
+        ctx: RequestContext,
+        order: Order,
+    ) => AdditionalRequestOptions | Promise<AdditionalRequestOptions>;
     customerCreateParams?: (
         injector: Injector,
         ctx: RequestContext,
@@ -219,7 +224,11 @@ to be used with the same PaymentIntent. This is done by adding a custom field to
 the Stripe customer ID, so switching this on will require a database migration / synchronization.
 ### metadata
 
-<MemberInfo kind="property" type={`(         injector: <a href='/reference/typescript-api/common/injector#injector'>Injector</a>,         ctx: <a href='/reference/typescript-api/request/request-context#requestcontext'>RequestContext</a>,         order: <a href='/reference/typescript-api/entities/order#order'>Order</a>,     ) =&#62; Stripe.MetadataParam | Promise&#60;Stripe.MetadataParam&#62;`}  since="1.9.7"  />
+<MemberInfo kind="property" type={`(
+         injector: <a href='/reference/typescript-api/common/injector#injector'>Injector</a>,
+         ctx: <a href='/reference/typescript-api/request/request-context#requestcontext'>RequestContext</a>,
+         order: <a href='/reference/typescript-api/entities/order#order'>Order</a>,
+     ) =&#62; Stripe.MetadataParam | Promise&#60;Stripe.MetadataParam&#62;`}  since="1.9.7"  />
 
 Attach extra metadata to Stripe payment intent creation call.
 
@@ -249,7 +258,11 @@ Note: If the `paymentIntentCreateParams` is also used and returns a `metadata` k
 returned by both functions will be merged.
 ### paymentIntentCreateParams
 
-<MemberInfo kind="property" type={`(         injector: <a href='/reference/typescript-api/common/injector#injector'>Injector</a>,         ctx: <a href='/reference/typescript-api/request/request-context#requestcontext'>RequestContext</a>,         order: <a href='/reference/typescript-api/entities/order#order'>Order</a>,     ) =&#62; AdditionalPaymentIntentCreateParams | Promise&#60;AdditionalPaymentIntentCreateParams&#62;`}  since="2.1.0"  />
+<MemberInfo kind="property" type={`(
+         injector: <a href='/reference/typescript-api/common/injector#injector'>Injector</a>,
+         ctx: <a href='/reference/typescript-api/request/request-context#requestcontext'>RequestContext</a>,
+         order: <a href='/reference/typescript-api/entities/order#order'>Order</a>,
+     ) =&#62; AdditionalPaymentIntentCreateParams | Promise&#60;AdditionalPaymentIntentCreateParams&#62;`}  since="2.1.0"  />
 
 Provide additional parameters to the Stripe payment intent creation. By default,
 the plugin will already pass the `amount`, `currency`, `customer` and `automatic_payment_methods: { enabled: true }` parameters.
@@ -275,9 +288,45 @@ export const config: VendureConfig = {
   ],
 };
 ```
+### requestOptions
+
+<MemberInfo kind="property" type={`(
+         injector: <a href='/reference/typescript-api/common/injector#injector'>Injector</a>,
+         ctx: <a href='/reference/typescript-api/request/request-context#requestcontext'>RequestContext</a>,
+         order: <a href='/reference/typescript-api/entities/order#order'>Order</a>,
+     ) =&#62; AdditionalRequestOptions | Promise&#60;AdditionalRequestOptions&#62;`}  since="3.0.6"  />
+
+Provide additional options to the Stripe payment intent creation. By default,
+the plugin will already pass the `idempotencyKey` parameter.
+
+For example, if you want to provide a `stripeAccount` for the payment intent, you can do so like this:
+
+*Example*
+
+```ts
+import { VendureConfig } from '@vendure/core';
+import { StripePlugin } from '@vendure/payments-plugin/package/stripe';
+
+export const config: VendureConfig = {
+  // ...
+  plugins: [
+    StripePlugin.init({
+      requestOptions: (injector, ctx, order) => {
+         return {
+           stripeAccount: ctx.channel.seller?.customFields.connectedAccountId
+         },
+       }
+     }),
+  ],
+};
+```
 ### customerCreateParams
 
-<MemberInfo kind="property" type={`(         injector: <a href='/reference/typescript-api/common/injector#injector'>Injector</a>,         ctx: <a href='/reference/typescript-api/request/request-context#requestcontext'>RequestContext</a>,         order: <a href='/reference/typescript-api/entities/order#order'>Order</a>,     ) =&#62; AdditionalCustomerCreateParams | Promise&#60;AdditionalCustomerCreateParams&#62;`}  since="2.1.0"  />
+<MemberInfo kind="property" type={`(
+         injector: <a href='/reference/typescript-api/common/injector#injector'>Injector</a>,
+         ctx: <a href='/reference/typescript-api/request/request-context#requestcontext'>RequestContext</a>,
+         order: <a href='/reference/typescript-api/entities/order#order'>Order</a>,
+     ) =&#62; AdditionalCustomerCreateParams | Promise&#60;AdditionalCustomerCreateParams&#62;`}  since="2.1.0"  />
 
 Provide additional parameters to the Stripe customer creation. By default,
 the plugin will already pass the `email` and `name` parameters.

--- a/packages/payments-plugin/src/stripe/stripe.service.ts
+++ b/packages/payments-plugin/src/stripe/stripe.service.ts
@@ -44,6 +44,11 @@ export class StripeService {
             ctx,
             order,
         );
+        const additionalOptions = await this.options.requestOptions?.(
+            new Injector(this.moduleRef),
+            ctx,
+            order,
+        );
         const metadata = sanitizeMetadata({
             ...(typeof this.options.metadata === 'function'
                 ? await this.options.metadata(new Injector(this.moduleRef), ctx, order)
@@ -69,7 +74,10 @@ export class StripeService {
                 ...(additionalParams ?? {}),
                 metadata: allMetadata,
             },
-            { idempotencyKey: `${order.code}_${amountInMinorUnits}` },
+            {
+                idempotencyKey: `${order.code}_${amountInMinorUnits}`,
+                ...(additionalOptions ?? {}),
+            },
         );
 
         if (!client_secret) {

--- a/packages/payments-plugin/src/stripe/types.ts
+++ b/packages/payments-plugin/src/stripe/types.ts
@@ -15,6 +15,8 @@ type AdditionalPaymentIntentCreateParams = Partial<
     Omit<Stripe.PaymentIntentCreateParams, 'amount' | 'currency' | 'customer'>
 >;
 
+type AdditionalRequestOptions = Partial<Omit<Stripe.RequestOptions, 'idempotencyKey'>>;
+
 type AdditionalCustomerCreateParams = Partial<Omit<Stripe.CustomerCreateParams, 'email'>>;
 
 /**
@@ -106,6 +108,41 @@ export interface StripePluginOptions {
         ctx: RequestContext,
         order: Order,
     ) => AdditionalPaymentIntentCreateParams | Promise<AdditionalPaymentIntentCreateParams>;
+
+    /**
+     * @description
+     * Provide additional options to the Stripe payment intent creation. By default,
+     * the plugin will already pass the `idempotencyKey` parameter.
+     *
+     * For example, if you want to provide a `stripeAccount` for the payment intent, you can do so like this:
+     *
+     * @example
+     * ```ts
+     * import { VendureConfig } from '\@vendure/core';
+     * import { StripePlugin } from '\@vendure/payments-plugin/package/stripe';
+     *
+     * export const config: VendureConfig = {
+     *   // ...
+     *   plugins: [
+     *     StripePlugin.init({
+     *       requestOptions: (injector, ctx, order) => {
+     *         return {
+     *           stripeAccount: ctx.channel.seller?.customFields.connectedAccountId
+     *         },
+     *       }
+     *     }),
+     *   ],
+     * };
+     * ```
+     *
+     * @since 3.0.6
+     *
+     */
+    requestOptions?: (
+        injector: Injector,
+        ctx: RequestContext,
+        order: Order,
+    ) => AdditionalRequestOptions | Promise<AdditionalRequestOptions>;
 
     /**
      * @description


### PR DESCRIPTION
# Description

This pull request allow the application to send the Stripe-Account header that is used to create a direct charge with Stripe Connect #3183 
https://docs.stripe.com/connect/authentication#stripe-account-header

# Breaking changes

I am not able to determine a breaking change. The implemented features represent new functionality and should have no effect on existing implementations.

# Screenshots

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [x] I have added or updated test cases
- [ ] I have updated the README if needed
