### PR TITLE
Fix: Correct execute function signature in purchase-group-tasks

### DIFF
--- a/docs/docs/guides/developer-guide/scheduled-tasks/index.md
+++ b/docs/docs/guides/developer-guide/scheduled-tasks/index.md
@@ -98,7 +98,7 @@ export const generateSitemapTask = new ScheduledTask({
     // `.configure()` method on the instance later.
     schedule: cron => cron.everyDayAt(0, 0),
     // This is the function that will be executed per the schedule.
-    async execute(injector, params) {
+    async execute({injector, params}) {
         // Using `app.get()` we can grab an instance of _any_ provider defined in the
         // Vendure core as well as by our plugins.
         const sitemapService = app.get(SitemapService);


### PR DESCRIPTION
## Description

Fixed a type mismatch between the actual execute definition and the code sample in the documentation. The execute function in scheduled tasks should use object destructuring to access the injector and params, rather than receiving them as separate parameters.

Changed from:
```typescript
async execute(injector, params) {
```

To:
```typescript
async execute({injector, params}) {
```

This change aligns with the TypeScript interface definition in `@vendure/core/dist/scheduler/scheduled-task.d.ts` which defines the execute method as:
```typescript
execute(args: ScheduledTaskExecutionArgs<C>): Promise<any>;
```

Where `ScheduledTaskExecutionArgs` is an object containing `injector`, `scheduledContext`, and `params`.

## Breaking changes

No breaking changes. This is a type-level fix that ensures the code matches the expected interface.

## Screenshots

N/A

## Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have checked my own PR

👍 Most of the time:
- [ ] I have added or updated test cases
- [ ] I have updated the README if needed