### PR TITLE
feat(elastic-search): improved default search

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,6 +104,5 @@
     "eslint-plugin-import": "^2.27.5",
     "eslint-plugin-jsdoc": "^45.0.0",
     "eslint-plugin-prefer-arrow": "^1.2.3"
-  },
-  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -104,5 +104,6 @@
     "eslint-plugin-import": "^2.27.5",
     "eslint-plugin-jsdoc": "^45.0.0",
     "eslint-plugin-prefer-arrow": "^1.2.3"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/packages/elasticsearch-plugin/e2e/e2e-helpers.ts
+++ b/packages/elasticsearch-plugin/e2e/e2e-helpers.ts
@@ -63,8 +63,8 @@ export async function testMatchSearchTerm(client: SimpleGraphQLClient) {
         },
     );
     expect(result.search.items.map(i => i.productName)).toEqual([
-        'Instant Camera',
         'Camera Lens',
+        'Instant Camera',
         'SLR Camera',
     ]);
 }

--- a/packages/elasticsearch-plugin/e2e/elasticsearch-plugin.e2e-spec.ts
+++ b/packages/elasticsearch-plugin/e2e/elasticsearch-plugin.e2e-spec.ts
@@ -155,12 +155,6 @@ describe('Elasticsearch plugin', () => {
                                 },
                             },
                         },
-                        boostFields: {
-                            description: 1,
-                            productName: 1,
-                            productVariantName: 1,
-                            sku: 1,
-                        },
                         mapSort: (sort, input) => {
                             const priority = (input.sort as any)?.priority;
                             if (priority) {
@@ -919,9 +913,8 @@ describe('Elasticsearch plugin', () => {
                     groupByProduct: true,
                     term: 'gaming',
                 });
-                expect(result.search.items.map(pick(['productId', 'enabled']))).toEqual([
-                    { productId: 'T_3', enabled: false },
-                ]);
+                const t3 = result.search.items.find(i => i.productId === 'T_3');
+                expect(t3?.enabled).toEqual(false);
             });
 
             // https://github.com/vendure-ecommerce/vendure/issues/295

--- a/packages/elasticsearch-plugin/e2e/elasticsearch-plugin.e2e-spec.ts
+++ b/packages/elasticsearch-plugin/e2e/elasticsearch-plugin.e2e-spec.ts
@@ -155,6 +155,12 @@ describe('Elasticsearch plugin', () => {
                                 },
                             },
                         },
+                        boostFields: {
+                            description: 1,
+                            productName: 1,
+                            productVariantName: 1,
+                            sku: 1,
+                        },
                         mapSort: (sort, input) => {
                             const priority = (input.sort as any)?.priority;
                             if (priority) {

--- a/packages/elasticsearch-plugin/src/build-elastic-body.spec.ts
+++ b/packages/elasticsearch-plugin/src/build-elastic-body.spec.ts
@@ -21,7 +21,8 @@ describe('buildElasticBody()', () => {
                         multi_match: {
                             query: 'test',
                             type: 'best_fields',
-                            fields: ['productName^1', 'productVariantName^1', 'description^1', 'sku^1'],
+                            fuzziness: 'AUTO',
+                            fields: ['productName^5', 'productVariantName^5', 'description^1', 'sku^1'],
                         },
                     },
                 ],
@@ -389,7 +390,8 @@ describe('buildElasticBody()', () => {
                             multi_match: {
                                 query: 'test',
                                 type: 'best_fields',
-                                fields: ['productName^1', 'productVariantName^1', 'description^1', 'sku^1'],
+                                fuzziness: 'AUTO',
+                                fields: ['productName^5', 'productVariantName^5', 'description^1', 'sku^1'],
                             },
                         },
                     ],
@@ -427,7 +429,8 @@ describe('buildElasticBody()', () => {
                         multi_match: {
                             query: 'test',
                             type: 'phrase',
-                            fields: ['productName^1', 'productVariantName^1', 'description^1', 'sku^1'],
+                            fuzziness: 'AUTO',
+                            fields: ['productName^5', 'productVariantName^5', 'description^1', 'sku^1'],
                         },
                     },
                 ],
@@ -456,6 +459,7 @@ describe('buildElasticBody()', () => {
                         multi_match: {
                             query: 'test',
                             type: 'best_fields',
+                            fuzziness: 'AUTO',
                             fields: ['productName^3', 'productVariantName^4', 'description^2', 'sku^5'],
                         },
                     },
@@ -482,7 +486,7 @@ describe('buildElasticBody()', () => {
         const result = buildElasticBody({ term: 'test' }, config, CHANNEL_ID, LanguageCode.en);
         expect(result.script_fields).toEqual({
             test: {
-                script: 'doc[\'property\'].dummyScript(test)',
+                script: "doc['property'].dummyScript(test)",
             },
         });
     });

--- a/packages/elasticsearch-plugin/src/build-elastic-body.ts
+++ b/packages/elasticsearch-plugin/src/build-elastic-body.ts
@@ -41,7 +41,7 @@ export function buildElasticBody(
             {
                 multi_match: {
                     query: term,
-                    fuzziness: "AUTO", 
+                    fuzziness: 'AUTO',
                     type: searchConfig.multiMatchType,
                     fields: [
                         `productName^${searchConfig.boostFields.productName}`,
@@ -167,13 +167,13 @@ function createScriptFields(
             for (const name of fields) {
                 const scriptField = scriptFields[name];
                 if (scriptField.context === 'product' && groupByProduct === true) {
-                    (result )[name] = scriptField.scriptFn(input);
+                    result[name] = scriptField.scriptFn(input);
                 }
                 if (scriptField.context === 'variant' && groupByProduct === false) {
-                    (result )[name] = scriptField.scriptFn(input);
+                    result[name] = scriptField.scriptFn(input);
                 }
                 if (scriptField.context === 'both' || scriptField.context === undefined) {
-                    (result )[name] = scriptField.scriptFn(input);
+                    result[name] = scriptField.scriptFn(input);
                 }
             }
             return result;

--- a/packages/elasticsearch-plugin/src/build-elastic-body.ts
+++ b/packages/elasticsearch-plugin/src/build-elastic-body.ts
@@ -41,6 +41,7 @@ export function buildElasticBody(
             {
                 multi_match: {
                     query: term,
+                    fuzziness: "AUTO", 
                     type: searchConfig.multiMatchType,
                     fields: [
                         `productName^${searchConfig.boostFields.productName}`,

--- a/packages/elasticsearch-plugin/src/options.ts
+++ b/packages/elasticsearch-plugin/src/options.ts
@@ -728,8 +728,8 @@ export const defaultOptions: ElasticsearchRuntimeOptions = {
         totalItemsMaxSize: 10000,
         multiMatchType: 'best_fields',
         boostFields: {
-            productName: 1,
-            productVariantName: 1,
+            productName: 5,
+            productVariantName: 5,
             description: 1,
             sku: 1,
         },


### PR DESCRIPTION
# Description

Minor tweaks to improve the out-of-the-box search results from elastic search.

It was a bit demotivating to see that my search results were worse than with the default plugin, while ES is such a powerful engine. In my case this was due to:
1. Description being just as important as name fields
2. No type tolerance (fuzziness)

Most consumers probably define their own queries, but for those starting with the defaults this gives them a better experience.

# Breaking changes

No

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [ ] I have added or updated test cases
- [ ] I have updated the README if needed
