### PR TITLE
docs: fix incorrect RequestContext serialization method

### DIFF
--- a/docs/docs/guides/developer-guide/worker-job-queue/index.mdx
+++ b/docs/docs/guides/developer-guide/worker-job-queue/index.mdx
@@ -326,8 +326,9 @@ export class ProductVideoPlugin {}
 
 Sometimes you need to pass the [RequestContext object](/reference/typescript-api/request/request-context) to the `process` function of a job, since `ctx` is required by many Vendure
 service methods that you may be using inside your `process` function. However, the `RequestContext` object itself is not serializable,
-so it cannot be passed directly to the `JobQueue.add()` method. Instead, you can serialize the `RequestContext` using the  ctx.serialize() method `
-method](/reference/typescript-api/request/request-context/#serialize), and then deserialize it in the `process` function using the static `deserialize` method:
+so it cannot be passed directly to the `JobQueue.add()` method. Instead, you can serialize the `RequestContext` using the [`ctx.serialize()` method](/reference/typescript-api/request/request-context/#serialize),
+ and then deserialize it in the `process` function using the static `deserialize` method.
+
 
 ```ts
 import { Injectable, OnModuleInit } from '@nestjs/common';

--- a/docs/docs/guides/developer-guide/worker-job-queue/index.mdx
+++ b/docs/docs/guides/developer-guide/worker-job-queue/index.mdx
@@ -326,7 +326,7 @@ export class ProductVideoPlugin {}
 
 Sometimes you need to pass the [RequestContext object](/reference/typescript-api/request/request-context) to the `process` function of a job, since `ctx` is required by many Vendure
 service methods that you may be using inside your `process` function. However, the `RequestContext` object itself is not serializable,
-so it cannot be passed directly to the `JobQueue.add()` method. Instead, you can serialize the `RequestContext` using the  ctx.serialize() method where ctx is an instance of `RequestContext` `
+so it cannot be passed directly to the `JobQueue.add()` method. Instead, you can serialize the `RequestContext` using the  ctx.serialize() method `
 method](/reference/typescript-api/request/request-context/#serialize), and then deserialize it in the `process` function using the static `deserialize` method:
 
 ```ts

--- a/docs/docs/guides/developer-guide/worker-job-queue/index.mdx
+++ b/docs/docs/guides/developer-guide/worker-job-queue/index.mdx
@@ -326,7 +326,7 @@ export class ProductVideoPlugin {}
 
 Sometimes you need to pass the [RequestContext object](/reference/typescript-api/request/request-context) to the `process` function of a job, since `ctx` is required by many Vendure
 service methods that you may be using inside your `process` function. However, the `RequestContext` object itself is not serializable,
-so it cannot be passed directly to the `JobQueue.add()` method. Instead, you can serialize the `RequestContext` using the [`RequestContext.serialize()`
+so it cannot be passed directly to the `JobQueue.add()` method. Instead, you can serialize the `RequestContext` using the  ctx.serialize() method where ctx is an instance of `RequestContext` `
 method](/reference/typescript-api/request/request-context/#serialize), and then deserialize it in the `process` function using the static `deserialize` method:
 
 ```ts
@@ -358,7 +358,7 @@ class ProductExportService implements OnModuleInit {
 
     exportAllProducts(ctx: RequestContext) {
         // highlight-next-line
-        return this.jobQueue.add({ ctx: RequestContext.serialize(ctx) });
+        return this.jobQueue.add({ ctx: ctx.serialize() });
     }
 }
 ```
@@ -468,7 +468,7 @@ class ProductExportService implements OnModuleInit {
     }
 
     exportAllProducts(ctx: RequestContext) {
-        return this.jobQueue.add({ ctx: RequestContext.serialize(ctx) });
+        return this.jobQueue.add({ ctx: ctx.serialize() });
     }
 }
 ```


### PR DESCRIPTION
# Description

Update documentation for RequestContext serialization to correctly use `ctx.serialize()` instead of `RequestContext.serialize(ctx)`. This change resolves an issue where the documentation incorrectly referenced a static method that does not exist, leading to confusion.

# Breaking changes

 N/A

# Screenshots

  N/A


# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [ ] I have added or updated test cases
- [ ] I have updated the README if needed
