### PR TITLE
fixes can not find product by slug if 2 products have the same slug in different channels

### DIFF
--- a/packages/core/src/service/services/product.service.ts
+++ b/packages/core/src/service/services/product.service.ts
@@ -196,7 +196,9 @@ export class ProductService {
             .select('_product_translation.baseId')
             .andWhere('_product_translation.slug = :slug', { slug });
 
-        qb.leftJoin('product.translations', 'translation')
+        qb.innerJoin('product.channels', 'channel')
+            .leftJoin('product.translations', 'translation')
+            .andWhere('channel.id = :channelId', { channelId: ctx.channelId })
             .andWhere('product.deletedAt IS NULL')
             .andWhere('product.id IN (' + translationQb.getQuery() + ')')
             .setParameters(translationQb.getParameters())


### PR DESCRIPTION
# Description

Fixes can not find product by slug if 2 products have the same slug in different channels

# Breaking changes

NO

# Screenshots

You can add screenshots here if applicable.

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [ ] I have added or updated test cases
- [ ] I have updated the README if needed
