### PR TITLE
fix(docs): updated docs for wishlist plugin

### DIFF
--- a/docs/docs/guides/developer-guide/plugins/index.mdx
+++ b/docs/docs/guides/developer-guide/plugins/index.mdx
@@ -358,7 +358,7 @@ export class WishlistService {
      */
     async addItem(ctx: RequestContext, variantId: ID): Promise<WishlistItem[]> {
         const customer = await this.getCustomerWithWishlistItems(ctx);
-        const variant = this.productVariantService.findOne(ctx, variantId);
+        const variant = await this.productVariantService.findOne(ctx, variantId);
         if (!variant) {
             throw new UserInputError(`No ProductVariant with the id ${variantId} could be found`);
         }

--- a/packages/dev-server/example-plugins/wishlist-plugin/service/wishlist.service.ts
+++ b/packages/dev-server/example-plugins/wishlist-plugin/service/wishlist.service.ts
@@ -33,7 +33,7 @@ export class WishlistService {
      */
     async addItem(ctx: RequestContext, variantId: ID): Promise<WishlistItem[]> {
         const customer = await this.getCustomerWithWishlistItems(ctx);
-        const variant = this.productVariantService.findOne(ctx, variantId);
+        const variant = await this.productVariantService.findOne(ctx, variantId);
         if (!variant) {
             throw new UserInputError(`No ProductVariant with the id ${variantId} could be found`);
         }


### PR DESCRIPTION
added await to db query causing the value to be promise and causing server crash

Issue#2868

# Description

If you run the `addToWhishlist` mutation twice then the server crashes with the error:

```
if (this.isReleased) throw new QueryRunnerAlreadyReleasedError()
                                  ^
QueryRunnerAlreadyReleasedError: Query runner already released. Cannot run queries anymore.
```

in simple words

If the variant is already in the wishlist and you run the mutation again *(trying to add a variant to wishlist when that variant is already in the wishlist)* the server crashes.

# Breaking changes

No breaking changes.


# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [ ] I have added or updated test cases
- [ ] I have updated the README if needed
