### PR TITLE
fix: add support for mac's command key for selection manager

### DIFF
--- a/packages/admin-ui/src/lib/core/src/common/utilities/selection-manager.ts
+++ b/packages/admin-ui/src/lib/core/src/common/utilities/selection-manager.ts
@@ -47,7 +47,7 @@ export class SelectionManager<T> {
                 ...this.items.slice(start, end).filter(a => !this._selection.find(s => itemsAreEqual(a, s))),
             );
         } else if (index === -1) {
-            if (multiSelect && (event?.ctrlKey || event?.shiftKey || additiveMode)) {
+            if (multiSelect && ((event?.ctrlKey || event?.metaKey) || event?.shiftKey || additiveMode)) {
                 this._selection.push(item);
             } else {
                 this._selection = [item];

--- a/packages/admin-ui/src/lib/core/src/common/utilities/selection-manager.ts
+++ b/packages/admin-ui/src/lib/core/src/common/utilities/selection-manager.ts
@@ -53,7 +53,7 @@ export class SelectionManager<T> {
                 this._selection = [item];
             }
         } else {
-            if (multiSelect && event?.ctrlKey) {
+            if (multiSelect && (event?.ctrlKey || event?.metaKey)) {
                 this._selection.splice(index, 1);
             } else if (1 < this._selection.length && !additiveMode) {
                 this._selection = [item];


### PR DESCRIPTION
# Description
Selection manager was missing support for multiple selection with the mac's command key, causing Mac users unable to select images one by one. since holding control on Mac opens the right click menu on chrome based browsers.

# Breaking changes
No

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [ ] I have added or updated test cases
- [ ] I have updated the README if needed
