### PR TITLE
fix(admin-ui): Fix incorrect pagination range

### DIFF
--- a/packages/admin-ui/src/lib/core/src/shared/components/data-table-2/data-table2.component.ts
+++ b/packages/admin-ui/src/lib/core/src/shared/components/data-table-2/data-table2.component.ts
@@ -196,8 +196,9 @@ export class DataTable2Component<T> implements AfterContentInit, OnChanges, OnDe
 
     ngOnChanges(changes: SimpleChanges) {
         if (changes.items) {
-            this.currentStart = this.itemsPerPage * (this.currentPage - 1);
-            this.currentEnd = this.currentStart + changes.items.currentValue?.length;
+            const startIndex = this.itemsPerPage * (this.currentPage - 1);
+            this.currentStart = startIndex + 1;
+            this.currentEnd = startIndex + changes.items.currentValue?.length;
             this.selectionManager?.setCurrentItems(this.items);
         }
     }


### PR DESCRIPTION
# Description

related issue: https://github.com/vendure-ecommerce/vendure/issues/3403

Pagination now appears as “0 - 10 of [total]” or “10 - 20 of [total]”. It is necessary to adjust the starting index by adding 1.

# Breaking changes

none

# Screenshots

<img width="990" alt="image" src="https://github.com/user-attachments/assets/48de85a0-41dc-48a7-a17d-85e4543ff794" />
<img width="987" alt="image" src="https://github.com/user-attachments/assets/1b2035c3-7010-4db2-89e4-7a401048d418" />
<img width="988" alt="image" src="https://github.com/user-attachments/assets/6e3f4651-a6ff-471b-9ad5-d267586c0f2e" />

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [ ] I have added or updated test cases
- [ ] I have updated the README if needed
