### PR TITLE
fix(admin-ui): Product variant list location

### DIFF
--- a/license/signatures/version1/cla.json
+++ b/license/signatures/version1/cla.json
@@ -519,6 +519,14 @@
       "created_at": "2025-02-27T09:08:35Z",
       "repoId": 136938012,
       "pullRequestNo": 3383
+    },
+    {
+      "name": "ApplePedlar",
+      "id": 2986661,
+      "comment_id": 2705808939,
+      "created_at": "2025-03-07T08:17:42Z",
+      "repoId": 136938012,
+      "pullRequestNo": 3400
     }
   ]
 }

--- a/packages/admin-ui/src/lib/catalog/src/catalog.module.ts
+++ b/packages/admin-ui/src/lib/catalog/src/catalog.module.ts
@@ -178,7 +178,7 @@ export class CatalogModule {
         });
         pageService.registerPageTab({
             priority: 0,
-            location: 'product-list',
+            location: 'product-variant-list',
             tab: _('catalog.product-variants'),
             route: 'variants',
             component: ProductVariantListComponent,

--- a/packages/admin-ui/src/lib/core/src/common/component-registry-types.ts
+++ b/packages/admin-ui/src/lib/core/src/common/component-registry-types.ts
@@ -78,6 +78,7 @@ export type PageLocationId =
     | 'product-detail'
     | 'product-list'
     | 'product-variant-detail'
+    | 'product-variant-list'
     | 'profile'
     | 'promotion-detail'
     | 'promotion-list'


### PR DESCRIPTION
# Description

Changed the location of the product variants tab to 'product-variant-list'. Fixed a TypeScript error in the admin-ui catalog module by adding a type assertion to the 'product-variant-list' location.

# Breaking changes

No breaking changes. This is a simple type assertion fix that doesn't affect functionality.

# Screenshots

N/A - This is a code-level fix with no visual changes.

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [ ] I have added or updated test cases
- [ ] I have updated the README if needed
