### PR TITLE
fix: products with identical slug names exist across multiple channels

### DIFF
--- a/packages/core/src/service/services/product.service.ts
+++ b/packages/core/src/service/services/product.service.ts
@@ -196,6 +196,10 @@ export class ProductService {
             .select('_product_translation.baseId')
             .andWhere('_product_translation.slug = :slug', { slug });
 
+        // Add channel join to ensure we're only getting products from this channel
+        qb.innerJoin('product.channels', 'channel', 'channel.id = :channelId', {
+            channelId: ctx.channelId,
+        })
         qb.leftJoin('product.translations', 'translation')
             .andWhere('product.deletedAt IS NULL')
             .andWhere('product.id IN (' + translationQb.getQuery() + ')')


### PR DESCRIPTION
### Summary 

When products with identical slug names exist across multiple channels, the store-front product query fails to retrieve the correct product. The query only returns the product from the first channel that created that slug, regardless of which channel token is used.

### How did you test this change?

1. add Channel A and insert a product with slug name = 'test'
2. add Channel B and insert a product with slug name = 'test'
3. invoke `prodcut()` GraphQL API in postman, set vendure-token and check if I can get the correct data
4. check sql in log info

**Before updating:**
<img width="80%" alt="image" src="https://github.com/user-attachments/assets/7aae5e2d-1eb2-4497-9904-df13c2e7e8f6" />

**After updating:**
<img width="80%" alt="image" src="https://github.com/user-attachments/assets/acf74290-42b4-4f98-9b32-717822174a94" />
