### PR TITLE
fix(core): Retrieve the softDelete ProductOptionGroup

### DIFF
--- a/packages/core/src/service/services/product-option-group.service.ts
+++ b/packages/core/src/service/services/product-option-group.service.ts
@@ -5,7 +5,7 @@ import {
     UpdateProductOptionGroupInput,
 } from '@vendure/common/lib/generated-types';
 import { ID } from '@vendure/common/lib/shared-types';
-import { FindManyOptions, Like } from 'typeorm';
+import { FindManyOptions, IsNull, Like } from 'typeorm';
 
 import { RequestContext } from '../../api/common/request-context';
 import { RelationPaths } from '../../api/decorators/relations.decorator';
@@ -69,7 +69,10 @@ export class ProductOptionGroupService {
         return this.connection
             .getRepository(ctx, ProductOptionGroup)
             .findOne({
-                where: { id },
+                where: {
+                    id,
+                    deletedAt: IsNull(),
+                },
                 relations: relations ?? ['options'],
             })
             .then(group => (group && this.translator.translate(group, ctx, ['options'])) ?? undefined);


### PR DESCRIPTION
# Description

Hey sir, I just updated one line, this PR is related to <https://github.com/vendure-ecommerce/vendure/issues/3281>, I can retrieve the `ProductOptionGroup` which had been soft deleted.

I use `removeOptionGroupFromProduct` to remove an `optionGroup` from a product,all the `productVariants` have been `softDelete`.

But after this remove,I can still use`ProductOptionGroup` GraphQL API get the `optionGroup` which had been soft deleted .I checked the database and the column `deletedAt` has value.

# Breaking changes

N/A

# Screenshots

Database:

<img width="822" alt="image" src="https://github.com/user-attachments/assets/a452802c-4c15-4bfd-a4dd-da9e8ac03acb" />

GraphQL:

<img width="320" alt="image" src="https://github.com/user-attachments/assets/1a714782-1b08-4f3c-b81d-9c8fd3811bdf" />

Before Updating:

<img width="444" alt="image" src="https://github.com/user-attachments/assets/c3bafa60-99c0-4303-a94f-e5da55d60d37" />

After Updating:

<img width="354" alt="image" src="https://github.com/user-attachments/assets/d41723b1-5955-4977-b46a-9b703cb3538a" />

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [ ] I have added or updated test cases
- [ ] I have updated the README if needed
