### PR TITLE
chore: Add logging to e2e test to diagnose e2e test failure

### DIFF
--- a/packages/core/e2e/custom-field-relations.e2e-spec.ts
+++ b/packages/core/e2e/custom-field-relations.e2e-spec.ts
@@ -107,11 +107,11 @@ const customConfig = mergeConfig(testConfig(), {
         // eslint-disable-next-line
         verbose: console.log,
         // eslint-disable-next-line
-        debug: console.log,
+        // debug: console.log,
     } as any,
     dbConnectionOptions: {
         timezone: 'Z',
-        logging: true,
+        // logging: ['query'],
     },
     customFields: customFieldConfig,
     plugins: [TestPlugin1636_1664, WithCustomEntity, PluginIssue2453],

--- a/packages/core/e2e/custom-field-relations.e2e-spec.ts
+++ b/packages/core/e2e/custom-field-relations.e2e-spec.ts
@@ -97,21 +97,8 @@ const customConfig = mergeConfig(testConfig(), {
     paymentOptions: {
         paymentMethodHandlers: [testSuccessfulPaymentMethod],
     },
-    logger: {
-        // eslint-disable-next-line
-        info: console.log,
-        // eslint-disable-next-line
-        error: console.log,
-        // eslint-disable-next-line
-        warn: console.log,
-        // eslint-disable-next-line
-        verbose: console.log,
-        // eslint-disable-next-line
-        // debug: console.log,
-    } as any,
     dbConnectionOptions: {
         timezone: 'Z',
-        // logging: ['query'],
     },
     customFields: customFieldConfig,
     plugins: [TestPlugin1636_1664, WithCustomEntity, PluginIssue2453],
@@ -121,15 +108,11 @@ describe('Custom field relations', () => {
     const { server, adminClient, shopClient } = createTestEnvironment(customConfig);
 
     beforeAll(async () => {
-        // eslint-disable-next-line
-        console.log('Custom field relations initialData:', JSON.stringify(initialData));
         await server.init({
             initialData,
             productsCsvPath: path.join(__dirname, 'fixtures/e2e-products-full.csv'),
             customerCount: 3,
         });
-        // eslint-disable-next-line
-        console.log(`server.init() done`);
         await adminClient.asSuperAdmin();
     }, TEST_SETUP_TIMEOUT_MS);
 

--- a/packages/core/e2e/custom-field-relations.e2e-spec.ts
+++ b/packages/core/e2e/custom-field-relations.e2e-spec.ts
@@ -4,15 +4,12 @@ import {
     Collection,
     Country,
     CustomFields,
-    DefaultLogger,
     defaultShippingCalculator,
     defaultShippingEligibilityChecker,
     Facet,
     FacetValue,
-    LogLevel,
     manualFulfillmentHandler,
     mergeConfig,
-    PluginCommonModule,
     Product,
     ProductOption,
     ProductOptionGroup,
@@ -20,8 +17,6 @@ import {
     RequestContext,
     ShippingMethod,
     TransactionalConnection,
-    VendureEntity,
-    VendurePlugin,
 } from '@vendure/core';
 import { createTestEnvironment } from '@vendure/testing';
 import gql from 'graphql-tag';
@@ -30,7 +25,7 @@ import { Repository } from 'typeorm';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
 import { initialData } from '../../../e2e-common/e2e-initial-data';
-import { testConfig, TEST_SETUP_TIMEOUT_MS } from '../../../e2e-common/test-config';
+import { TEST_SETUP_TIMEOUT_MS, testConfig } from '../../../e2e-common/test-config';
 
 import { testSuccessfulPaymentMethod } from './fixtures/test-payment-methods';
 import { TestPlugin1636_1664 } from './fixtures/test-plugins/issue-1636-1664/issue-1636-1664-plugin';
@@ -114,6 +109,8 @@ describe('Custom field relations', () => {
     const { server, adminClient, shopClient } = createTestEnvironment(customConfig);
 
     beforeAll(async () => {
+        // eslint-disable-next-line
+        console.log('Custom field relations initialData:', JSON.stringify(initialData));
         await server.init({
             initialData,
             productsCsvPath: path.join(__dirname, 'fixtures/e2e-products-full.csv'),

--- a/packages/core/e2e/custom-field-relations.e2e-spec.ts
+++ b/packages/core/e2e/custom-field-relations.e2e-spec.ts
@@ -109,7 +109,7 @@ const customConfig = mergeConfig(testConfig(), {
     } as any,
     dbConnectionOptions: {
         timezone: 'Z',
-        logging: ['error'],
+        logging: ['error', 'query'],
     },
     customFields: customFieldConfig,
     plugins: [TestPlugin1636_1664, WithCustomEntity, PluginIssue2453],
@@ -126,6 +126,8 @@ describe('Custom field relations', () => {
             productsCsvPath: path.join(__dirname, 'fixtures/e2e-products-full.csv'),
             customerCount: 3,
         });
+        // eslint-disable-next-line
+        console.log(`server.init() done`);
         await adminClient.asSuperAdmin();
     }, TEST_SETUP_TIMEOUT_MS);
 

--- a/packages/core/e2e/custom-field-relations.e2e-spec.ts
+++ b/packages/core/e2e/custom-field-relations.e2e-spec.ts
@@ -109,6 +109,7 @@ const customConfig = mergeConfig(testConfig(), {
     } as any,
     dbConnectionOptions: {
         timezone: 'Z',
+        logging: ['error'],
     },
     customFields: customFieldConfig,
     plugins: [TestPlugin1636_1664, WithCustomEntity, PluginIssue2453],

--- a/packages/core/e2e/custom-field-relations.e2e-spec.ts
+++ b/packages/core/e2e/custom-field-relations.e2e-spec.ts
@@ -97,7 +97,16 @@ const customConfig = mergeConfig(testConfig(), {
     paymentOptions: {
         paymentMethodHandlers: [testSuccessfulPaymentMethod],
     },
-    // logger: new DefaultLogger({ level: LogLevel.Debug }),
+    logger: {
+        // eslint-disable-next-line
+        info: console.log,
+        // eslint-disable-next-line
+        error: console.log,
+        // eslint-disable-next-line
+        warn: console.log,
+        // eslint-disable-next-line
+        verbose: console.log,
+    } as any,
     dbConnectionOptions: {
         timezone: 'Z',
     },

--- a/packages/core/e2e/custom-field-relations.e2e-spec.ts
+++ b/packages/core/e2e/custom-field-relations.e2e-spec.ts
@@ -106,10 +106,12 @@ const customConfig = mergeConfig(testConfig(), {
         warn: console.log,
         // eslint-disable-next-line
         verbose: console.log,
+        // eslint-disable-next-line
+        debug: console.log,
     } as any,
     dbConnectionOptions: {
         timezone: 'Z',
-        logging: ['error', 'query'],
+        logging: true,
     },
     customFields: customFieldConfig,
     plugins: [TestPlugin1636_1664, WithCustomEntity, PluginIssue2453],


### PR DESCRIPTION
why are the Node 20 sql.js e2e tests failing? Adding some logging to diagnose.