### PR TITLE
Modal Dark mode message readability improvement

### DIFF
--- a/packages/admin-ui/src/lib/core/src/shared/components/modal-dialog/modal-dialog.component.scss
+++ b/packages/admin-ui/src/lib/core/src/shared/components/modal-dialog/modal-dialog.component.scss
@@ -17,15 +17,38 @@
         display: flex;
         flex-direction: column;
     }
+
     @media screen and (max-height: 700px) {
         .modal-dialog .modal-content {
             padding: 0.8rem;
         }
-        .modal-header, .modal-header--accessible {
+        .modal-header,
+        .modal-header--accessible {
             padding-bottom: 0.8rem;
         }
         .modal-footer {
             padding-top: 0.8rem;
+        }
+    }
+
+    // Dark Theme Styles
+    :host-context([data-theme="dark"]) & {
+        .modal-dialog {
+            background-color: var(--color-weight-150);
+            color: var(--color-text-100);
+            border: 1px solid var(--color-component-border-100);
+            box-shadow: 0 0 0 1px var(--color-component-border-200),
+                        0 4px 12px rgba(0, 0, 0, 0.6);
+        }
+
+        .modal-title,
+        .modal-body,
+        .modal-footer {
+            color: var(--color-text-100);
+        }
+
+        button {
+            color: var(--color-button-small-text);
         }
     }
 }


### PR DESCRIPTION
# Description

This PR adds support for dark mode in the modal component.  
It updates the modal styling to align with the dark theme and ensures proper contrast and readability across light and dark modes to solve the issue #3431 

# Breaking changes

No breaking changes.

# Screenshots
**Light Mode:**
![image](https://github.com/user-attachments/assets/80b16d32-9146-4ac5-8001-47aa547bb5f1)

**Dark Mode:**
![image](https://github.com/user-attachments/assets/e6331e95-4036-46e3-82aa-70548ec069c3)



I have read the CLA Document and I hereby sign the CLA