### PR TITLE
docs: Clarify migration commands for testing plugins

### DIFF
--- a/docs/docs/guides/developer-guide/plugins/index.mdx
+++ b/docs/docs/guides/developer-guide/plugins/index.mdx
@@ -621,13 +621,27 @@ export const config: VendureConfig = {
 };
 ```
 
-### Test the plugin
+### Test the Plugin
 
-Now that the plugin is installed, we can test it out. Since we have defined a custom field, we'll need to generate and run a migration to add the new column to the database:
+Now that the plugin is installed, we can test it out. Since we have defined a custom field, we'll need to generate and run a migration to add the new column to the database.
 
-```bash
-npm run migration:generate wishlist-plugin
-```
+1. **Generate the Migration File**
+
+   Run the following command to generate a migration file for the `wishlist-plugin`:
+
+   ```bash
+   npx vendure migrate wishlist-plugin
+   ```
+
+When prompted, select the "Generate a new migration" option. This will create a new migration file in the `src/migrations` folder.
+
+2. **Run the Migration**
+
+After generating the migration file, apply the changes to the database by running the same command again:
+
+   ```bash
+   npx vendure migrate wishlist-plugin
+   ```
 
 Then start the server:
 


### PR DESCRIPTION
# Description

This PR clarifies the migration commands in the "Test the Plugin" section of the Vendure documentation. The current instructions are incomplete and could lead to confusion for users trying to test their plugins.

   Changes:

**Updated the documentation to clearly separate the two steps required for migrations**:

- Generating the migration file using `npx vendure migrate wishlist-plugin`.

- Running the migration using `npx vendure migrate wishlist-plugin`.

**Why this matters:**

- The current documentation only mentions the first step (npm run migration:generate), which give error on cmd.

- By explicitly stating both steps, users can seamlessly test their plugins without confusion or errors.

# Breaking changes

No

# Screenshots

You can add screenshots here if applicable.

# Checklist

📌 Always:
- [ ] I have set a clear title
- [ ] My PR is small and contains a single feature
- [ ] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [ ] I have added or updated test cases
- [ ] I have updated the README if needed
