### PR TITLE
fix(docs): Remove unused import "WishlistItem" from resolver snippet

### DIFF
--- a/docs/docs/guides/developer-guide/plugins/index.mdx
+++ b/docs/docs/guides/developer-guide/plugins/index.mdx
@@ -519,7 +519,6 @@ Now that we have defined the GraphQL schema extensions, we need to create a reso
 import { Args, Mutation, Query, Resolver } from '@nestjs/graphql';
 import { Allow, Ctx, Permission, RequestContext, Transaction } from '@vendure/core';
 
-import { WishlistItem } from '../entities/wishlist-item.entity';
 import { WishlistService } from '../services/wishlist.service';
 
 @Resolver()


### PR DESCRIPTION
# Description

Removed the unused `WishlistItem` import from the resolver code snippet in the documentation.  

## 🛠 Changes  
- Removed `import { WishlistItem } from '../entities/wishlist-item.entity';` as it was unused in the snippet.  

## ✅ Impact  
Improves code quality and avoids confusion for developers following the documentation.  

## 🧐 Context  
The import was not used in the provided resolver snippet, and removing it ensures cleaner and more accurate examples.  

# Breaking changes

No

# Screenshots

You can add screenshots here if applicable.

# Checklist

📌 Always:
- [ ] I have set a clear title
- [ ] My PR is small and contains a single feature
- [ ] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [ ] I have added or updated test cases
- [ ] I have updated the README if needed
