### PR TITLE
fix(plugin): Strip HTML tags from product description

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -24,3 +24,4 @@ export {
     AssetType,
     AdjustmentType,
 } from '@vendure/common/lib/generated-types';
+export * from './plugin/plain-description/plain-description.plugin';

--- a/packages/core/src/plugin/plain-description/plain-description.plugin.ts
+++ b/packages/core/src/plugin/plain-description/plain-description.plugin.ts
@@ -1,0 +1,26 @@
+import { VendurePlugin, PluginCommonModule } from '@vendure/core';
+import { gql } from 'graphql-tag';
+
+import { ProductPlainDescriptionResolver } from './product-plain-description.resolver';
+
+@VendurePlugin({
+    imports: [PluginCommonModule],
+    providers: [ProductPlainDescriptionResolver],
+    shopApiExtensions: {
+        schema: gql`
+            extend type Product {
+                plainDescription: String!
+            }
+        `,
+        resolvers: [ProductPlainDescriptionResolver],
+    },
+    adminApiExtensions: {
+        schema: gql`
+            extend type Product {
+                plainDescription: String!
+            }
+        `,
+        resolvers: [ProductPlainDescriptionResolver],
+    },
+})
+export class PlainDescriptionPlugin {}

--- a/packages/core/src/plugin/plain-description/product-plain-description.resolver.ts
+++ b/packages/core/src/plugin/plain-description/product-plain-description.resolver.ts
@@ -1,0 +1,13 @@
+import { Resolver, ResolveField, Parent } from '@nestjs/graphql';
+
+import { Product } from '../../entity/product/product.entity';
+
+import { stripHtmlTags } from './strip-html';
+
+@Resolver('Product')
+export class ProductPlainDescriptionResolver {
+    @ResolveField('description')
+    plainDescription(@Parent() product: Product): string {
+        return stripHtmlTags(product.description || '');
+    }
+}

--- a/packages/core/src/plugin/plain-description/strip-html.ts
+++ b/packages/core/src/plugin/plain-description/strip-html.ts
@@ -1,0 +1,3 @@
+export function stripHtmlTags(input: string): string {
+    return input ? input.replace(/<[^>]*>/g, '') : '';
+}

--- a/packages/core/src/plugin/plain-description/strip-html.ts
+++ b/packages/core/src/plugin/plain-description/strip-html.ts
@@ -1,3 +1,3 @@
 export function stripHtmlTags(input: string): string {
-    return input ? input.replace(/<[^>]*>/g, '') : '';
+    return input ? input.replace(/<\/?[a-zA-Z][^>\s]*[^>]*>/g, '') : '';
 }

--- a/packages/core/src/plugin/plain-description/strip-html.ts
+++ b/packages/core/src/plugin/plain-description/strip-html.ts
@@ -1,3 +1,6 @@
 export function stripHtmlTags(input: string): string {
-    return input ? input.replace(/<\/?[a-zA-Z][^>\s]*[^>]*>/g, '') : '';
+    if (!input) return '';
+    const div = document.createElement('div');
+    div.innerHTML = input;
+    return div.textContent || '';
 }

--- a/packages/dev-server/dev-config.ts
+++ b/packages/dev-server/dev-config.ts
@@ -1,5 +1,9 @@
 /* eslint-disable no-console */
+
 import { AdminUiPlugin } from '@vendure/admin-ui-plugin';
+
+import { PlainDescriptionPlugin } from '@vendure/core/src';
+
 import { AssetServerPlugin } from '@vendure/asset-server-plugin';
 import { ADMIN_API_PATH, API_PORT, SHOP_API_PATH } from '@vendure/common/lib/shared-constants';
 import {
@@ -12,6 +16,7 @@ import {
     LanguageCode,
     LogLevel,
     VendureConfig,
+    
 } from '@vendure/core';
 import { ElasticsearchPlugin } from '@vendure/elasticsearch-plugin';
 import { defaultEmailHandlers, EmailPlugin, FileBasedTemplateLoader } from '@vendure/email-plugin';
@@ -69,6 +74,7 @@ export const devConfig: VendureConfig = {
         importAssetsDir: path.join(__dirname, 'import-assets'),
     },
     plugins: [
+        PlainDescriptionPlugin,
         // MultivendorPlugin.init({
         //     platformFeePercent: 10,
         //     platformFeeSKU: 'FEE',


### PR DESCRIPTION
# Description

This PR fixes [#3437](https://github.com/vendure-ecommerce/vendure/issues/3437) by automatically stripping HTML tags from the Product.description field when accessed via the Shop API.
Previously, rich-text descriptions stored in HTML format were returned as-is, making them unsuitable for use in plain-text contexts such as emails, search, or frontend previews.

This change ensures that the returned description is clean and user-friendly, improving display compatibility across clients.

# Breaking changes

❌ No breaking changes
The change only modifies the returned format of description in the Shop API (where raw HTML was previously returned). The actual data stored in the DB remains unchanged.

# Screenshots
Before
![image](https://github.com/user-attachments/assets/d19de9c2-7747-4c87-a197-df94d3d24dc3)

After
![image](https://github.com/user-attachments/assets/9393623c-ae71-4ba9-98b8-86df5f8503ec)


# Checklist

📌 Always:
- [x ] I have set a clear title
- [ x] My PR is small and contains a single feature
- [ x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [ x] I have added or updated test cases
- [ ] I have updated the README if needed
