### PR TITLE
fix(payments-plugin): use some instead of find

### DIFF
--- a/packages/payments-plugin/src/stripe/stripe-utils.ts
+++ b/packages/payments-plugin/src/stripe/stripe-utils.ts
@@ -34,7 +34,7 @@ function currencyHasFractionPart(currencyCode: CurrencyCode): boolean {
         currencyDisplay: 'symbol',
     }).formatToParts(123.45);
 
-    return !!parts.find(p => p.type === 'fraction');
+    return parts.some(p => p.type === 'fraction');
 }
 
 /**


### PR DESCRIPTION
# Description

This pull request includes a small change to the `currencyHasFractionPart` function in the `stripe-utils.ts` file. The change improves the readability of the code by replacing the `find` method with the `some` method to check for the presence of a fraction part in the currency formatting.

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [ ] I have added or updated test cases
- [ ] I have updated the README if needed
