### PR TITLE
feat(job-queue): Respect custom prefix for BullMQ Redis keys and test with Sentinel

### DIFF
--- a/packages/job-queue-plugin/src/bullmq/bullmq-job-queue-strategy.ts
+++ b/packages/job-queue-plugin/src/bullmq/bullmq-job-queue-strategy.ts
@@ -145,8 +145,8 @@ export class BullMQJobQueueStrategy implements InspectableJobQueueStrategy {
     }
 
     async add<Data extends JobData<Data> = object>(job: Job<Data>): Promise<Job<Data>> {
-        const retries = this.options.setJobOptions?.(job.queueName, job) ?? job.retries ?? 0;
-        const backoff = this.options.setJobOptions?.(job.queueName, job) ?? {
+        const retries = this.options.setRetries?.(job.queueName, job) ?? job.retries ?? 0;
+        const backoff = this.options.setBackoff?.(job.queueName, job) ?? {
             delay: 1000,
             type: 'exponential',
         };

--- a/packages/job-queue-plugin/src/bullmq/bullmq-job-queue-strategy.ts
+++ b/packages/job-queue-plugin/src/bullmq/bullmq-job-queue-strategy.ts
@@ -62,19 +62,12 @@ export class BullMQJobQueueStrategy implements InspectableJobQueueStrategy {
                     age: 60 * 60 * 24 * 30,
                     count: 5000,
                 },
-                removeOnFail: options.workerOptions?.removeOnFail ?? {
-                    age: 60 * 60 * 24 * 30,
-                    count: 5000,
-                },
+                removeOnFail: options.workerOptions?.removeOnFail ?? { age: 60 * 60 * 24 * 30, count: 5000 },
             },
         };
         this.connectionOptions =
             options.connection ??
-            ({
-                host: 'localhost',
-                port: 6379,
-                maxRetriesPerRequest: null,
-            } as RedisOptions);
+            ({ host: 'localhost', port: 6379, maxRetriesPerRequest: null } as RedisOptions);
 
         this.redisConnection =
             this.connectionOptions instanceof EventEmitter
@@ -92,10 +85,7 @@ export class BullMQJobQueueStrategy implements InspectableJobQueueStrategy {
             Logger.info('Connected to Redis ✔', loggerCtx);
         }
 
-        this.queue = new Queue(QUEUE_NAME, {
-            ...options.queueOptions,
-            connection: this.redisConnection,
-        })
+        this.queue = new Queue(QUEUE_NAME, { ...options.queueOptions, connection: this.redisConnection })
             .on('error', (e: any) =>
                 Logger.error(`BullMQ Queue error: ${JSON.stringify(e.message)}`, loggerCtx, e.stack),
             )
@@ -156,10 +146,7 @@ export class BullMQJobQueueStrategy implements InspectableJobQueueStrategy {
 
     async add<Data extends JobData<Data> = object>(job: Job<Data>): Promise<Job<Data>> {
         const retries = this.options.setRetries?.(job.queueName, job) ?? job.retries ?? 0;
-        const backoff = this.options.setBackoff?.(job.queueName, job) ?? {
-            delay: 1000,
-            type: 'exponential',
-        };
+        const backoff = this.options.setBackoff?.(job.queueName, job) ?? { delay: 1000, type: 'exponential' };
         const customJobOptions = this.options.setJobOptions?.(job.queueName, job) ?? {};
         const bullJob = await this.queue.add(job.queueName, job.data, {
             attempts: retries + 1,
@@ -246,10 +233,7 @@ export class BullMQJobQueueStrategy implements InspectableJobQueueStrategy {
             throw new InternalServerError(e.message);
         }
 
-        return {
-            items: await Promise.all(items.map(bullJob => this.createVendureJob(bullJob))),
-            totalItems,
-        };
+        return { items: await Promise.all(items.map(bullJob => this.createVendureJob(bullJob))), totalItems };
     }
 
     async findManyById(ids: ID[]): Promise<Job[]> {
@@ -413,8 +397,9 @@ export class BullMQJobQueueStrategy implements InspectableJobQueueStrategy {
         args: Args,
     ): Promise<T> {
         return new Promise<T>((resolve, reject) => {
+            const prefix = this.options.workerOptions?.prefix ?? 'bull';
             (this.redisConnection as any)[scriptDef.name](
-                `bull:${this.queue.name}:`,
+                `${prefix}:${this.queue.name}:`,
                 ...args,
                 (err: any, result: any) => {
                     if (err) {


### PR DESCRIPTION
# Description

This PR adds support for setting a custom Redis key prefix in the BullMQJobQueueStrategy. Previously, all Redis keys used the default bull prefix. With this change, developers can now specify a prefix via workerOptions.prefix and queueOptions.prefix.

# Breaking changes

No breaking changes.

# Screenshots

n/a

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [ ] I have added or updated test cases
- [ ] I have updated the README if needed
