### PR TITLE
Fix(core): Allow non-public customOrderLineFields in admin api

### DIFF
--- a/packages/core/src/api/config/configure-graphql-module.ts
+++ b/packages/core/src/api/config/configure-graphql-module.ts
@@ -160,7 +160,7 @@ async function createGraphQLOptions(
             .forEach(documentNode => (schema = extendSchema(schema, documentNode)));
         schema = generateListOptions(schema);
         schema = addGraphQLCustomFields(schema, customFields, apiType === 'shop');
-        schema = addOrderLineCustomFieldsInput(schema, customFields.OrderLine || []);
+        schema = addOrderLineCustomFieldsInput(schema, customFields.OrderLine || [], apiType === 'shop');
         schema = addModifyOrderCustomFields(schema, customFields.Order || []);
         schema = addShippingMethodQuoteCustomFields(schema, customFields.ShippingMethod || []);
         schema = addPaymentMethodQuoteCustomFields(schema, customFields.PaymentMethod || []);

--- a/packages/core/src/api/config/graphql-custom-fields.ts
+++ b/packages/core/src/api/config/graphql-custom-fields.ts
@@ -394,10 +394,13 @@ export function addModifyOrderCustomFields(
 export function addOrderLineCustomFieldsInput(
     typeDefsOrSchema: string | GraphQLSchema,
     orderLineCustomFields: CustomFieldConfig[],
+    publicOnly: boolean,
 ): GraphQLSchema {
     const schema = typeof typeDefsOrSchema === 'string' ? buildSchema(typeDefsOrSchema) : typeDefsOrSchema;
+    orderLineCustomFields = orderLineCustomFields.filter(f => f.internal !== true);
     const publicCustomFields = orderLineCustomFields.filter(f => f.public !== false);
-    if (!publicCustomFields || publicCustomFields.length === 0) {
+    const customFields = publicOnly ? publicCustomFields : orderLineCustomFields;
+    if (!customFields || customFields.length === 0) {
         return schema;
     }
     const schemaConfig = schema.toConfig();
@@ -428,7 +431,7 @@ export function addOrderLineCustomFieldsInput(
     }
     const input = new GraphQLInputObjectType({
         name: 'OrderLineCustomFieldsInput',
-        fields: publicCustomFields.reduce((fields, field) => {
+        fields: customFields.reduce((fields, field) => {
             const name = getGraphQlInputName(field);
             const inputTypeName = getGraphQlInputType('OrderLine')(field);
             // eslint-disable-next-line @typescript-eslint/no-non-null-assertion


### PR DESCRIPTION
# Description
Previously, adjustDraftOrderLine and other admin mutation on order lines did not include non-public custom OrderLine fields. This fixes that. I think my issue is the same as issue #3342 and this should fix #3342.

I also filtered out internal fields, as custom fields simply marked internal were showing in the order line input for both admin and shop api.

# Breaking changes
No known breaking changes

# Screenshots

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [ ] I have added or updated test cases
- [ ] I have updated the README if needed
