### PR TITLE
docs: Small error in entity events

### DIFF
--- a/docs/docs/guides/developer-guide/events/index.mdx
+++ b/docs/docs/guides/developer-guide/events/index.mdx
@@ -255,7 +255,7 @@ type BlogPostInputTypes = CreateBlogPostInput | UpdateBlogPostInput | ID | ID[];
  * This event is fired whenever a BlogPost is added, updated
  * or deleted.
  */
-export class BlogPostEvent extends VendureEntityEvent<BlogPost[], BlogPostInputTypes> {
+export class BlogPostEvent extends VendureEntityEvent<BlogPost, BlogPostInputTypes> {
     constructor(
         ctx: RequestContext,
         entity: BlogPost,


### PR DESCRIPTION
# Description

A small error I noticed in the Entity Event docs [here](https://docs.vendure.io/guides/developer-guide/events/#entity-events)
`VendureEntityEvent<BlogPost[], BlogPostInputTypes>`
BlogPost shouldnt be defined as an Array here

# Breaking changes

No

# Screenshots

You can add screenshots here if applicable.

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [ ] I have added or updated test cases
- [ ] I have updated the README if needed
