### PR TITLE
Recommend global installation for Vendure CLI in Documentation

### DIFF
--- a/docs/docs/guides/developer-guide/cli/index.md
+++ b/docs/docs/guides/developer-guide/cli/index.md
@@ -17,20 +17,20 @@ codebase to integrate new functionality.
 The Vendure CLI comes installed with a new Vendure project by default from v2.2.0+
 :::
 
-To manually install the CLI, run:
+To install the Vendure CLI globally, run:
 
 <Tabs groupId="package-manager">
 <TabItem value="npm" label="npm" default>
 
 ```bash
-npm install -D @vendure/cli
+npm install -g @vendure/cli
 ```
 
 </TabItem>
 <TabItem value="yarn" label="yarn">
 
 ```bash
-yarn add -D @vendure/cli
+yarn add -g @vendure/cli
 ```
 
 </TabItem>


### PR DESCRIPTION
# Description

This PR updates the installation instructions for the Vendure CLI. Previously, the documentation suggested installing the Vendure CLI locally in each project. However, I recommend installing the Vendure CLI globally to streamline the developer workflow and avoid redundant installations.

### Key Changes:

**Global Installation**: Installing the Vendure CLI globally via `npm install -g @vendure/cli` eliminates the need to install it in each individual project. This makes the CLI available for use across all projects on the system, improving the developer experience.

  **Local Installation** (Optional): Local installation instructions remain available for users who prefer a project-specific setup, but the global installation option should be the default for most use cases.

# Breaking changes

No

# Screenshots

No

# Checklist

📌 Always:
- [X] I have set a clear title
- [X] My PR is small and contains a single feature
- [ ] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [ ] I have added or updated test cases
- [ ] I have updated the README if needed
