### PR TITLE
fix(core): Avoid variant options combination check on updateProductVariant mutation

### DIFF
--- a/packages/core/src/service/services/product-variant.service.ts
+++ b/packages/core/src/service/services/product-variant.service.ts
@@ -483,7 +483,7 @@ export class ProductVariantService {
             throw new UserInputError('error.stockonhand-cannot-be-negative');
         }
         if (input.optionIds) {
-            await this.validateVariantOptionIds(ctx, existingVariant.productId, input.optionIds);
+            await this.validateVariantOptionIds(ctx, existingVariant.productId, input.optionIds, true);
         }
         const inputWithoutPriceAndStockLevels = {
             ...input,
@@ -899,7 +899,12 @@ export class ProductVariantService {
         return result;
     }
 
-    private async validateVariantOptionIds(ctx: RequestContext, productId: ID, optionIds: ID[] = []) {
+    private async validateVariantOptionIds(
+        ctx: RequestContext,
+        productId: ID,
+        optionIds: ID[] = [],
+        isUpdateOperation?: boolean,
+    ) {
         // this could be done with fewer queries but depending on the data, node will crash
         // https://github.com/vendure-ecommerce/vendure/issues/328
         const optionGroups = (
@@ -936,6 +941,7 @@ export class ProductVariantService {
             .filter(v => !v.deletedAt)
             .forEach(variant => {
                 const variantOptionIds = this.sortJoin(variant.options, ',', 'id');
+                if (isUpdateOperation) return;
                 if (variantOptionIds === inputOptionIds) {
                     throw new UserInputError('error.product-variant-options-combination-already-exists', {
                         variantName: this.translator.translate(variant, ctx).name,


### PR DESCRIPTION
# Description

Avoids throwing an error checking for variant option combinations that already exist when updating variants.
Related Issue: #3190 

# Breaking changes

No

# Screenshots

Error doesnt show up now when updating an variant while also specifying the current optionIds
![image](https://github.com/user-attachments/assets/975befeb-d73f-4760-8e42-ff7d16a11933)

But is thrown when trying to specify already existing optionIds while creating a new variant 
![image](https://github.com/user-attachments/assets/101622c3-3c0b-4f09-b2ee-5897cac75ad9)


# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [ ] I have added or updated test cases
- [ ] I have updated the README if needed
