### PR TITLE
fix(elasticsearch-plugin): Fix ElasticSearch groupByProduct to collapse on sku.keyword instead of productId

### DIFF
--- a/packages/elasticsearch-plugin/src/build-elastic-body.ts
+++ b/packages/elasticsearch-plugin/src/build-elastic-body.ts
@@ -145,7 +145,7 @@ export function buildElasticBody(
             : undefined),
     };
     if (groupByProduct) {
-        body.collapse = { field: 'productId' };
+        body.collapse = { field: 'sku.keyword' };
     }
     return body;
 }


### PR DESCRIPTION
# Description
When groupByProduct bool is set to true in the search query, collapsing by productId doesnt make sense because when multiple product entries are created, say the same product but for different channels, then they all autogenerate new productIds and the collapse never does anything

groupByProduct should actually collapse by SKU and not productId because a SKU represents a unique product identifier with certain attributes and is a value assigned by the seller to represent this unique offering. Collapsing by the SKU will truly result in 1 unique instance of that unique product being returned in the results.

Please include a summary of the changes and the related issue.

One word change to collapse on sku.keyword instead of productId
https://github.com/vendure-ecommerce/vendure/issues/3527

# Breaking changes

Does this PR include any breaking changes we should be aware of?
None

# Screenshots

You can add screenshots here if applicable.

# Checklist

📌 Always:
- [ X ] I have set a clear title
- [ X ] My PR is small and contains a single feature
- [ X ] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [ ] I have added or updated test cases
- [ ] I have updated the README if needed
