### PR TITLE
feat(admin-ui-plugin): fixed an issue with sendFile and absolute paths

### DIFF
--- a/packages/admin-ui-plugin/src/plugin.ts
+++ b/packages/admin-ui-plugin/src/plugin.ts
@@ -259,7 +259,7 @@ export class AdminUiPlugin implements NestModule {
         adminUiServer.use(limiter as any);
         adminUiServer.use(express.static(adminUiAppPath));
         adminUiServer.use((req, res) => {
-            res.sendFile(path.join(adminUiAppPath, 'index.html'));
+            res.sendFile('index.html', { root: adminUiAppPath });
         });
 
         return adminUiServer;

--- a/packages/email-plugin/src/dev-mailbox.ts
+++ b/packages/email-plugin/src/dev-mailbox.ts
@@ -20,7 +20,7 @@ export class DevMailbox {
         const { outputPath, handlers } = options;
         const server = Router();
         server.get('/', (req, res) => {
-            res.sendFile(path.join(__dirname, '../../dev-mailbox.html'));
+            res.sendFile('dev-mailbox.html', { root: path.join(__dirname, '../..') });
         });
         server.get('/list', async (req, res) => {
             const list = await fs.readdir(outputPath);


### PR DESCRIPTION
# Description

Some paths in sendFile causes a notFound error in [Send](https://github.com/pillarjs/send/blob/fb1bed76209e88f3b83f0b52dc5f9783e820aaaf/index.js#L451) used by Express By setting the root as an option we can ensure it works while using pnpm.

# Breaking changes

- 


# Checklist

📌 Always:
- [X] I have set a clear title
- [X] My PR is small and contains a single feature
- [X] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [X] I have added or updated test cases
- [X] I have updated the README if needed
