### PR TITLE
fix(common): Better support for slug generation when the replacer occurs in the input string

### DIFF
--- a/packages/common/src/normalize-string.spec.ts
+++ b/packages/common/src/normalize-string.spec.ts
@@ -46,4 +46,11 @@ describe('normalizeString()', () => {
     it('replaces combining diaeresis with e', () => {
         expect(normalizeString('Ja quäkt Schwyz Pöbel vor Gmünd')).toBe('ja quaekt schwyz poebel vor gmuend');
     });
+
+    it('contracts multiple sequential replacers to a single replacer', () => {
+        expect(normalizeString('foo - bar', '-')).toBe('foo-bar');
+        expect(normalizeString('foo--bar', '-')).toBe('foo-bar');
+        expect(normalizeString('foo - bar', '_')).toBe('foo_-_bar');
+        expect(normalizeString('foo _ bar', '_')).toBe('foo_bar');
+    });
 });

--- a/packages/common/src/normalize-string.ts
+++ b/packages/common/src/normalize-string.ts
@@ -4,6 +4,8 @@
  * Based on https://stackoverflow.com/a/37511463/772859
  */
 export function normalizeString(input: string, spaceReplacer = ' '): string {
+    const multipleSequentialReplacerRegex = new RegExp(`([${spaceReplacer}]){2,}`, 'g');
+
     return (input || '')
         .normalize('NFD')
         .replace(/[\u00df]/g, 'ss')
@@ -12,5 +14,6 @@ export function normalizeString(input: string, spaceReplacer = ' '): string {
         .replace(/[\u0300-\u036f]/g, '')
         .toLowerCase()
         .replace(/[!"£$%^&*()+[\]{};:@#~?\\/,|><`¬'=‘’©®™]/g, '')
-        .replace(/\s+/g, spaceReplacer);
+        .replace(/\s+/g, spaceReplacer)
+        .replace(multipleSequentialReplacerRegex, spaceReplacer);
 }


### PR DESCRIPTION
# Description

The `normalizeString` function doesn't effectively support cases where the replacer itself occurs in the original string.
`My Product - Complete Collection` -> `my-product---complete-collection`

this PR adjusts the normalizer such that the resultant output is `my-product-complete-collection`

(i've taken a [solitary additional upvote](https://github.com/vendure-ecommerce/vendure/discussions/3169) as the go-ahead signal)

# Breaking changes

Does this PR include any breaking changes we should be aware of? nup

# Screenshots

You can add screenshots here if applicable.

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [x] I have added or updated test cases
- [ ] I have updated the README if needed
