### PR TITLE
fix(product-duplicator): Add source variant customFields to duplicated variant

### DIFF
--- a/packages/core/src/config/entity/entity-duplicators/product-duplicator.ts
+++ b/packages/core/src/config/entity/entity-duplicators/product-duplicator.ts
@@ -182,6 +182,7 @@ export const productDuplicator = new EntityDuplicator({
                         return {
                             languageCode: translation.languageCode,
                             name: translation.name,
+                            customFields: translation.customFields,
                         };
                     }),
                     optionIds: options.map(option => option.id),
@@ -190,6 +191,7 @@ export const productDuplicator = new EntityDuplicator({
                         stockLocationId: stockLevel.stockLocationId,
                         stockOnHand: stockLevel.stockOnHand,
                     })),
+                    customFields: variant.customFields,
                 };
             });
             const duplicatedProductVariants = await productVariantService.create(ctx, variantInput);


### PR DESCRIPTION
# Description

Product duplicator now copies variant customFields. Fixes https://github.com/vendure-ecommerce/vendure/issues/3202

# Breaking changes

- This will start copying variant related customFields when you use the product duplicator with `includeVariants: true`. This could potentially cause unexpected side effects, if your code previously assumed those customFields were not copied.

# Checklist

📌 Always:
- [x ] I have set a clear title
- [ x] My PR is small and contains a single feature
- [ x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [ ] I have added or updated test cases
- [ ] I have updated the README if needed
