### PR TITLE
refactor(core): cleanup order-calculator's applyOrderItemPromotions

### DIFF
--- a/packages/core/src/service/helpers/order-calculator/order-calculator.ts
+++ b/packages/core/src/service/helpers/order-calculator/order-calculator.ts
@@ -90,7 +90,7 @@ export class OrderCalculator {
             // Then test and apply promotions
             const totalBeforePromotions = order.subTotal;
             await this.applyPromotions(ctx, order, promotions);
-            // itemsModifiedByPromotions.forEach(item => updatedOrderItems.add(item));
+
 
             if (order.subTotal !== totalBeforePromotions) {
                 // Finally, re-calculate taxes because the promotions may have
@@ -213,7 +213,7 @@ export class OrderCalculator {
         order: Order,
         promotions: Promotion[],
     ): Promise<void> {
-        // const updatedItems = new Set<OrderItem>();
+
         const orderHasDistributedPromotions = !!order.discounts.find(
             adjustment => adjustment.type === AdjustmentType.DISTRIBUTED_ORDER_PROMOTION,
         );

--- a/packages/core/src/service/helpers/order-calculator/order-calculator.ts
+++ b/packages/core/src/service/helpers/order-calculator/order-calculator.ts
@@ -189,7 +189,6 @@ export class OrderCalculator {
             line.clearAdjustments();
 
             for (const promotion of promotions) {
-                let priceAdjusted = false;
                 // We need to test the promotion *again*, even though we've tested them for the line.
                 // This is because the previous Promotions may have adjusted the Order in such a way
                 // as to render later promotions no longer applicable.
@@ -199,11 +198,7 @@ export class OrderCalculator {
                     const adjustment = await promotion.apply(ctx, { orderLine: line }, state);
                     if (adjustment) {
                         line.addAdjustment(adjustment);
-                        priceAdjusted = true;
-                    }
-                    if (priceAdjusted) {
                         this.calculateOrderTotals(order);
-                        priceAdjusted = false;
                     }
                     this.addPromotion(order, promotion);
                 }

--- a/packages/core/src/service/helpers/order-calculator/order-calculator.ts
+++ b/packages/core/src/service/helpers/order-calculator/order-calculator.ts
@@ -187,9 +187,8 @@ export class OrderCalculator {
             // Must be re-calculated for each line, since the previous lines may have triggered promotions
             // which affected the order price.
             line.clearAdjustments();
-            const applicablePromotions = await filterAsync(promotions, p => p.test(ctx, order).then(Boolean));
 
-            for (const promotion of applicablePromotions) {
+            for (const promotion of promotions) {
                 let priceAdjusted = false;
                 // We need to test the promotion *again*, even though we've tested them for the line.
                 // This is because the previous Promotions may have adjusted the Order in such a way

--- a/packages/core/src/service/helpers/order-calculator/order-calculator.ts
+++ b/packages/core/src/service/helpers/order-calculator/order-calculator.ts
@@ -197,7 +197,6 @@ export class OrderCalculator {
                 const applicableOrState = await promotion.test(ctx, order);
                 if (applicableOrState) {
                     const state = typeof applicableOrState === 'object' ? applicableOrState : undefined;
-                    // for (const item of line.items) {
                     const adjustment = await promotion.apply(ctx, { orderLine: line }, state);
                     if (adjustment) {
                         line.addAdjustment(adjustment);


### PR DESCRIPTION
# Description
This is just a tiny refactor, that removes some commented out code and cleans up the `applyOrderItemPromotions` function

# Breaking changes
None

# Screenshots
-

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [ ] I have added or updated test cases
- [ ] I have updated the README if needed
