### PR TITLE
fix(e2e): Use VITEST_WORKER_ID to generate test server ports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,6 @@ docs/static/intro.css*
 docs/public
 docs/data/build.json
 yarn-error.log
-e2e-common/ports.json
 
 # Sensitive or high-churn files:
 .idea/**/dataSources/

--- a/docs/docs/guides/developer-guide/testing/index.md
+++ b/docs/docs/guides/developer-guide/testing/index.md
@@ -195,7 +195,7 @@ All that's left is to run your tests to find out whether your code behaves as ex
 
 :::caution
 **Note:** When using **Vitest** with multiple test suites (multiple `.e2e-spec.ts` files), it will attempt to run them in parallel. If all the test servers are running
-on the same port (the default in the `testConfig` is `3050`), then this will cause a port conflict. To avoid this, you can manually set a unique port for each test suite. Be aware that `mergeConfig` is used here:
+on the same port (the default in the `testConfig` is `3050`), then this will cause a port conflict. To avoid this, you can use the `VITEST_WORKER_ID` environment variable to set a unique port for each test suite. Be aware that `mergeConfig` is used here:
 
 ```ts title="src/plugins/my-plugin/e2e/my-plugin.e2e-spec.ts"
 import { createTestEnvironment, testConfig } from '@vendure/testing';
@@ -208,7 +208,7 @@ describe('my plugin', () => {
     const {server, adminClient, shopClient} = createTestEnvironment(mergeConfig(testConfig, {
         // highlight-start
         apiOptions: {
-            port: 3051,
+            port: 3050 + Number(process.env.VITEST_WORKER_ID),
         },
         // highlight-end
         plugins: [MyPlugin],


### PR DESCRIPTION
# Description

Closes #3247. Instead of using unsynchronized access to a temporary file to determine the next available port, it uses the [`VITEST_WORKER_ID`](https://vitest.dev/guide/migration#envs) environment variable, which should be unique in each test suite, to figure out what port it should be using.

# Breaking changes

Nope, it only applies to the internal test configuration used in Vendure's e2e self-tests.

# Checklist

📌 Always:
- [X] I have set a clear title
- [X] My PR is small and contains a single feature
- [X] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [ ] I have added or updated test cases
- [X] I have updated the README if needed
