### PR TITLE
feat(elastic-search): add request context to mapQuery

### DIFF
--- a/packages/elasticsearch-plugin/src/build-elastic-body.spec.ts
+++ b/packages/elasticsearch-plugin/src/build-elastic-body.spec.ts
@@ -1,5 +1,5 @@
 import { LanguageCode, LogicalOperator, SortOrder } from '@vendure/common/lib/generated-types';
-import { DeepRequired } from '@vendure/core';
+import { Channel, DeepRequired, RequestContext } from '@vendure/core';
 import { describe, expect, it } from 'vitest';
 
 import { buildElasticBody } from './build-elastic-body';
@@ -10,9 +10,23 @@ describe('buildElasticBody()', () => {
     const CHANNEL_ID = 42;
     const CHANNEL_ID_TERM = { term: { channelId: CHANNEL_ID } };
     const LANGUAGE_CODE_TERM = { term: { languageCode: LanguageCode.en } };
+    const ctx = new RequestContext({
+        apiType: 'admin',
+        isAuthorized: true,
+        authorizedAsOwnerOnly: false,
+        channel: new Channel({ id: CHANNEL_ID }),
+        languageCode: LanguageCode.en,
+    });
 
     it('search term', () => {
-        const result = buildElasticBody({ term: 'test' }, searchConfig, CHANNEL_ID, LanguageCode.en);
+        const result = buildElasticBody(
+            { term: 'test' },
+            searchConfig,
+            CHANNEL_ID,
+            LanguageCode.en,
+            undefined,
+            ctx,
+        );
         expect(result.query).toEqual({
             bool: {
                 filter: [CHANNEL_ID_TERM, LANGUAGE_CODE_TERM],
@@ -36,6 +50,8 @@ describe('buildElasticBody()', () => {
             searchConfig,
             CHANNEL_ID,
             LanguageCode.en,
+            undefined,
+            ctx,
         );
         expect(result.query).toEqual({
             bool: {
@@ -58,6 +74,8 @@ describe('buildElasticBody()', () => {
             searchConfig,
             CHANNEL_ID,
             LanguageCode.en,
+            undefined,
+            ctx,
         );
         expect(result.query).toEqual({
             bool: {
@@ -80,6 +98,8 @@ describe('buildElasticBody()', () => {
             searchConfig,
             CHANNEL_ID,
             LanguageCode.en,
+            undefined,
+            ctx,
         );
         expect(result.query).toEqual({
             bool: {
@@ -103,6 +123,8 @@ describe('buildElasticBody()', () => {
             searchConfig,
             CHANNEL_ID,
             LanguageCode.en,
+            undefined,
+            ctx,
         );
         expect(result.query).toEqual({
             bool: {
@@ -122,6 +144,8 @@ describe('buildElasticBody()', () => {
             searchConfig,
             CHANNEL_ID,
             LanguageCode.en,
+            undefined,
+            ctx,
         );
         expect(result.query).toEqual({
             bool: {
@@ -148,6 +172,8 @@ describe('buildElasticBody()', () => {
             searchConfig,
             CHANNEL_ID,
             LanguageCode.en,
+            undefined,
+            ctx,
         );
         expect(result.query).toEqual({
             bool: {
@@ -180,6 +206,8 @@ describe('buildElasticBody()', () => {
             searchConfig,
             CHANNEL_ID,
             LanguageCode.en,
+            undefined,
+            ctx,
         );
         expect(result.query).toEqual({
             bool: {
@@ -203,7 +231,14 @@ describe('buildElasticBody()', () => {
     });
 
     it('collectionId', () => {
-        const result = buildElasticBody({ collectionId: '1' }, searchConfig, CHANNEL_ID, LanguageCode.en);
+        const result = buildElasticBody(
+            { collectionId: '1' },
+            searchConfig,
+            CHANNEL_ID,
+            LanguageCode.en,
+            undefined,
+            ctx,
+        );
         expect(result.query).toEqual({
             bool: {
                 filter: [CHANNEL_ID_TERM, LANGUAGE_CODE_TERM, { term: { collectionIds: '1' } }],
@@ -217,6 +252,8 @@ describe('buildElasticBody()', () => {
             searchConfig,
             CHANNEL_ID,
             LanguageCode.en,
+            undefined,
+            ctx,
         );
         expect(result.query).toEqual({
             bool: {
@@ -226,7 +263,14 @@ describe('buildElasticBody()', () => {
     });
 
     it('paging', () => {
-        const result = buildElasticBody({ skip: 20, take: 10 }, searchConfig, CHANNEL_ID, LanguageCode.en);
+        const result = buildElasticBody(
+            { skip: 20, take: 10 },
+            searchConfig,
+            CHANNEL_ID,
+            LanguageCode.en,
+            undefined,
+            ctx,
+        );
         expect(result).toEqual({
             from: 20,
             size: 10,
@@ -242,6 +286,8 @@ describe('buildElasticBody()', () => {
             searchConfig,
             CHANNEL_ID,
             LanguageCode.en,
+            undefined,
+            ctx,
         );
         expect(result.query).toEqual({
             bool: {
@@ -256,6 +302,8 @@ describe('buildElasticBody()', () => {
             searchConfig,
             CHANNEL_ID,
             LanguageCode.en,
+            undefined,
+            ctx,
         );
         expect(result.query).toEqual({
             bool: {
@@ -265,7 +313,14 @@ describe('buildElasticBody()', () => {
     });
 
     it('inStock is undefined and groupByProduct', () => {
-        const result = buildElasticBody({ groupByProduct: true }, searchConfig, CHANNEL_ID, LanguageCode.en);
+        const result = buildElasticBody(
+            { groupByProduct: true },
+            searchConfig,
+            CHANNEL_ID,
+            LanguageCode.en,
+            undefined,
+            ctx,
+        );
         expect(result.query).toEqual({
             bool: {
                 filter: [CHANNEL_ID_TERM, LANGUAGE_CODE_TERM],
@@ -279,6 +334,8 @@ describe('buildElasticBody()', () => {
             searchConfig,
             CHANNEL_ID,
             LanguageCode.en,
+            undefined,
+            ctx,
         );
         expect(result.query).toEqual({
             bool: {
@@ -293,6 +350,8 @@ describe('buildElasticBody()', () => {
             searchConfig,
             CHANNEL_ID,
             LanguageCode.en,
+            undefined,
+            ctx,
         );
         expect(result.query).toEqual({
             bool: {
@@ -302,7 +361,14 @@ describe('buildElasticBody()', () => {
     });
 
     it('inStock is undefined and not groupByProduct', () => {
-        const result = buildElasticBody({ groupByProduct: false }, searchConfig, CHANNEL_ID, LanguageCode.en);
+        const result = buildElasticBody(
+            { groupByProduct: false },
+            searchConfig,
+            CHANNEL_ID,
+            LanguageCode.en,
+            undefined,
+            ctx,
+        );
         expect(result.query).toEqual({
             bool: {
                 filter: [CHANNEL_ID_TERM, LANGUAGE_CODE_TERM],
@@ -317,6 +383,8 @@ describe('buildElasticBody()', () => {
                 searchConfig,
                 CHANNEL_ID,
                 LanguageCode.en,
+                undefined,
+                ctx,
             );
             expect(result.sort).toEqual([{ 'productName.keyword': { order: 'desc' } }]);
         });
@@ -327,6 +395,8 @@ describe('buildElasticBody()', () => {
                 searchConfig,
                 CHANNEL_ID,
                 LanguageCode.en,
+                undefined,
+                ctx,
             );
             expect(result.sort).toEqual([{ price: { order: 'asc' } }]);
         });
@@ -337,13 +407,15 @@ describe('buildElasticBody()', () => {
                 searchConfig,
                 CHANNEL_ID,
                 LanguageCode.en,
+                undefined,
+                ctx,
             );
             expect(result.sort).toEqual([{ price: { order: 'asc' } }]);
         });
     });
 
     it('enabledOnly true', () => {
-        const result = buildElasticBody({}, searchConfig, CHANNEL_ID, LanguageCode.en, true);
+        const result = buildElasticBody({}, searchConfig, CHANNEL_ID, LanguageCode.en, true, ctx);
         expect(result.query).toEqual({
             bool: {
                 filter: [CHANNEL_ID_TERM, LANGUAGE_CODE_TERM, { term: { enabled: true } }],
@@ -352,7 +424,7 @@ describe('buildElasticBody()', () => {
     });
 
     it('enabledOnly false', () => {
-        const result = buildElasticBody({}, searchConfig, CHANNEL_ID, LanguageCode.en, false);
+        const result = buildElasticBody({}, searchConfig, CHANNEL_ID, LanguageCode.en, false, ctx);
         expect(result.query).toEqual({
             bool: { filter: [CHANNEL_ID_TERM, LANGUAGE_CODE_TERM] },
         });
@@ -375,6 +447,7 @@ describe('buildElasticBody()', () => {
             CHANNEL_ID,
             LanguageCode.en,
             true,
+            ctx,
         );
 
         expect(result).toEqual({
@@ -420,6 +493,8 @@ describe('buildElasticBody()', () => {
             { ...searchConfig, multiMatchType: 'phrase' },
             CHANNEL_ID,
             LanguageCode.en,
+            undefined,
+            ctx,
         );
         expect(result.query).toEqual({
             bool: {
@@ -450,7 +525,14 @@ describe('buildElasticBody()', () => {
                 },
             },
         };
-        const result = buildElasticBody({ term: 'test' }, config, CHANNEL_ID, LanguageCode.en);
+        const result = buildElasticBody(
+            { term: 'test' },
+            config,
+            CHANNEL_ID,
+            LanguageCode.en,
+            undefined,
+            ctx,
+        );
         expect(result.query).toEqual({
             bool: {
                 filter: [CHANNEL_ID_TERM, LANGUAGE_CODE_TERM],
@@ -483,7 +565,14 @@ describe('buildElasticBody()', () => {
                 },
             },
         };
-        const result = buildElasticBody({ term: 'test' }, config, CHANNEL_ID, LanguageCode.en);
+        const result = buildElasticBody(
+            { term: 'test' },
+            config,
+            CHANNEL_ID,
+            LanguageCode.en,
+            undefined,
+            ctx,
+        );
         expect(result.script_fields).toEqual({
             test: {
                 script: "doc['property'].dummyScript(test)",
@@ -498,6 +587,8 @@ describe('buildElasticBody()', () => {
                 searchConfig,
                 CHANNEL_ID,
                 LanguageCode.en,
+                undefined,
+                ctx,
             );
             expect(result.query).toEqual({
                 bool: {
@@ -523,6 +614,8 @@ describe('buildElasticBody()', () => {
                 searchConfig,
                 CHANNEL_ID,
                 LanguageCode.en,
+                undefined,
+                ctx,
             );
             expect(result.query).toEqual({
                 bool: {
@@ -548,6 +641,8 @@ describe('buildElasticBody()', () => {
                 searchConfig,
                 CHANNEL_ID,
                 LanguageCode.en,
+                undefined,
+                ctx,
             );
             expect(result.query).toEqual({
                 bool: {
@@ -573,6 +668,8 @@ describe('buildElasticBody()', () => {
                 searchConfig,
                 CHANNEL_ID,
                 LanguageCode.en,
+                undefined,
+                ctx,
             );
             expect(result.query).toEqual({
                 bool: {
@@ -603,6 +700,8 @@ describe('buildElasticBody()', () => {
                 searchConfig,
                 CHANNEL_ID,
                 LanguageCode.en,
+                undefined,
+                ctx,
             );
             expect(result.query).toEqual({
                 bool: {

--- a/packages/elasticsearch-plugin/src/build-elastic-body.ts
+++ b/packages/elasticsearch-plugin/src/build-elastic-body.ts
@@ -1,5 +1,5 @@
 import { LanguageCode, LogicalOperator, PriceRange, SortOrder } from '@vendure/common/lib/generated-types';
-import { DeepRequired, ID, UserInputError } from '@vendure/core';
+import { DeepRequired, ID, RequestContext, UserInputError } from '@vendure/core';
 
 import { SearchConfig } from './options';
 import { CustomScriptMapping, ElasticSearchInput, ElasticSearchSortInput, SearchRequestBody } from './types';
@@ -13,6 +13,7 @@ export function buildElasticBody(
     channelId: ID,
     languageCode: LanguageCode,
     enabledOnly: boolean = false,
+    ctx: RequestContext,
 ): SearchRequestBody {
     const {
         term,
@@ -130,7 +131,7 @@ export function buildElasticBody(
 
     const body: SearchRequestBody = {
         query: searchConfig.mapQuery
-            ? searchConfig.mapQuery(query, input, searchConfig, channelId, enabledOnly)
+            ? searchConfig.mapQuery(query, input, searchConfig, channelId, enabledOnly, ctx)
             : query,
         sort: searchConfig.mapSort ? searchConfig.mapSort(sortArray, input) : sortArray,
         from: skip || 0,

--- a/packages/elasticsearch-plugin/src/elasticsearch.service.ts
+++ b/packages/elasticsearch-plugin/src/elasticsearch.service.ts
@@ -189,6 +189,7 @@ export class ElasticsearchService implements OnModuleInit, OnModuleDestroy {
             ctx.channelId,
             ctx.languageCode,
             enabledOnly,
+            ctx,
         );
         if (groupByProduct) {
             try {
@@ -256,6 +257,7 @@ export class ElasticsearchService implements OnModuleInit, OnModuleDestroy {
             ctx.channelId,
             ctx.languageCode,
             enabledOnly,
+            ctx,
         );
         elasticSearchBody.from = 0;
         elasticSearchBody.size = 0;
@@ -367,6 +369,7 @@ export class ElasticsearchService implements OnModuleInit, OnModuleDestroy {
             ctx.channelId,
             ctx.languageCode,
             enabledOnly,
+            ctx,
         );
         elasticSearchBody.from = 0;
         elasticSearchBody.size = 0;
@@ -412,6 +415,7 @@ export class ElasticsearchService implements OnModuleInit, OnModuleDestroy {
             ctx.channelId,
             ctx.languageCode,
             true,
+            ctx,
         );
         elasticSearchBody.from = 0;
         elasticSearchBody.size = 0;

--- a/packages/elasticsearch-plugin/src/options.ts
+++ b/packages/elasticsearch-plugin/src/options.ts
@@ -7,7 +7,7 @@ import {
     LanguageCode,
     Product,
     ProductVariant,
-    RequestContext
+    RequestContext,
 } from '@vendure/core';
 import deepmerge from 'deepmerge';
 
@@ -240,7 +240,9 @@ export interface ElasticsearchOptions {
      * ```
      */
     customProductMappings?: {
-        [fieldName: string]: CustomMapping<[Product, ProductVariant[], LanguageCode, Injector, RequestContext]>;
+        [fieldName: string]: CustomMapping<
+            [Product, ProductVariant[], LanguageCode, Injector, RequestContext]
+        >;
     };
     /**
      * @description
@@ -487,8 +489,8 @@ export interface SearchConfig {
      *
      * @example
      * ```ts
-     * mapQuery: (query, input, searchConfig, channelId, enabledOnly){
-     *   if(query.bool.must){
+     * mapQuery: (query, input, searchConfig, channelId, enabledOnly, ctx) => {
+     *   if (query.bool.must) {
      *     delete query.bool.must;
      *   }
      *   query.bool.should = [
@@ -523,6 +525,7 @@ export interface SearchConfig {
         searchConfig: DeepRequired<SearchConfig>,
         channelId: ID,
         enabledOnly: boolean,
+        ctx: RequestContext,
     ) => any;
     /**
      * @description


### PR DESCRIPTION
# Description

Adds the request context to mapQuery, allowing searching to be based of the customer, such as filtering on whether the customer is in a group.

# Breaking changes

None

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [x] I have added or updated test cases
- [ ] I have updated the README if needed
