### PR TITLE
Assign type 'float' to taxRate of defaultShippingCalculator

### DIFF
--- a/packages/core/e2e/shipping-method.e2e-spec.ts
+++ b/packages/core/e2e/shipping-method.e2e-spec.ts
@@ -136,7 +136,7 @@ describe('ShippingMethod resolver', () => {
                         description: null,
                         label: 'Tax rate',
                         name: 'taxRate',
-                        type: 'int',
+                        type: 'float',
                     },
                 ],
                 code: 'default-shipping-calculator',

--- a/packages/core/src/config/shipping-method/default-shipping-calculator.ts
+++ b/packages/core/src/config/shipping-method/default-shipping-calculator.ts
@@ -43,7 +43,7 @@ export const defaultShippingCalculator = new ShippingCalculator({
             label: [{ languageCode: LanguageCode.en, value: 'Price includes tax' }],
         },
         taxRate: {
-            type: 'int',
+            type: 'float',
             defaultValue: 0,
             ui: { component: 'number-form-input', suffix: '%' },
             label: [{ languageCode: LanguageCode.en, value: 'Tax rate' }],


### PR DESCRIPTION
The tax rate should be of type floating-point, as some countries (e. g. Switzerland) do have a fractional part in their VAT.