### PR TITLE
fix(core): fix order cancellation when shipping has tax

### DIFF
--- a/e2e-common/e2e-initial-data.ts
+++ b/e2e-common/e2e-initial-data.ts
@@ -12,6 +12,7 @@ export const initialData: InitialData = {
     shippingMethods: [
         { name: 'Standard Shipping', price: 500 },
         { name: 'Express Shipping', price: 1000 },
+        { name: 'Express Shipping (Taxed)', price: 1000, taxRate: 20 },
     ],
     paymentMethods: [],
     countries: [

--- a/packages/core/e2e/active-order-strategy.e2e-spec.ts
+++ b/packages/core/e2e/active-order-strategy.e2e-spec.ts
@@ -446,6 +446,11 @@ describe('custom ActiveOrderStrategy', () => {
                     name: 'Express Shipping',
                     priceWithTax: 1000,
                 },
+                {
+                    id: 'T_3',
+                    name: 'Express Shipping (Taxed)',
+                    priceWithTax: 1200,
+                },
             ]);
         });
 

--- a/packages/core/e2e/draft-order.e2e-spec.ts
+++ b/packages/core/e2e/draft-order.e2e-spec.ts
@@ -382,6 +382,15 @@ describe('Draft Orders resolver', () => {
                 price: 1000,
                 priceWithTax: 1000,
             },
+            {
+                code: 'express-shipping-taxed',
+                description: '',
+                id: 'T_3',
+                metadata: null,
+                name: 'Express Shipping (Taxed)',
+                price: 1000,
+                priceWithTax: 1200,
+            },
         ]);
     });
 

--- a/packages/core/e2e/order-multi-vendor.e2e-spec.ts
+++ b/packages/core/e2e/order-multi-vendor.e2e-spec.ts
@@ -169,6 +169,7 @@ describe('Multi-vendor orders', () => {
             'alices-wares-shipping',
             'bobs-parts-shipping',
             'express-shipping',
+            'express-shipping-taxed',
             'standard-shipping',
         ]);
 

--- a/packages/core/e2e/order-multiple-shipping.e2e-spec.ts
+++ b/packages/core/e2e/order-multiple-shipping.e2e-spec.ts
@@ -140,8 +140,8 @@ describe('Multiple shipping orders', () => {
             },
         });
 
-        expect(result1.createShippingMethod.id).toBe('T_3');
-        expect(result2.createShippingMethod.id).toBe('T_4');
+        expect(result1.createShippingMethod.id).toBe('T_4');
+        expect(result2.createShippingMethod.id).toBe('T_5');
         lessThan100MethodId = result1.createShippingMethod.id;
         greaterThan100MethodId = result2.createShippingMethod.id;
     });

--- a/packages/core/e2e/order.e2e-spec.ts
+++ b/packages/core/e2e/order.e2e-spec.ts
@@ -1170,7 +1170,7 @@ describe('Orders resolver', () => {
                 customers[0].emailAddress,
                 password,
             );
-            await proceedToArrangingPayment(shopClient);
+            await proceedToArrangingPayment(shopClient, 2);
             const order = await addPaymentToOrder(shopClient, failsToSettlePaymentMethod);
             orderGuard.assertSuccess(order);
 
@@ -1290,7 +1290,7 @@ describe('Orders resolver', () => {
         });
 
         it('cannot cancel from ArrangingPayment state', async () => {
-            await proceedToArrangingPayment(shopClient);
+            await proceedToArrangingPayment(shopClient, 2);
             const { order } = await adminClient.query<Codegen.GetOrderQuery, Codegen.GetOrderQueryVariables>(
                 GET_ORDER,
                 {
@@ -1708,7 +1708,7 @@ describe('Orders resolver', () => {
             >(REFUND_ORDER, {
                 input: {
                     lines: order!.lines.map(l => ({ orderLineId: l.id, quantity: l.quantity })),
-                    shipping: order!.shipping,
+                    shipping: order!.shippingWithTax,
                     adjustment: 0,
                     reason: 'foo',
                     paymentId,
@@ -1716,7 +1716,7 @@ describe('Orders resolver', () => {
             });
             refundGuard.assertSuccess(refundOrder);
 
-            expect(refundOrder.shipping).toBe(order!.shipping);
+            expect(refundOrder.shipping).toBe(order!.shippingWithTax);
             expect(refundOrder.items).toBe(order!.subTotalWithTax);
             expect(refundOrder.total).toBe(order!.totalWithTax);
             expect(refundOrder.transactionId).toBe(null);
@@ -1815,7 +1815,7 @@ describe('Orders resolver', () => {
                 customers[0].emailAddress,
                 password,
             );
-            await proceedToArrangingPayment(shopClient);
+            await proceedToArrangingPayment(shopClient, 2);
             const order = await addPaymentToOrder(shopClient, singleStageRefundFailingPaymentMethod);
             orderGuard.assertSuccess(order);
 
@@ -1827,7 +1827,7 @@ describe('Orders resolver', () => {
             >(REFUND_ORDER, {
                 input: {
                     lines: order.lines.map(l => ({ orderLineId: l.id, quantity: l.quantity })),
-                    shipping: order.shipping,
+                    shipping: order.shippingWithTax,
                     adjustment: 0,
                     reason: 'foo',
                     paymentId: order.payments![0].id,
@@ -1843,7 +1843,7 @@ describe('Orders resolver', () => {
             >(REFUND_ORDER, {
                 input: {
                     lines: order.lines.map(l => ({ orderLineId: l.id, quantity: l.quantity })),
-                    shipping: order.shipping,
+                    shipping: order.shippingWithTax,
                     adjustment: 0,
                     reason: 'foo',
                     paymentId: order.payments![0].id,
@@ -1862,7 +1862,7 @@ describe('Orders resolver', () => {
                 customers[0].emailAddress,
                 password,
             );
-            await proceedToArrangingPayment(shopClient);
+            await proceedToArrangingPayment(shopClient, 2);
             const order = await addPaymentToOrder(shopClient, singleStageRefundablePaymentMethod);
             orderGuard.assertSuccess(order);
 
@@ -1886,7 +1886,7 @@ describe('Orders resolver', () => {
             >(REFUND_ORDER, {
                 input: {
                     lines: order.lines.map(l => ({ orderLineId: l.id, quantity: l.quantity })),
-                    shipping: order.shipping,
+                    shipping: order.shippingWithTax,
                     adjustment: 0,
                     reason: 'foo',
                     paymentId: order.payments![0].id,
@@ -2181,7 +2181,7 @@ describe('Orders resolver', () => {
         });
 
         it('adds a partial payment', async () => {
-            await proceedToArrangingPayment(shopClient);
+            await proceedToArrangingPayment(shopClient, 2);
             const { addPaymentToOrder: order } = await shopClient.query<
                 CodegenShop.AddPaymentToOrderMutation,
                 CodegenShop.AddPaymentToOrderMutationVariables

--- a/packages/core/e2e/shipping-method.e2e-spec.ts
+++ b/packages/core/e2e/shipping-method.e2e-spec.ts
@@ -154,9 +154,10 @@ describe('ShippingMethod resolver', () => {
         const { shippingMethods } = await adminClient.query<Codegen.GetShippingMethodListQuery>(
             GET_SHIPPING_METHOD_LIST,
         );
-        expect(shippingMethods.totalItems).toEqual(2);
+        expect(shippingMethods.totalItems).toEqual(3);
         expect(shippingMethods.items[0].code).toBe('standard-shipping');
         expect(shippingMethods.items[1].code).toBe('express-shipping');
+        expect(shippingMethods.items[2].code).toBe('express-shipping-taxed');
     });
 
     it('shippingMethod', async () => {
@@ -195,7 +196,7 @@ describe('ShippingMethod resolver', () => {
         });
 
         expect(createShippingMethod).toEqual({
-            id: 'T_3',
+            id: 'T_4',
             code: 'new-method',
             name: 'new method',
             description: '',
@@ -268,7 +269,7 @@ describe('ShippingMethod resolver', () => {
 
         expect(testEligibleShippingMethods).toEqual([
             {
-                id: 'T_3',
+                id: 'T_4',
                 name: 'new method',
                 description: '',
                 price: 100,
@@ -292,6 +293,14 @@ describe('ShippingMethod resolver', () => {
                 priceWithTax: 1000,
                 metadata: null,
             },
+            {
+                id: 'T_3',
+                name: 'Express Shipping (Taxed)',
+                description: '',
+                price: 1000,
+                priceWithTax: 1200,
+                metadata: null,
+            },
         ]);
     });
 
@@ -301,7 +310,7 @@ describe('ShippingMethod resolver', () => {
             Codegen.UpdateShippingMethodMutationVariables
         >(UPDATE_SHIPPING_METHOD, {
             input: {
-                id: 'T_3',
+                id: 'T_4',
                 translations: [{ languageCode: LanguageCode.en, name: 'changed method', description: '' }],
             },
         });
@@ -313,13 +322,13 @@ describe('ShippingMethod resolver', () => {
         const listResult1 = await adminClient.query<Codegen.GetShippingMethodListQuery>(
             GET_SHIPPING_METHOD_LIST,
         );
-        expect(listResult1.shippingMethods.items.map(i => i.id)).toEqual(['T_1', 'T_2', 'T_3']);
+        expect(listResult1.shippingMethods.items.map(i => i.id)).toEqual(['T_1', 'T_2', 'T_3', 'T_4']);
 
         const { deleteShippingMethod } = await adminClient.query<
             Codegen.DeleteShippingMethodMutation,
             Codegen.DeleteShippingMethodMutationVariables
         >(DELETE_SHIPPING_METHOD, {
-            id: 'T_3',
+            id: 'T_4',
         });
 
         expect(deleteShippingMethod).toEqual({
@@ -330,7 +339,7 @@ describe('ShippingMethod resolver', () => {
         const listResult2 = await adminClient.query<Codegen.GetShippingMethodListQuery>(
             GET_SHIPPING_METHOD_LIST,
         );
-        expect(listResult2.shippingMethods.items.map(i => i.id)).toEqual(['T_1', 'T_2']);
+        expect(listResult2.shippingMethods.items.map(i => i.id)).toEqual(['T_1', 'T_2', 'T_3']);
     });
 
     describe('argument ordering', () => {
@@ -379,7 +388,7 @@ describe('ShippingMethod resolver', () => {
                 Codegen.UpdateShippingMethodMutationVariables
             >(UPDATE_SHIPPING_METHOD, {
                 input: {
-                    id: 'T_4',
+                    id: 'T_5',
                     translations: [],
                     calculator: {
                         code: defaultShippingCalculator.code,
@@ -407,7 +416,7 @@ describe('ShippingMethod resolver', () => {
                 Codegen.GetShippingMethodQuery,
                 Codegen.GetShippingMethodQueryVariables
             >(GET_SHIPPING_METHOD, {
-                id: 'T_4',
+                id: 'T_5',
             });
 
             expect(shippingMethod?.calculator.args).toEqual([

--- a/packages/core/e2e/shop-order.e2e-spec.ts
+++ b/packages/core/e2e/shop-order.e2e-spec.ts
@@ -1623,6 +1623,13 @@ describe('Shop orders', () => {
                         name: 'Express Shipping',
                         description: '',
                     },
+                    {
+                        id: 'T_3',
+                        price: 1000,
+                        code: 'express-shipping-taxed',
+                        name: 'Express Shipping (Taxed)',
+                        description: '',
+                    },
                 ]);
             });
 

--- a/packages/core/e2e/utils/test-order-utils.ts
+++ b/packages/core/e2e/utils/test-order-utils.ts
@@ -14,7 +14,10 @@ import {
     TRANSITION_TO_STATE,
 } from '../graphql/shop-definitions';
 
-export async function proceedToArrangingPayment(shopClient: SimpleGraphQLClient): Promise<ID> {
+export async function proceedToArrangingPayment(
+    shopClient: SimpleGraphQLClient,
+    shippingMethodIdx = 1,
+): Promise<ID> {
     await shopClient.query<
         CodegenShop.SetShippingAddressMutation,
         CodegenShop.SetShippingAddressMutationVariables
@@ -36,7 +39,7 @@ export async function proceedToArrangingPayment(shopClient: SimpleGraphQLClient)
         CodegenShop.SetShippingMethodMutation,
         CodegenShop.SetShippingMethodMutationVariables
     >(SET_SHIPPING_METHOD, {
-        id: eligibleShippingMethods[1].id,
+        id: eligibleShippingMethods[shippingMethodIdx].id,
     });
 
     const { transitionOrderToState } = await shopClient.query<

--- a/packages/core/src/data-import/providers/populator/populator.ts
+++ b/packages/core/src/data-import/providers/populator/populator.ts
@@ -288,7 +288,7 @@ export class Populator {
 
     private async populateShippingMethods(
         ctx: RequestContext,
-        shippingMethods: Array<{ name: string; price: number }>,
+        shippingMethods: Array<{ name: string; price: number; taxRate?: number }>,
     ) {
         for (const method of shippingMethods) {
             await this.shippingMethodService.create(ctx, {
@@ -301,7 +301,7 @@ export class Populator {
                     code: defaultShippingCalculator.code,
                     arguments: [
                         { name: 'rate', value: method.price.toString() },
-                        { name: 'taxRate', value: '0' },
+                        { name: 'taxRate', value: method.taxRate ? method.taxRate.toString() : '0' },
                         { name: 'includesTax', value: 'auto' },
                     ],
                 },

--- a/packages/core/src/data-import/types.ts
+++ b/packages/core/src/data-import/types.ts
@@ -50,7 +50,7 @@ export interface InitialData {
     roles?: RoleDefinition[];
     countries: CountryDefinition[];
     taxRates: Array<{ name: string; percentage: number }>;
-    shippingMethods: Array<{ name: string; price: number }>;
+    shippingMethods: Array<{ name: string; price: number; taxRate?: number }>;
     paymentMethods: Array<{ name: string; handler: ConfigurableOperationInput }>;
     collections: CollectionDefinition[];
 }

--- a/packages/core/src/service/helpers/order-modifier/order-modifier.ts
+++ b/packages/core/src/service/helpers/order-modifier/order-modifier.ts
@@ -346,7 +346,7 @@ export class OrderModifier {
                     adjustmentSource: 'CANCEL_ORDER',
                     type: AdjustmentType.OTHER,
                     description: 'shipping cancellation',
-                    amount: -shippingLine.discountedPriceWithTax,
+                    amount: -shippingLine.discountedPrice,
                     data: {},
                 });
                 await this.connection.getRepository(ctx, ShippingLine).save(shippingLine, { reload: false });


### PR DESCRIPTION
# Description

When cancelling and order that has a shipping line with a tax rate, the order total after the cancellation would be negative the amount of tax on the shipping method. This fixes that, and changes some order e2e tests to use a shipping method with a tax rate.

# Breaking changes

No known breaking changes

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [x] I have added or updated test cases
- [ ] I have updated the README if needed
