### PR TITLE
feat(graphql): Allow interceptors on field resolvers

### DIFF
--- a/packages/core/src/api/config/configure-graphql-module.ts
+++ b/packages/core/src/api/config/configure-graphql-module.ts
@@ -120,7 +120,7 @@ async function createGraphQLOptions(
         typeDefs: printSchema(builtSchema),
         include: [options.resolverModule],
         inheritResolversFromInterfaces: true,
-        fieldResolverEnhancers: ['guards'],
+        fieldResolverEnhancers: ['guards', 'interceptors'],
         resolvers,
         // We no longer rely on the upload facility bundled with Apollo Server, and instead
         // manually configure the graphql-upload package. See https://github.com/vendure-ecommerce/vendure/issues/396


### PR DESCRIPTION
# Description

Allows you to use graphql interceptors on field resolvers. This is by default possible for Queries and Mutations. However, in order for this to work for field resolver, an additional setting is necessary.

Current workaround for some scenarios would be to use a guard. 

# Breaking changes

No

# Screenshots

# Checklist

📌 Always:
- [x ] I have set a clear title
- [ x] My PR is small and contains a single feature
- [x ] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [ ] I have added or updated test cases
- [ ] I have updated the README if needed
