### PR TITLE
fix(admin-ui): Fixed tracking code not showing in order history

### DIFF
--- a/packages/admin-ui/src/lib/order/src/components/order-history/order-history.component.ts
+++ b/packages/admin-ui/src/lib/order/src/components/order-history/order-history.component.ts
@@ -128,7 +128,7 @@ export class OrderHistoryComponent {
                 entry.type === HistoryEntryType.ORDER_FULFILLMENT_TRANSITION) &&
             this.order.fulfillments
         ) {
-            return this.order.fulfillments.find(f => f.id === entry.data.fulfillmentId);
+            return this.order.fulfillments.find(f => f.id == entry.data.fulfillmentId);
         }
     }
 


### PR DESCRIPTION
# Description

related issue: https://github.com/vendure-ecommerce/vendure/issues/3115

I have fixed the tracking code not showing up in order history.
The cause of the bug was a type mismatch in the fulfillmentId match determination.
entry.data.fulfillmentId is a number and this.order.fulfillments[0].id is a string.
Not sure why the latter is a string, but I was able to fix it by changing the decision operator from === to ==.

# Breaking changes

none

# Screenshots

![image](https://github.com/user-attachments/assets/6907c05c-bdfb-4d0b-9c43-2be9693abcbe)

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [ ] I have added or updated test cases
- [ ] I have updated the README if needed
