### PR TITLE
fix(job-queue-plugin): Fix ignoring values from workerOptions

### DIFF
--- a/packages/job-queue-plugin/src/bullmq/bullmq-job-queue-strategy.ts
+++ b/packages/job-queue-plugin/src/bullmq/bullmq-job-queue-strategy.ts
@@ -57,6 +57,7 @@ export class BullMQJobQueueStrategy implements InspectableJobQueueStrategy {
         this.options = {
             ...options,
             workerOptions: {
+                ...options.workerOptions,
                 removeOnComplete: options.workerOptions?.removeOnComplete ?? {
                     age: 60 * 60 * 24 * 30,
                     count: 5000,


### PR DESCRIPTION
# Description

Fix ignoring values (like concurrency) from workerOptions other than removeOnComplete and removeOnFail

Resolves: #3425 

# Breaking changes

no

# Screenshots

Not applicable

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [ ] I have added or updated test cases
- [ ] I have updated the README if needed
