### PR TITLE
Corrected a small typo in documentation for ProductVariantSelectorCom…

### DIFF
--- a/docs/docs/reference/admin-ui-api/components/product-variant-selector-component.md
+++ b/docs/docs/reference/admin-ui-api/components/product-variant-selector-component.md
@@ -19,7 +19,7 @@ A component for selecting product variants via an autocomplete-style select inpu
 
 ```HTML
 <vdr-product-variant-selector
-  (productSelected)="selectResult($event)"></vdr-product-selector>
+  (productSelected)="selectResult($event)"></vdr-product-variant-selector>
 ```
 
 ```ts title="Signature"

--- a/packages/admin-ui/src/lib/core/src/shared/components/product-variant-selector/product-variant-selector.component.ts
+++ b/packages/admin-ui/src/lib/core/src/shared/components/product-variant-selector/product-variant-selector.component.ts
@@ -13,7 +13,7 @@ import { DataService } from '../../../data/providers/data.service';
  * @example
  * ```HTML
  * <vdr-product-variant-selector
- *   (productSelected)="selectResult($event)"></vdr-product-selector>
+ *   (productSelected)="selectResult($event)"></vdr-product-variant-selector>
  * ```
  *
  * @docsCategory components


### PR DESCRIPTION
…ponent.

# Description

Fixed a small issue in documentation, from:

```
<vdr-product-variant-selector
  (productSelected)="selectResult($event)"></vdr-product-selector>
```

to:

```
<vdr-product-variant-selector
  (productSelected)="selectResult($event)"></vdr-product-variant-selector>
```

Also updated doc comment for said component.

# Breaking changes

No breaking changes, documentation only.

# Screenshots

<img width="791" alt="Skärmavbild 2024-11-09 kl  10 53 26" src="https://github.com/user-attachments/assets/3770b0e5-cabb-403c-9c0c-bc605c5e50ee">

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [] I have added or updated test cases
- [] I have updated the README if needed
