### PR TITLE
Add productVariantId,orderId to OrderLine api, orderId column to OrderLine

### DIFF
--- a/packages/core/src/api/schema/common/order.type.graphql
+++ b/packages/core/src/api/schema/common/order.type.graphql
@@ -122,6 +122,7 @@ type OrderLine implements Node {
     createdAt: DateTime!
     updatedAt: DateTime!
     productVariant: ProductVariant!
+    productVariantId: ID!
     featuredAsset: Asset
     "The price of a single unit, excluding tax and discounts"
     unitPrice: Money!
@@ -184,6 +185,7 @@ type OrderLine implements Node {
     discounts: [Discount!]!
     taxLines: [TaxLine!]!
     order: Order!
+    orderId: ID!
     fulfillmentLines: [FulfillmentLine!]
 }
 

--- a/packages/core/src/entity/order-line/order-line.entity.ts
+++ b/packages/core/src/entity/order-line/order-line.entity.ts
@@ -87,6 +87,9 @@ export class OrderLine extends VendureEntity implements HasCustomFields {
     @ManyToOne(type => Order, order => order.lines, { onDelete: 'CASCADE' })
     order: Order;
 
+    @EntityId()
+    orderId: ID;
+
     @OneToMany(type => OrderLineReference, lineRef => lineRef.orderLine)
     linesReferences: OrderLineReference[];
 


### PR DESCRIPTION
# Description

I cannot tell you how much time I spent on performance related issues caused by needing access to the `orderId` from an `OrderLine` without having access to the root `order`. 

Vendure strongly assumes that orderLines and payments are accessed through the order. And normally, that's the case. However, there are a number of scenario's where you might want to access the `orderId` or `productVariantId` without loading those entities. And you might not have the root order entity handy. It's a scenario common to us.

Also, Vendure should IMHO optimize for getting all ManyToOne columns easily through GraphQL and code, without having to load the entire entity if all you need is the id. Which IS a common scenario.

I want to push another PR which addreses ALL of the columns and ManyToOne relations, but let's see how this one goes first :-)

# Breaking changes

No

# Screenshots

# Checklist

📌 Always:
- [x ] I have set a clear title
- [x ] My PR is small and contains a single feature
- [ x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [ ] I have added or updated test cases
- [ ] I have updated the README if needed
