### PR TITLE
Elasticsearch plugin reindex improvements

### DIFF
--- a/docs/docs/guides/getting-started/installation/index.md
+++ b/docs/docs/guides/getting-started/installation/index.md
@@ -8,7 +8,7 @@ import TabItem from '@theme/TabItem';
 
 ## Requirements
  
-* [Node.js](https://nodejs.org/en/) **v18** or above, with support for **even-numbered Node.js versions**. (Odd-numbered versions should still work but are not officially supported.)
+* [Node.js](https://nodejs.org/en/) **v20** or above, with support for **even-numbered Node.js versions**. (Odd-numbered versions should still work but are not officially supported.)
 
 ### Optional
 * [Docker Desktop](https://www.docker.com/products/docker-desktop/): If you want to use the quick start with Postgres, you must have Docker Desktop installed. If you do not have Docker Desktop installed 


### PR DESCRIPTION
# Description

Easing memory consumption for elasticsearch-plugin when reading variants. Instead or using active query, we now can use query builder with leftJoinAndSelect which is not the most optimal thing to do but it's stable and gives direction for further improvements. In general the applied approach will boost reindex performance with ~10 times, if i have 1-2 days time to spare we can go crazy for magnitude of dozens, because if we go with raw queries with only fields that are needed and if we fetch relations on demand and construct the object from the raw response we can get really optimal. But this is good starting point

# Breaking changes

Does this PR include any breaking changes we should be aware of?

No breaking changes expected

# Screenshots

No screenshots

# Checklist
