### PR TITLE
feat(payments-plugin): Unable to use `klarna` payment via Mollie

### DIFF
--- a/packages/payments-plugin/e2e/mollie-payment.e2e-spec.ts
+++ b/packages/payments-plugin/e2e/mollie-payment.e2e-spec.ts
@@ -291,21 +291,6 @@ describe('Mollie payments', () => {
             expect(result.errorCode).toBe('ORDER_PAYMENT_STATE_ERROR');
         });
 
-        it('Should fail to create payment intent with invalid Mollie method', async () => {
-            await shopClient.asUserWithCredentials(customers[0].emailAddress, 'test');
-            await setShipping(shopClient);
-            const { createMolliePaymentIntent: result } = await shopClient.query(
-                CREATE_MOLLIE_PAYMENT_INTENT,
-                {
-                    input: {
-                        paymentMethodCode: mockData.methodCode,
-                        molliePaymentMethodCode: 'invalid',
-                    },
-                },
-            );
-            expect(result.errorCode).toBe('INELIGIBLE_PAYMENT_METHOD_ERROR');
-        });
-
         it('Should fail to get payment url when items are out of stock', async () => {
             let { updateProductVariants } = await adminClient.query(UPDATE_PRODUCT_VARIANTS, {
                 input: {
@@ -316,6 +301,8 @@ describe('Mollie payments', () => {
                 },
             });
             expect(updateProductVariants[0].stockOnHand).toBe(1);
+            await shopClient.asUserWithCredentials(customers[0].emailAddress, 'test');
+            await setShipping(shopClient);
             const { createMolliePaymentIntent: result } = await shopClient.query(
                 CREATE_MOLLIE_PAYMENT_INTENT,
                 {

--- a/packages/payments-plugin/src/mollie/mollie.service.ts
+++ b/packages/payments-plugin/src/mollie/mollie.service.ts
@@ -82,12 +82,6 @@ export class MollieService {
         input: MolliePaymentIntentInput,
     ): Promise<MolliePaymentIntentResult> {
         const { paymentMethodCode, molliePaymentMethodCode } = input;
-        const allowedMethods = Object.values(MollieClientMethod) as string[];
-        if (molliePaymentMethodCode && !allowedMethods.includes(molliePaymentMethodCode)) {
-            return new InvalidInputError(
-                `molliePaymentMethodCode has to be one of "${allowedMethods.join(',')}"`,
-            );
-        }
         const [order, paymentMethod] = await Promise.all([
             this.getOrder(ctx, input.orderId),
             this.getPaymentMethod(ctx, paymentMethodCode),


### PR DESCRIPTION
# Description

The Mollie Plugin is checking for allowed payment methods, but `klarna` is not allowed. **This is because the plugin uses an outdated version of Mollie NodeJS package.**

This PR removes the check in Vendure, and lets the Mollie API handle the error when an invalid payment method code is passed.

:warning: 
> Why not update the Mollie Node package?

I have attempted to upgrade the Mollie Node package, but that resulted in some bugs. These have been reported at Mollie and fixed, but upgrading the node package is not a small task. I would like to make that big change together with #2921to prevent duplicate work. 

However, we would like to have this fix before that time, because we now can not have payment method selection in our  own storefront, and are stuck with the Mollie hosted checkout.

# Breaking changes

Technically, this might be breaking, as a regular Error will be thrown, instead of a `INELIGIBLE_PAYMENT_METHOD_ERROR`. However, with correct usage of the API (first fetch eligible methods), this will not happen. Also, the fact that this has gone unnoticed, makes me think that not many people are using `klarna` or even self-host the payment methods.

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [x] I have added or updated test cases
- [x] I have updated the README if needed
