### PR TITLE
Fix: Correct execute function injector call 

### DIFF
--- a/docs/docs/guides/developer-guide/scheduled-tasks/index.md
+++ b/docs/docs/guides/developer-guide/scheduled-tasks/index.md
@@ -98,7 +98,7 @@ export const generateSitemapTask = new ScheduledTask({
     // `.configure()` method on the instance later.
     schedule: cron => cron.everyDayAt(0, 0),
     // This is the function that will be executed per the schedule.
-    async execute(injector, params) {
+    async execute({injector, params}) {
         // Using `app.get()` we can grab an instance of _any_ provider defined in the
         // Vendure core as well as by our plugins.
         const sitemapService = app.get(SitemapService);

--- a/docs/docs/guides/developer-guide/scheduled-tasks/index.md
+++ b/docs/docs/guides/developer-guide/scheduled-tasks/index.md
@@ -99,13 +99,13 @@ export const generateSitemapTask = new ScheduledTask({
     schedule: cron => cron.everyDayAt(0, 0),
     // This is the function that will be executed per the schedule.
     async execute({injector, params}) {
-        // Using `app.get()` we can grab an instance of _any_ provider defined in the
+        // Using `injector.get()` we can grab an instance of _any_ provider defined in the
         // Vendure core as well as by our plugins.
-        const sitemapService = app.get(SitemapService);
+        const sitemapService = injector.get(SitemapService);
 
         // For most service methods, we'll need to pass a RequestContext object.
         // We can use the RequestContextService to create one.
-        const ctx = await app.get(RequestContextService).create({
+        const ctx = await injector.get(RequestContextService).create({
             apiType: 'admin',
         });
 


### PR DESCRIPTION

## Description

Fixed a type mismatch between the actual execute definition and the code sample in the documentation. The execute function in scheduled tasks should use object destructuring to access the injector and params, rather than receiving them as separate parameters.

Changed from:
```typescript
async execute(injector, params) {
//code
app.get()
}
```

To:
```typescript
async execute({injector, params}) {
//code
injector.get()
}
```

## Breaking changes

No breaking changes. This is a type-level fix that ensures the code matches the expected interface.

## Screenshots

N/A

## Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have checked my own PR

👍 Most of the time:
- [ ] I have added or updated test cases
- [ ] I have updated the README if needed