### PR TITLE
feat(core): Add driverConfigs option to ApiOptions

### DIFF
--- a/packages/core/src/api/config/configure-graphql-module.ts
+++ b/packages/core/src/api/config/configure-graphql-module.ts
@@ -116,6 +116,7 @@ async function createGraphQLOptions(
         plugins: apolloServerPlugins,
         validationRules: options.validationRules,
         introspection: configService.apiOptions.introspection ?? true,
+        ...configService.apiOptions.driverConfigs,
     } as ApolloDriverConfig;
 
     /**

--- a/packages/core/src/config/default-config.ts
+++ b/packages/core/src/config/default-config.ts
@@ -87,6 +87,7 @@ export const defaultConfig: RuntimeVendureConfig = {
         middleware: [],
         introspection: true,
         apolloServerPlugins: [],
+        driverConfigs: {},
     },
     entityIdStrategy: new AutoIncrementIdStrategy(),
     authOptions: {

--- a/packages/core/src/config/vendure-config.ts
+++ b/packages/core/src/config/vendure-config.ts
@@ -1,5 +1,6 @@
 import { ApolloServerPlugin } from '@apollo/server';
 import { RenderPageOptions } from '@apollographql/graphql-playground-html';
+import { ApolloDriverConfig } from '@nestjs/apollo';
 import { DynamicModule, Type } from '@nestjs/common';
 import { CorsOptions } from '@nestjs/common/interfaces/external/cors-options.interface';
 import { LanguageCode } from '@vendure/common/lib/generated-types';
@@ -215,6 +216,35 @@ export interface ApiOptions {
      * @since 1.5.0
      */
     introspection?: boolean;
+    /**
+     * @description
+     * Allows arbitrary configuration options to be passed directly to the underlying
+     * Apollo Driver. This is useful for configuring driver-specific features not
+     * explicitly exposed by Vendure's `ApiOptions`.
+     *
+     * @example
+     * ```ts
+     * // Example: Enable subscriptions using graphql-ws
+     * driverConfigs: {
+     *   subscriptions: {
+     *     'graphql-ws': {
+     *       path: '/subscriptions' // Or your desired path
+     *     },
+     *   },
+     *   // You can combine this with other driver configs, e.g., landing pages
+     *   playground: false, // Disable default playground if using landing page plugin
+     *   plugins: [
+     *     process.env.NODE_ENV === 'production'
+     *       ? ApolloServerPluginLandingPageProductionDefault({ footer: false })
+     *       : ApolloServerPluginLandingPageLocalDefault({ footer: false }),
+     *   ],
+     * }
+     * ```
+     *
+     * @default {}
+     * @since 3.2.2
+     */
+    driverConfigs?: ApolloDriverConfig;
 }
 
 /**


### PR DESCRIPTION
# Description

This PR introduces the `driverConfigs` property to the `ApiOptions` interface (`packages/core/src/config/vendure-config.ts`). This new option allows developers to pass arbitrary configuration settings directly to the underlying Apollo Driver instance used by Vendure.

Key changes:
- Added `driverConfigs?: ApolloDriverConfig` to `ApiOptions`.
- Added JSDoc documentation and an example demonstrating subscription configuration.
- Set a default value of `{}` for `driverConfigs` in the default configuration (`packages/core/src/config/default-config.ts`).
- Verified that the configurations are spread into the Apollo Driver options in `packages/core/src/api/config/configure-graphql-module.ts`.

This enhancement provides greater flexibility for configuring driver-specific features (e.g., subscriptions, landing pages, Apollo Studio integration) that are not explicitly exposed through existing Vendure `ApiOptions`.

# Breaking changes

No breaking changes are introduced by this PR. The `driverConfigs` property is optional and defaults to an empty object, ensuring backward compatibility.

# Screenshots

N/A

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [ ] I have added or updated test cases
- [ ] I have updated the README if needed