### PR TITLE
fix(core): Avoid variant options combination check on updateProductVariant mutation

### DIFF
--- a/packages/core/e2e/product.e2e-spec.ts
+++ b/packages/core/e2e/product.e2e-spec.ts
@@ -1736,22 +1736,28 @@ describe('Product resolver', () => {
                     }, 'ProductVariant optionIds must include one optionId from each of the groups: group-2, group-3'),
                 );
 
-                it(
-                    'passing optionIds that match an existing variant throws',
-                    assertThrowsWithMessage(async () => {
-                        await adminClient.query<
-                            Codegen.UpdateProductVariantsMutation,
-                            Codegen.UpdateProductVariantsMutationVariables
-                        >(UPDATE_PRODUCT_VARIANTS, {
-                            input: [
-                                {
-                                    id: variantToModify.id,
-                                    optionIds: variants[1]!.options.map(o => o.id),
-                                },
-                            ],
-                        });
-                    }, 'A ProductVariant with the selected options already exists: Variant 3'),
-                );
+                it('passing optionIds that match an existing variant should not throw', async () => {
+                    const { updateProductVariants } = await adminClient.query<
+                        Codegen.UpdateProductVariantsMutation,
+                        Codegen.UpdateProductVariantsMutationVariables
+                    >(UPDATE_PRODUCT_VARIANTS, {
+                        input: [
+                            {
+                                id: variantToModify.id,
+                                optionIds: variantToModify!.options.map(o => o.id),
+                                sku: 'ABC',
+                                price: 432,
+                            },
+                        ],
+                    });
+                    const updatedVariant = updateProductVariants[0];
+                    if (!updatedVariant) {
+                        fail('no updated variant returned.');
+                        return;
+                    }
+                    expect(updatedVariant.sku).toBe('ABC');
+                    expect(updatedVariant.price).toBe(432);
+                });
 
                 it('addOptionGroupToProduct and then update existing ProductVariant with a new option', async () => {
                     const optionGroup4 = await createOptionGroup('group-4', [

--- a/packages/core/src/service/services/product-variant.service.ts
+++ b/packages/core/src/service/services/product-variant.service.ts
@@ -483,7 +483,7 @@ export class ProductVariantService {
             throw new UserInputError('error.stockonhand-cannot-be-negative');
         }
         if (input.optionIds) {
-            await this.validateVariantOptionIds(ctx, existingVariant.productId, input.optionIds);
+            await this.validateVariantOptionIds(ctx, existingVariant.productId, input.optionIds, true);
         }
         const inputWithoutPriceAndStockLevels = {
             ...input,
@@ -899,7 +899,12 @@ export class ProductVariantService {
         return result;
     }
 
-    private async validateVariantOptionIds(ctx: RequestContext, productId: ID, optionIds: ID[] = []) {
+    private async validateVariantOptionIds(
+        ctx: RequestContext,
+        productId: ID,
+        optionIds: ID[] = [],
+        isUpdateOperation?: boolean,
+    ) {
         // this could be done with fewer queries but depending on the data, node will crash
         // https://github.com/vendure-ecommerce/vendure/issues/328
         const optionGroups = (
@@ -936,6 +941,7 @@ export class ProductVariantService {
             .filter(v => !v.deletedAt)
             .forEach(variant => {
                 const variantOptionIds = this.sortJoin(variant.options, ',', 'id');
+                if (isUpdateOperation) return;
                 if (variantOptionIds === inputOptionIds) {
                     throw new UserInputError('error.product-variant-options-combination-already-exists', {
                         variantName: this.translator.translate(variant, ctx).name,


### PR DESCRIPTION
# Description

Avoids throwing an error checking for variant option combinations that already exist when updating variants.
Related Issue: #3190

# Breaking changes

no

# Screenshots

Error doesnt show up now when updating an variant while also specifying the current optionIds
![image](https://github.com/user-attachments/assets/c29ccae6-3e42-4fc4-8e29-d0b9e8b5907a)

But is thrown when trying to specify already existing optionIds while creating a new variant
![image](https://github.com/user-attachments/assets/15cd8737-505f-496b-8d3e-92b9a81372b1)

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [x] I have added or updated test cases
- [ ] I have updated the README if needed
