### PR TITLE
chore: Add GPL exception for Vendure plugins

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -24,6 +24,11 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+Additional permission under GNU GPL version 3 section 7:
+
+An additional exception under section 7 of the GPL is included in the plugin-exception.txt file,
+which allows you to distribute Vendure plugins (i.e. extensions) under a different license.
+
 ## Vendure Commercial License (VCL)
 
 Alternatively, commercial and supported versions of the program - also known as

--- a/docs/docs/guides/how-to/publish-plugin/index.mdx
+++ b/docs/docs/guides/how-to/publish-plugin/index.mdx
@@ -52,9 +52,9 @@ is using a compatible version of Vendure.
 
 ### License
 
-Your plugin **must** use a license that is compatible with the GPL v3 license that Vendure uses. This means your package.json
-file should include `"license": "GPL-3.0-or-later"`, and your repository should include a license file (usually named `LICENSE.txt`) containing the
-[full text of the GPL v3 license](https://www.gnu.org/licenses/gpl-3.0.txt).
+You are free to license your plugin as you wish. Although Vendure itself is licensed under the GPLv3, there is
+a special exception for plugins which allows you to distribute them under a different license. See the
+[plugin exception](https://github.com/vendure-ecommerce/vendure/blob/master/license/plugin-exception.txt) for more details.
 
 ## Publishing to npm
 

--- a/license/license-faq.md
+++ b/license/license-faq.md
@@ -26,7 +26,8 @@ All Vendure contributors retain copyright on their code, but agree to release it
 If you are unable or unwilling to contribute a patch under the GPL version 3 and the Vendure Commercial License, do not submit a patch.
 
 ## I want to release my work under a different license than GPLv3, is that possible?
-No. You can only release your work under any GPL version 3 or later compatible license.
+Yes. There is a special exception described in the file `plugin-exception.txt` that allows you to distribute Vendure plugins under a different license.
+If you modify the Vendure core code, you must still release your changes under the GPLv3.
 
 ## The GPL requires that I distribute the "source code" of my files. What does that mean for a web application?
 The "source code" of a file means the format that is intended for people to edit.
@@ -35,34 +36,11 @@ For TypeScript, CSS, and HTML code, the file itself, without any compression or 
 The "source code" is whichever version is intended to be edited by people.
 
 ## If I write a plugin for my Vendure application, do I have to license it under the GPL?
-Yes. Vendure plugins for your application are a derivative work of Vendure.
-If you distribute them, you must do so under the terms of the GPL version 3 or later.
-
-You are not required to distribute them at all, however.
-
-However, when distributing your own Vendure-based work, it is important to keep in mind what the GPLv3 applies to.
-The GPLv3 on code applies to code that interacts with that code, but not to data.
-That is, Vendure's TypeScript code is under the GPLv3, and so all TypeScript code that interacts with it must also be
-under the GPLv3 or GPLv3 compatible. Images and JSON files that TypeScript sends to the browser are not
-affected by the GPL because they are data
-
-When distributing your own plugin, therefore,
-the GPLv3 applies to any pieces that directly interact with parts of Vendure that are under the GPLv3.
-Images and other asset files you create yourself are not affected.
-
-## If I write a plugin for my application, do I have to give it away to everyone?
-No. The GPL requires that if you make a derivative work of Vendure and distribute it to someone else,
-you must provide that person with the source code under the terms of the GPLv3 so that they may modify and redistribute
-it under the terms of the GPLv3 as well. However, you are under no obligation to distribute the code to anyone else.
-If you do not distribute the code but use it only within your organization,
-then you are not required to distribute it to anyone at all.
-
-However, if your plugin is of general use then it is often a good idea to contribute it back to the community anyway.
-You can get feedback, bug reports, and new feature patches from others who find it useful.
+No. There is a special exception described in the file `plugin-exception.txt` that allows you to 
+distribute Vendure plugins under a different license.
 
 ## Is it permitted for me to sell Vendure or a Vendure plugin?
-Yes. However, you must distribute it under the GPL version 3 or later,
-so those you sell it to must be allowed to modify and redistribute it as well. See questions above.
+Yes. However, any modifications to Vendure Core must be made available under the terms of the GPL version 3.
 
 ## Do I have to give the code for my web site to anyone who visits it?
 

--- a/license/plugin-exception.txt
+++ b/license/plugin-exception.txt
@@ -1,0 +1,20 @@
+Vendure Plugin Exception
+
+0. Definitions
+
+"Vendure Core" includes all the source code files included in this repository, which are licensed under the
+GPL v3.0 license.
+
+A "Plugin" is a software module that is designed to enable additional functionality by
+ using APIs exposed by the Vendure Core packages, including but not limited to the public
+APIs described in the Vendure documentation at https://docs.vendure.io. A Plugin does not include any source code from
+the Vendure Core itself.
+
+1. Grant of Additional Permission.
+
+For Plugins that are distributed separately from Vendure Core (such as via a package repository),
+Vendure GmbH hereby grants you permission to link the Vendure Core from that Plugin and to
+distribute the Plugin under terms of your choice, including licenses which are not compatible with the GPL v3.0,
+ without any of the additional requirements listed in the GNU Library General Public License.
+
+(The GPL v3.0 restrictions do apply in other respects; for example, they cover modifications made to the Vendure Core.)


### PR DESCRIPTION
# Description

Because Vendure uses the GPL v3.0 license, the common interpretation based on GNU FAQ ([single combined program](https://www.gnu.org/licenses/gpl-faq.html#GPLPlugins)) would suggest that any plugins must also be GPL licensed.

However, it is our opinion that plugins should not be subject to this restriction. In our opinion, the GPL requirements should apply to the Vendure code itself (i.e., the files in this repo). Plugin code is not typically distributed as a combined program - it is distributed as a stand-alone package that only consumes the public APIs of Vendure.

## Background

A good general background on the topic of linking & derived works as applied to the GPL can be found here: [GNU General Public License: Linking and derived works](https://en.wikipedia.org/wiki/GNU_General_Public_License#Linking_and_derived_works). In short: there is controversy and lack of clarity on what constitutes a "derived work" and therefore whether programs which make use of GPL libraries must themselves be licensed under the GPL.

To resolve this lack of clarity, many projects make explicit exceptions to the GPL terms, which make clear how the library may be used.

There are many examples of GPL projects/licenses which include special exceptions. 

- The [Linux syscall exception](https://github.com/torvalds/linux/blob/master/LICENSES/exceptions/Linux-syscall-note) allows programs to make "normal system calls" and not fall under "derivative work"
- The [GCC compiler has an exception](https://www.gnu.org/licenses/gcc-exception-3.1.html) allows you to include GPL code in your compiled executable without requiring you to then license the resulting executable under the GPL.
- The [GNU Lesser General Public License (LGPL)](https://en.wikipedia.org/wiki/GNU_Lesser_General_Public_License) is a distinct variant of the GPL which explicitly allows for use of the LGPL library without the resulting work needing to be similarly licensed.
- The [GPL v2.0 with classpath exception](https://spdx.org/licenses/GPL-2.0-with-classpath-exception.html) is a generalized form of this idea.

This [stackexchange answer](https://softwareengineering.stackexchange.com/a/326325) gives a good summary of the intent of the classpath exception:

> Here is where the Classpath Exception is invaluable. It clearly states that the code under the license is (L)GPL, but anything using that code can follow whatever license they'd like. No ifs, ands, or buts. If you change the core code (e.g. fixing bugs), you do still have to release those changes as part of the GPL. But using does NOT infect you...
> So, to me, the Classpath Exception is a much different than LGPL. It is a legally clean way to draw a bright line allowing non-GPL use of GPL or LGPL source code or libraries.

which in turn features a reply from one of the creators of this license, [Anthony Green](https://github.com/atgreen)

> IANAL, but I am one of the creators of the Classpath Exception, and this is the right answer. The Exception was created to support AOT compiled embedded use cases where developers would be statically linking binaries (with gcj in our case). We needed something like the libgcc license, so I wrote the first version of the Classpath Exception based on that. It has since matured, but the spirit is the same.

Here is another article from Vaultinum, a firm specializing in digital IP: [The GPL and its Unique GPL Classpath Exception: what does it mean?](https://vaultinum.com/blog/the-gpl-and-its-unique-gpl-classpath-exception-what-does-it-mean)

> Libraries, by design, are tools intended to be used by a broader range of software. Their primary purpose is to offer functionality to be leveraged by various applications. When a library is GPL-licensed, its strict licensing can deter its adoption, as not every developer or company wishes to open-source their entire application under the GPL. 

> The GPL Classpath Exception bridges this gap. It allows libraries to remain free and open (thus benefiting from community contributions) while still being attractive to a broader spectrum of software projects that might have otherwise avoided it due to licensing concerns. 

> The GPL Classpath Exception offers several notable benefits: 
> **1. Greater Adoption of the Library**: Libraries licensed with the GPL Classpath Exception are more attractive for a wide range of developers, including those working on proprietary software, as they don't impose GPL's stringent redistribution requirements. 
> **2. Maintaining Software Freedoms**: Despite the Classpath Exception, the library itself continues to be governed by the GPL. 
  This means that any changes or improvements to the library must be open sourced, thereby preserving the essence of software freedom for the library. 
> **3. Flexibility for Developers**: Developers can choose to either use the library under the strict GPL (without the Classpath 
  Exception) or with the Classpath Exception, depending on their project's needs. 
> **4. Protecting Proprietary Interests**: Businesses can integrate powerful GPL libraries into their proprietary solutions without risking their intellectual property or business model. 

The above quotes about the classpath exception express well the intent behind this PR. 

## GPL v3.0 section 7

Since the specific "classpath exception" license is specific to GPL v2.0, and we are using GPL v3.0, we will not use that exact license. Instead, we will use a mechanism explicitly built in to GPL v3.0 in section 7 "Additional Terms":

> 7. Additional Terms.
> “Additional permissions” are terms that supplement the terms of this License by making exceptions from one or more of its conditions. Additional permissions that are applicable to the entire Program shall be treated as though they were included in this License, to the extent that they are valid under applicable law. If additional permissions apply only to part of the Program, that part may be used separately under those permissions, but the entire Program remains governed by this License without regard to the additional permissions.

A discussion of the intent behind section 7 can be found in the FSF archive article [Opinion on Additional Terms](https://gplv3.fsf.org/additional-terms-dd2.html/)

> We have licensed some of our own software under GPLv2 with permissive exceptions that allow combination with non-free code, and that allow removal of those permissions by downstream recipients; similarly, LGPLv2.1 is in essence a permissive variant of GPLv2, and it permits relicensing under the GPL. We have generalized these practices in section 7.

An example of section 7 being used to allow non-GPL plugins is the [Roundcube license](https://roundcube.net/license/)

This PR applies the same principle to our license.

## Our Implementation

This PR builds on the examples set by other projects by using GPL v3.0 section 7 in this way:

```
Additional permission under GNU GPL version 3 section 7:

An additional exception under section 7 of the GPL is included in the plugin-exception.txt file,
which allows you to distribute Vendure plugins (i.e. extensions) under a different license.
```

The text in the `plugin-exception.txt` file is based on the pattern of the [GCC Runtime Library Exception](https://www.gnu.org/licenses/gcc-exception-3.1.html), defining the distinction between "Vendure Core" and "Plugins", and then granting additional permissions on "Plugins".

The PR also includes updates to the plugin FAQ and documentation to bring them into line with this new exception.

**This change will explicitly allow people to license Vendure plugins under any license they choose, both open source and proprietary.**