### PR TITLE
feat(admin-ui-plugin): support proxy-middleware v2 to v3

### DIFF
--- a/packages/core/src/plugin/plugin-utils.ts
+++ b/packages/core/src/plugin/plugin-utils.ts
@@ -39,7 +39,7 @@ export function createProxyHandler(options: ProxyOptions): RequestHandler {
     const proxyHostname = options.hostname || 'localhost';
     const middleware = createProxyMiddleware({
         // TODO: how do we detect https?
-        target: `http://${proxyHostname}:${options.port}`,
+        target: `http://${proxyHostname}:${options.port}/(options.basePath || '')`,
         pathRewrite: {
             [`^${route}`]: '/' + (options.basePath || ''),
         },


### PR DESCRIPTION
# Description

When using the compileUiExtensions, the proxy path was broken due to some breaking changes in proxy middleware, which ends up in an endless redirect loop.

https://github.com/chimurai/http-proxy-middleware/blob/master/MIGRATION.md#removed-requrl-patching

# Breaking changes

No

# Screenshots

You can add screenshots here if applicable.

# Checklist

📌 Always:
- [z] I have set a clear title
- [z] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")
