### PR TITLE
Fix GraphiqlPlugin import name

### DIFF
--- a/docs/docs/reference/core-plugins/graphiql-plugin/index.md
+++ b/docs/docs/reference/core-plugins/graphiql-plugin/index.md
@@ -21,12 +21,12 @@ for the respective APIs.
 ## Installation
 
 ```ts
-import { GraphiQLPlugin } from '@vendure/graphiql-plugin';
+import { GraphiqlPlugin } from '@vendure/graphiql-plugin';
 
 const config: VendureConfig = {
   // Add an instance of the plugin to the plugins array
   plugins: [
-    GraphiQLPlugin.init({
+    GraphiqlPlugin.init({
       route: 'graphiql', // Optional, defaults to 'graphiql'
     }),
   ],


### PR DESCRIPTION
# Description

The documentation says to import `GraphiQLPlugin` from `@vendure/graphiql-plugin`, but that plugin exports `GraphiqlPlugin`

# Breaking changes

None

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [ ] I have added or updated test cases
- [ ] I have updated the README if needed
