### PR TITLE
feat(payments-plugin): Allow use of Stripe-Account header

### DIFF
--- a/packages/payments-plugin/src/stripe/stripe.service.ts
+++ b/packages/payments-plugin/src/stripe/stripe.service.ts
@@ -44,6 +44,11 @@ export class StripeService {
             ctx,
             order,
         );
+        const additionalOptions = await this.options.requestOptions?.(
+            new Injector(this.moduleRef),
+            ctx,
+            order,
+        );
         const metadata = sanitizeMetadata({
             ...(typeof this.options.metadata === 'function'
                 ? await this.options.metadata(new Injector(this.moduleRef), ctx, order)
@@ -69,7 +74,10 @@ export class StripeService {
                 ...(additionalParams ?? {}),
                 metadata: allMetadata,
             },
-            { idempotencyKey: `${order.code}_${amountInMinorUnits}` },
+            {
+                idempotencyKey: `${order.code}_${amountInMinorUnits}`,
+                ...(additionalOptions ?? {}),
+            },
         );
 
         if (!client_secret) {

--- a/packages/payments-plugin/src/stripe/types.ts
+++ b/packages/payments-plugin/src/stripe/types.ts
@@ -15,6 +15,8 @@ type AdditionalPaymentIntentCreateParams = Partial<
     Omit<Stripe.PaymentIntentCreateParams, 'amount' | 'currency' | 'customer'>
 >;
 
+type AdditionalRequestOptions = Partial<Omit<Stripe.RequestOptions, 'idempotencyKey'>>;
+
 type AdditionalCustomerCreateParams = Partial<Omit<Stripe.CustomerCreateParams, 'email'>>;
 
 /**
@@ -106,6 +108,41 @@ export interface StripePluginOptions {
         ctx: RequestContext,
         order: Order,
     ) => AdditionalPaymentIntentCreateParams | Promise<AdditionalPaymentIntentCreateParams>;
+
+    /**
+     * @description
+     * Provide additional options to the Stripe payment intent creation. By default,
+     * the plugin will already pass the `idempotencyKey` parameter.
+     *
+     * For example, if you want to provide a `stripeAccount` for the payment intent, you can do so like this:
+     *
+     * @example
+     * ```ts
+     * import { VendureConfig } from '\@vendure/core';
+     * import { StripePlugin } from '\@vendure/payments-plugin/package/stripe';
+     *
+     * export const config: VendureConfig = {
+     *   // ...
+     *   plugins: [
+     *     StripePlugin.init({
+     *       requestOptions: (injector, ctx, order) => {
+     *         return {
+     *           stripeAccount: ctx.channel.seller?.customFields.connectedAccountId
+     *         },
+     *       }
+     *     }),
+     *   ],
+     * };
+     * ```
+     *
+     * @since 3.1.0
+     *
+     */
+    requestOptions?: (
+        injector: Injector,
+        ctx: RequestContext,
+        order: Order,
+    ) => AdditionalRequestOptions | Promise<AdditionalRequestOptions>;
 
     /**
      * @description


### PR DESCRIPTION
# Description

This pull request allow the application to send the Stripe-Account header that is used to create a direct charge with Stripe Connect https://github.com/vendure-ecommerce/vendure/issues/3183
https://docs.stripe.com/connect/authentication#stripe-account-header

# Breaking changes

I am not able to determine a breaking change. The implemented features represent new functionality and should have no effect on existing implementations.

# Screenshots

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [X] I have added or updated test cases
- [ ] I have updated the README if needed
