### PR TITLE
docs(core): Add notes about custom fields on custom entities

### DIFF
--- a/docs/docs/guides/developer-guide/custom-fields/index.md
+++ b/docs/docs/guides/developer-guide/custom-fields/index.md
@@ -17,6 +17,10 @@ Some use-cases for custom fields include:
 * Storing an external identifier (e.g. from a payment provider) on the `Customer` entity.
 * Adding a longitude and latitude to the `StockLocation` for use in selecting the closest location to a customer.
 
+:::note
+Custom fields are not solely restricted to Vendure's native entities though, it's also possible to add support for custom fields to your own custom entities. See: [Supporting custom fields](/guides/developer-guide/database-entity/#supporting-custom-fields) 
+:::
+
 ## Defining custom fields
 
 Custom fields are specified in the VendureConfig:

--- a/docs/docs/guides/developer-guide/plugins/index.mdx
+++ b/docs/docs/guides/developer-guide/plugins/index.mdx
@@ -308,6 +308,10 @@ We can then import this types file in our plugin's main file:
 import './types';
 ```
 
+:::note
+Custom fields are not solely restricted to Vendure's native entities though, it's also possible to add support for custom fields to your own custom entities. This way other plugins would be able to extend our example `WishlistItem`. See: [Supporting custom fields](/guides/developer-guide/database-entity/#supporting-custom-fields) 
+:::
+
 ### Step 4: Create a service
 
 A "service" is a class which houses the bulk of the business logic of any plugin. A plugin can define multiple services if needed, but each service should be responsible for a single unit of functionality, such as dealing with a particular entity, or performing a particular task.


### PR DESCRIPTION
# Description

Personally was looking for custom field docs for custom entities but couldnt find them both in the plugin, nor on custom fields sections. They're located in ["Define a database entity"](https://docs.vendure.io/guides/developer-guide/database-entity/#supporting-custom-fields), so I thought let's link to there to save someone else's time.

---

Another note: Running `npm run docs:build` resulted in many many markdown file whitespace changes, which I now purposefully didnt include in the patch. Is that only happening for me, some local linter thingy? Would be cool to harden this but I'm not sure what causes this just wanted to take note.

# Breaking changes

None.

# Screenshots

| Header | Header |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/e97acd9a-86d0-4bc9-b7f5-bb8f5f5a7f2f) | ![image](https://github.com/user-attachments/assets/1a86269a-006b-4f9c-aeab-e28a67aa87dd) | 

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [x] I have added or updated test cases
- [x] I have updated the README if needed
