### PR TITLE
feat(payments-plugin): Optionally, do not throw if Stripe payment intent doesn't have Vendure metadata

### DIFF
--- a/packages/payments-plugin/e2e/stripe-payment.e2e-spec.ts
+++ b/packages/payments-plugin/e2e/stripe-payment.e2e-spec.ts
@@ -16,7 +16,7 @@ import { Stripe } from 'stripe';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
 import { initialData } from '../../../e2e-common/e2e-initial-data';
-import { testConfig, TEST_SETUP_TIMEOUT_MS } from '../../../e2e-common/test-config';
+import { TEST_SETUP_TIMEOUT_MS, testConfig } from '../../../e2e-common/test-config';
 import { StripePlugin } from '../src/stripe';
 import { stripePaymentMethodHandler } from '../src/stripe/stripe.handler';
 
@@ -387,6 +387,50 @@ describe('Stripe payments', () => {
         // I would expect to the status to be 200, but at the moment either the
         // `orderService.transitionToState()` or the `orderService.addPaymentToOrder()`
         // throws an error of 'error.entity-with-id-not-found'
+        expect(result.status).toEqual(200);
+    });
+
+    // https://github.com/vendure-ecommerce/vendure/issues/3249
+    it('Should skip events without expected metadata, when the plugin option is set', async () => {
+        StripePlugin.options.skipPaymentIntentsWithoutExpectedMetadata = true;
+
+        const MOCKED_WEBHOOK_PAYLOAD = {
+            id: 'evt_0',
+            object: 'event',
+            api_version: '2022-11-15',
+            data: {
+                object: {
+                    id: 'pi_0',
+                    currency: 'usd',
+                    metadata: {
+                        dummy: 'not a vendure payload',
+                    },
+                    amount_received: 10000,
+                    status: 'succeeded',
+                },
+            },
+            livemode: false,
+            pending_webhooks: 1,
+            request: {
+                id: 'req_0',
+                idempotency_key: '00000000-0000-0000-0000-000000000000',
+            },
+            type: 'payment_intent.succeeded',
+        };
+
+        const payloadString = JSON.stringify(MOCKED_WEBHOOK_PAYLOAD, null, 2);
+        const stripeWebhooks = new Stripe('test-api-secret', { apiVersion: '2023-08-16' }).webhooks;
+        const header = stripeWebhooks.generateTestHeaderString({
+            payload: payloadString,
+            secret: 'test-signing-secret',
+        });
+
+        const result = await fetch(`http://localhost:${serverPort}/payments/stripe`, {
+            method: 'post',
+            body: payloadString,
+            headers: { 'Content-Type': 'application/json', 'Stripe-Signature': header },
+        });
+
         expect(result.status).toEqual(200);
     });
 

--- a/packages/payments-plugin/src/stripe/stripe-utils.ts
+++ b/packages/payments-plugin/src/stripe/stripe-utils.ts
@@ -1,4 +1,5 @@
 import { CurrencyCode, Order } from '@vendure/core';
+import Stripe from 'stripe';
 
 /**
  * @description
@@ -34,4 +35,17 @@ function currencyHasFractionPart(currencyCode: CurrencyCode): boolean {
     }).formatToParts(123.45);
 
     return !!parts.find(p => p.type === 'fraction');
+}
+
+/**
+ *
+ * @description
+ * Ensures that the payment intent metadata object contains the expected properties, as defined by the plugin.
+ */
+export function isExpectedVendureStripeEventMetadata(metadata: Stripe.Metadata): metadata is {
+    channelToken: string;
+    orderCode: string;
+    orderId: string;
+} {
+    return !!metadata.channelToken && !!metadata.orderCode && !!metadata.orderId;
 }

--- a/packages/payments-plugin/src/stripe/types.ts
+++ b/packages/payments-plugin/src/stripe/types.ts
@@ -1,5 +1,5 @@
-import '@vendure/core/dist/entity/custom-entity-fields';
 import type { Injector, Order, RequestContext } from '@vendure/core';
+import '@vendure/core/dist/entity/custom-entity-fields';
 import type { Request } from 'express';
 import type Stripe from 'stripe';
 
@@ -151,6 +151,12 @@ export interface StripePluginOptions {
         ctx: RequestContext,
         order: Order,
     ) => AdditionalCustomerCreateParams | Promise<AdditionalCustomerCreateParams>;
+    /**
+     * @description
+     * If your Stripe account also generates payment intents which are independent of Vendure orders, you can set this
+     * to `true` to skip processing those payment intents.
+     */
+    skipPaymentIntentsWithoutExpectedMetadata?: boolean;
 }
 
 export interface RequestWithRawBody extends Request {


### PR DESCRIPTION
# Description
#3249 - gracefully handle non-vendure payment intents from Stripe

Included an option for the consumer as this could be a breaking change otherwise, though it seems extremely unlikely. 

# Breaking changes

Does this PR include any breaking changes we should be aware of?

# Screenshots

You can add screenshots here if applicable.

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [x] I have added or updated test cases
- [ ] I have updated the README if needed
