### PR TITLE
fix: circular merge-deep issue

### DIFF
--- a/packages/core/src/service/helpers/entity-hydrator/merge-deep.spec.ts
+++ b/packages/core/src/service/helpers/entity-hydrator/merge-deep.spec.ts
@@ -62,8 +62,13 @@ describe('mergeDeep()', () => {
             },
         };
 
-        const merged = mergeDeep(obj1, obj2)
+        // @ts-ignore
+        first.entity = first;
+        // @ts-ignore
+        second.entity = second;
 
-        expect(merged.name).toBe('Jane')
+        const merged = mergeDeep(obj1, obj2);
+
+        expect(merged.name).toBe('Jane');
     });
 });

--- a/packages/core/src/service/helpers/entity-hydrator/merge-deep.spec.ts
+++ b/packages/core/src/service/helpers/entity-hydrator/merge-deep.spec.ts
@@ -42,4 +42,28 @@ describe('mergeDeep()', () => {
         expect(line2?.sales[0].id).toBe('sale-of-line-2');
         expect(line2?.productVariant?.id).toBe('variant-of-line-2');
     });
+
+    it('should handle circular objects', () => {
+        const first = {
+            name: 'John',
+            age: 30,
+            address: {
+              city: 'New York',
+              zip: '10001',
+            },
+        };
+        
+        const second = {
+            name: 'Jane',
+            age: 25,
+            address: {
+              city: 'Los Angeles',
+              zip: '90001',
+            },
+        };
+
+        const merged = mergeDeep(obj1, obj2)
+
+        expect(merged.name).toBe('Jane')
+    });
 });

--- a/packages/core/src/service/helpers/entity-hydrator/merge-deep.spec.ts
+++ b/packages/core/src/service/helpers/entity-hydrator/merge-deep.spec.ts
@@ -67,7 +67,7 @@ describe('mergeDeep()', () => {
         // @ts-ignore
         second.entity = second;
 
-        const merged = mergeDeep(obj1, obj2);
+        const merged = mergeDeep(first, second);
 
         expect(merged.name).toBe('Jane');
     });


### PR DESCRIPTION
# Description

closes #3355 by tracking visited objects in a `WeakSet` and skipping the merge process if we encounter them again. This seems to prevent `RangeError: Maximum call stack size exceeded` when there's a cyclic reference.

# Breaking changes

No

# Screenshots

You can add screenshots here if applicable.

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [x] I have added or updated test cases
- [ ] I have updated the README if needed
