### PR TITLE
fix(job-queue): use job alias for clean-jobs task

### DIFF
--- a/packages/core/src/plugin/default-job-queue-plugin/clean-jobs-task.ts
+++ b/packages/core/src/plugin/default-job-queue-plugin/clean-jobs-task.ts
@@ -29,7 +29,7 @@ export const cleanJobsTask = new ScheduledTask({
             .where(`job.state IN (:...states)`, {
                 states: ['COMPLETED', 'FAILED', 'CANCELLED'],
             })
-            .orderBy('createdAt', 'ASC');
+            .orderBy('job.createdAt', 'ASC');
 
         const count = await qb.getCount();
 


### PR DESCRIPTION
# Description

Use the `job` alias for the query builder. 

See https://discord.com/channels/1100672177260478564/1371844277881147452

# Breaking changes

Nope

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

