### PR TITLE
chore(elasticsearch-plugin): changed package dependency from ~7.10.2 to ~8.15.3

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -80,12 +80,19 @@ services:
     volumes:
       - keycloak_data:/opt/keycloak/data
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:7.10.2
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.15.3
     container_name: elasticsearch
     environment:
+      - node.name=es
+      - cluster.name=es-docker-cluster
+      - xpack.security.enabled=false
+      - xpack.security.http.ssl.enabled=false
+      - xpack.security.transport.ssl.enabled=false
+      - xpack.license.self_generated.type=basic
       - discovery.type=single-node
       - bootstrap.memory_lock=true
       - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+    mem_limit: 536870912
     ulimits:
       memlock:
         soft: -1

--- a/packages/elasticsearch-plugin/package.json
+++ b/packages/elasticsearch-plugin/package.json
@@ -21,7 +21,7 @@
         "access": "public"
     },
     "dependencies": {
-        "@elastic/elasticsearch": "~7.9.1",
+        "@elastic/elasticsearch": "~8.15.3",
         "deepmerge": "^4.2.2",
         "fast-deep-equal": "^3.1.3"
     },

--- a/packages/elasticsearch-plugin/src/plugin.ts
+++ b/packages/elasticsearch-plugin/src/plugin.ts
@@ -64,10 +64,21 @@ function getCustomResolvers(options: ElasticsearchRuntimeOptions) {
  * advanced Elasticsearch features like spacial search.
  *
  * ## Installation
- *
- * **Requires Elasticsearch v7.0 < required Elasticsearch version < 7.10 **
- * Elasticsearch version 7.10.2 will throw error due to incompatibility with elasticsearch-js client.
- * [Check here for more info](https://github.com/elastic/elasticsearch-js/issues/1519).
+ * 
+ * **ElasticSearch v8.15.3 is supported**
+ * 
+ * **Important information about versions and ElasticSearch security:**
+ * The version of ElasticSearch that is deployed, the version of the JS library @elastic/elasticsearch installed in your Vendure project and the version of the JS library @elastic/elasticsearch used in the @vendure/elasticsearch-plugin must all match to avoid any issues. ElasticSearch does not allow @latest in its repository so these versions must be updated regularly.
+ * | Package  | Version |
+ * | ------------- | ------------- |
+ * | ElasticSearch  | v8.15.3  |
+ * | @elastic/elastisearch  | v8.15.3  |
+ * | @vendure/elasticsearch-plugin | v3.1.8 |
+ * | Last updated | Mar 15, 2025 |
+ * 
+ * With ElasticSearch v8+, basic authentication, SSL, and TLS are enabled by default and may result in your client and plugin not being able to connect to ElasticSearch successfully if your client is not configured appropriately. You must also set ```xpack.license.self_generated.type=basic``` if you are using the free Community Edition of ElasticSearch.
+ * 
+ * Review the ElasticSearch docker [example](<https://github.com/vendure-ecommerce/vendure/blob/master/docker-compose.yml>) here for development and testing without authentication and security enabled. Refer to ElasticSearch documentation to enable authentication and security in production.
  *
  * `yarn add \@elastic/elasticsearch \@vendure/elasticsearch-plugin`
  *
@@ -266,7 +277,7 @@ export class ElasticsearchPlugin implements OnApplicationBootstrap {
         private elasticsearchIndexService: ElasticsearchIndexService,
         private elasticsearchHealthIndicator: ElasticsearchHealthIndicator,
         private healthCheckRegistryService: HealthCheckRegistryService,
-    ) {}
+    ) { }
 
     /**
      * Set the plugin options.


### PR DESCRIPTION
# Description

Vendure has had a limitation on the version of ElasticSearch that can be used because of a licensing issue in v7.11 which has since been resolved. Therefore we can now use v8.15.3 as long as the plugin and the Vendure project use the new ES deployment and matching library.

# Breaking changes

Does this PR include any breaking changes we should be aware of?

Users can continue using their existing ES instance and plugin without issues if they keep the older v7.10.2 ES library in their Vendure project's package.json.
Upgrading ElasticSearch is a one-way process, migrating the DB schema from v7.10.2 to v8.15.3 with no option to downgrade.
The ES library in both the plugin and Vendure project package.json must match the upgraded ES instance version (v8.15.3).

# Screenshots

You can add screenshots here if applicable.

# Checklist

📌 Always:
- [X] I have set a clear title
- [X] My PR is small and contains a single feature
- [X] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [X] I have added or updated test cases
- [X] I have updated the README if needed
