### PR TITLE
[WIP] feat(facet-service): Ensure FacetValue retrieval is channel specific …

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,5 +103,6 @@
     "eslint-plugin-import": "^2.27.5",
     "eslint-plugin-jsdoc": "^45.0.0",
     "eslint-plugin-prefer-arrow": "^1.2.3"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }


### PR DESCRIPTION
Ensures that FacetValues retrieved with Facet query are channel specific. 
Related to https://github.com/vendure-ecommerce/vendure/issues/2882

Currently having problems running tests on my environment to verify functionality.

# Description

Facets and FacetValues are channelaware. You can have a central facet that can be accessed through multiple channels. However, a number of queries in the facet service, including one used for the `populate` script `findByCode`. retrieve associated FacetValues in a non channel aware manner, leading to problems in importing and other issues when working in a multi vendor scenario

# Breaking changes

Possibly. If your code assumed the non channel aware retrieval of facetValues through the now changed code

# Screenshots


# Checklist

📌 Always:
- [x ] I have set a clear title
- [x ] My PR is small and contains a single feature
- [ x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [ x] I have added or updated test cases
- [ ] I have updated the README if needed
