### PR TITLE
fix(core): Clear previous line adjustments before testing order item promotions

### DIFF
--- a/packages/core/src/service/helpers/order-calculator/order-calculator.ts
+++ b/packages/core/src/service/helpers/order-calculator/order-calculator.ts
@@ -186,8 +186,8 @@ export class OrderCalculator {
         for (const line of order.lines) {
             // Must be re-calculated for each line, since the previous lines may have triggered promotions
             // which affected the order price.
-            const applicablePromotions = await filterAsync(promotions, p => p.test(ctx, order).then(Boolean));
             line.clearAdjustments();
+            const applicablePromotions = await filterAsync(promotions, p => p.test(ctx, order).then(Boolean));
 
             for (const promotion of applicablePromotions) {
                 let priceAdjusted = false;


### PR DESCRIPTION
# Description

`OrderCalculator#applyOrderPromotions` clears out all existing `DISTRIBUTED_ORDER_PROMOTION`s before testing promotions. `applyOrderItemPromotions` does not currently do the same, the result of which is that when conditions / actions are encountered, previous adjustment data may be present on the line items in question.

My specific use case was when creating a promotion of the type "apply a bulk purchase discount, but only to items that aren't already discounted," e.g. when there are 10+ of a product and they aren't already discounted.

**Without this change**: upon reaching 10 items, the line items become discounted. Upon reaching 11 items, the test for "are there adjustments applied" returns true (the previous adjustment), resulting in the discount being removed. Bump the quantity to 12 and it applies again.

**With this change**: it works properly when reaching 10, 11, 12, and on.

# Breaking changes

No.

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [x] I have added or updated test cases
- [x] (N/A) I have updated the README if needed
