### PR TITLE
fix: Make slug queries channel aware

### DIFF
--- a/packages/core/e2e/product-channel.e2e-spec.ts
+++ b/packages/core/e2e/product-channel.e2e-spec.ts
@@ -376,6 +376,8 @@ describe('ChannelAware Products and ProductVariants', () => {
 
             expect(defaultProductRes.product).toBeDefined();
             expect(secondProductRes.product).toBeDefined();
+            expect(defaultProductRes.product).not.toBeNull();
+            expect(secondProductRes.product).not.toBeNull();
             expect(defaultProductRes.product.name).toBe('Channel Product1');
             expect(secondProductRes.product.name).toBe('Channel Product2');
             expect(defaultProductRes.product.slug).toBe('channel-product-test');

--- a/packages/core/src/service/services/product.service.ts
+++ b/packages/core/src/service/services/product.service.ts
@@ -195,7 +195,10 @@ export class ProductService {
             .createQueryBuilder('_product_translation')
             .select('_product_translation.baseId')
             .andWhere('_product_translation.slug = :slug', { slug });
-
+        // Add channel awareness
+        qb.innerJoin('product.channels', 'channel', 'channel.id = :channelId', {
+            channelId: ctx.channelId,
+        });
         qb.leftJoin('product.translations', 'translation')
             .andWhere('product.deletedAt IS NULL')
             .andWhere('product.id IN (' + translationQb.getQuery() + ')')


### PR DESCRIPTION
# Description

This PR adds channel awareness to product queries when filtering by slug. It joins the product.channels table and filters by the current channel ID from the context, ensuring that products are correctly filtered according to the active channel.

The issue addressed is that previously, the product query for finding products by slug was not channel-aware, which could lead to incorrect product retrieval across channels.

# Breaking changes

No breaking changes. This PR enhances the existing functionality by making product queries properly respect channel context, which should be the expected behavior.

# Screenshots

N/A - This is a backend code change with no visual elements.

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [ ] I have added or updated test cases
- [ ] I have updated the README if needed