### PR TITLE
fix(core): Improve ProductOptionGroup soft-delete handling

### DIFF
--- a/packages/core/src/api/resolvers/entity/product-option-entity.resolver.ts
+++ b/packages/core/src/api/resolvers/entity/product-option-entity.resolver.ts
@@ -40,7 +40,11 @@ export class ProductOptionEntityResolver {
             return option.group;
         }
         return this.requestContextCache.get(ctx, `ProductOptionEntityResolver.group(${option.groupId})`, () =>
-            assertFound(this.productOptionGroupService.findOne(ctx, option.groupId)),
+            assertFound(
+                this.productOptionGroupService.findOne(ctx, option.groupId, undefined, {
+                    includeSoftDeleted: true,
+                }),
+            ),
         );
     }
 }

--- a/packages/core/src/api/resolvers/entity/product-option-group-entity.resolver.ts
+++ b/packages/core/src/api/resolvers/entity/product-option-group-entity.resolver.ts
@@ -37,7 +37,9 @@ export class ProductOptionGroupEntityResolver {
         if (optionGroup.options) {
             options = optionGroup.options;
         } else {
-            const group = await this.productOptionGroupService.findOne(ctx, optionGroup.id);
+            const group = await this.productOptionGroupService.findOne(ctx, optionGroup.id, undefined, {
+                includeSoftDeleted: true,
+            });
             options = group?.options ?? [];
         }
         return options.filter(o => !o.deletedAt);

--- a/packages/core/src/service/services/product-option-group.service.ts
+++ b/packages/core/src/service/services/product-option-group.service.ts
@@ -51,10 +51,14 @@ export class ProductOptionGroupService {
     ): Promise<Array<Translated<ProductOptionGroup>>> {
         const findOptions: FindManyOptions = {
             relations: relations ?? ['options'],
+            where: {
+                deletedAt: IsNull(),
+            },
         };
         if (filterTerm) {
             findOptions.where = {
                 code: Like(`%${filterTerm}%`),
+                ...findOptions.where,
             };
         }
         return this.connection
@@ -67,13 +71,14 @@ export class ProductOptionGroupService {
         ctx: RequestContext,
         id: ID,
         relations?: RelationPaths<ProductOptionGroup>,
+        findOneOptions?: { includeSoftDeleted: boolean },
     ): Promise<Translated<ProductOptionGroup> | undefined> {
         return this.connection
             .getRepository(ctx, ProductOptionGroup)
             .findOne({
                 where: {
                     id,
-                    deletedAt: IsNull(),
+                    deletedAt: !findOneOptions?.includeSoftDeleted ? IsNull() : undefined,
                 },
                 relations: relations ?? ['options'],
             })
@@ -87,6 +92,7 @@ export class ProductOptionGroupService {
                 relations: ['options'],
                 where: {
                     product: { id },
+                    deletedAt: IsNull(),
                 },
                 order: {
                     id: 'ASC',

--- a/packages/core/src/service/services/product-option.service.ts
+++ b/packages/core/src/service/services/product-option.service.ts
@@ -8,6 +8,7 @@ import {
 } from '@vendure/common/lib/generated-types';
 import { ID } from '@vendure/common/lib/shared-types';
 
+import { IsNull } from 'typeorm';
 import { RequestContext } from '../../api/common/request-context';
 import { Instrument } from '../../common/instrument-decorator';
 import { Translated } from '../../common/types/locale-types';
@@ -46,6 +47,7 @@ export class ProductOptionService {
             .getRepository(ctx, ProductOption)
             .find({
                 relations: ['group'],
+                where: { deletedAt: IsNull() },
             })
             .then(options => options.map(option => this.translator.translate(option, ctx)));
     }
@@ -54,7 +56,7 @@ export class ProductOptionService {
         return this.connection
             .getRepository(ctx, ProductOption)
             .findOne({
-                where: { id },
+                where: { id, deletedAt: IsNull() },
                 relations: ['group'],
             })
             .then(option => (option && this.translator.translate(option, ctx)) ?? undefined);


### PR DESCRIPTION
# Description
Fixes #3502 

- Allows fetching of deleted option group when connected to a product option (i.e. in old orders)
- Filters out soft deleted option groups from productOptionGroups query.
- Filters out soft deleted option groups from product.optionGroups field resolver.
- Filters out soft deleted options on their findAll and findOne method.

Previous attempt #3503 

# Breaking changes
None

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [ ] I have added or updated test cases
- [ ] I have updated the README if needed
