### PR TITLE
feat(core): Add support for deprecating custom fields with @deprecated directive

### DIFF
--- a/docs/docs/guides/developer-guide/custom-fields/index.md
+++ b/docs/docs/guides/developer-guide/custom-fields/index.md
@@ -279,6 +279,7 @@ All custom fields share some common properties:
 - [`unique`](#unique)
 - [`validate`](#validate)
 - [`requiresPermission`](#requirespermission)
+- [`deprecated`](#deprecated)
 
 #### name
 
@@ -651,6 +652,46 @@ a custom [field resolver](/guides/developer-guide/extend-graphql-api/#add-fields
 the entity's custom field value if the current customer meets the requirements.
 
 :::
+
+#### deprecated
+
+<CustomFieldProperty required={false} type="boolean | string" />
+
+Marks the custom field as deprecated in the GraphQL schema. When set to `true`, the field will be marked with the `@deprecated` directive. When set to a string, that string will be used as the deprecation reason.
+
+This is useful for API evolution - you can mark fields as deprecated to signal to API consumers that they should migrate to newer alternatives, while still maintaining backward compatibility.
+
+```ts title="src/vendure-config.ts"
+const config = {
+    // ...
+    customFields: {
+        Product: [
+            {
+                name: 'oldField',
+                type: 'string',
+                // highlight-next-line
+                deprecated: true,
+            },
+            {
+                name: 'legacyUrl',
+                type: 'string',
+                // highlight-next-line
+                deprecated: 'Use the new infoUrl field instead',
+            },
+        ]
+    }
+};
+```
+
+When querying the GraphQL schema, deprecated fields will be marked accordingly:
+
+```graphql
+type ProductCustomFields {
+    oldField: String @deprecated
+    legacyUrl: String @deprecated(reason: "Use the new infoUrl field instead")
+    infoUrl: String
+}
+```
 
 ### Properties for `string` fields
 

--- a/packages/core/src/api/config/__snapshots__/graphql-custom-fields.spec.ts.snap
+++ b/packages/core/src/api/config/__snapshots__/graphql-custom-fields.spec.ts.snap
@@ -224,6 +224,49 @@ input UpdateProductCustomFieldsInput {
 }"
 `;
 
+exports[`addGraphQLCustomFields() > handles deprecated custom fields 1`] = `
+"type Product {
+  id: ID
+  customFields: ProductCustomFields
+}
+
+scalar JSON
+
+scalar DateTime
+
+type ProductCustomFields {
+  available: Boolean
+  oldField: String @deprecated
+  legacyField: Int @deprecated(reason: "Use newField instead")
+}"
+`;
+
+exports[`addGraphQLCustomFields() > handles deprecated custom fields with translations 1`] = `
+"type Product {
+  id: ID
+  translations: [ProductTranslation!]!
+  customFields: ProductCustomFields
+}
+
+type ProductTranslation {
+  id: ID
+  customFields: ProductTranslationCustomFields
+}
+
+scalar JSON
+
+scalar DateTime
+
+type ProductCustomFields {
+  available: Boolean
+  oldName: String @deprecated(reason: "Use name instead")
+}
+
+type ProductTranslationCustomFields {
+  oldName: String @deprecated(reason: "Use name instead")
+}"
+`;
+
 exports[`addGraphQLCustomFields() > publicOnly = true 1`] = `
 "type Product {
   id: ID

--- a/packages/core/src/api/config/graphql-custom-fields.spec.ts
+++ b/packages/core/src/api/config/graphql-custom-fields.spec.ts
@@ -246,6 +246,44 @@ describe('addGraphQLCustomFields()', () => {
         const result = addGraphQLCustomFields(input, customFieldConfig, true);
         expect(printSchema(result)).toMatchSnapshot();
     });
+
+    it('handles deprecated custom fields', () => {
+        const input = `
+            type Product {
+                id: ID
+            }
+        `;
+        const customFieldConfig: CustomFields = {
+            Product: [
+                { name: 'available', type: 'boolean' },
+                { name: 'oldField', type: 'string', deprecated: true },
+                { name: 'legacyField', type: 'int', deprecated: 'Use newField instead' },
+            ],
+        };
+        const result = addGraphQLCustomFields(input, customFieldConfig, false);
+        expect(printSchema(result)).toMatchSnapshot();
+    });
+
+    it('handles deprecated custom fields with translations', () => {
+        const input = `
+            type Product {
+                id: ID
+                translations: [ProductTranslation!]!
+            }
+
+            type ProductTranslation {
+                id: ID
+            }
+        `;
+        const customFieldConfig: CustomFields = {
+            Product: [
+                { name: 'available', type: 'boolean' },
+                { name: 'oldName', type: 'localeString', deprecated: 'Use name instead' },
+            ],
+        };
+        const result = addGraphQLCustomFields(input, customFieldConfig, false);
+        expect(printSchema(result)).toMatchSnapshot();
+    });
 });
 
 describe('addOrderLineCustomFieldsInput()', () => {
@@ -260,7 +298,7 @@ describe('addOrderLineCustomFieldsInput()', () => {
             { name: 'giftWrap', type: 'boolean' },
             { name: 'message', type: 'string' },
         ];
-        const result = addOrderLineCustomFieldsInput(input, customFieldConfig);
+        const result = addOrderLineCustomFieldsInput(input, customFieldConfig, false);
         expect(printSchema(result)).toMatchSnapshot();
     });
 });

--- a/packages/core/src/api/config/graphql-custom-fields.ts
+++ b/packages/core/src/api/config/graphql-custom-fields.ts
@@ -619,7 +619,7 @@ function mapToFields(
             }
             const name = nameFn ? nameFn(field) : field.name;
             const deprecationDirective = getDeprecationDirective(field);
-            return `${name}: ${type}${deprecationDirective}`;
+            return `${name}: ${type} ${deprecationDirective}`;
         })
         .filter(x => x != null);
     return res.join('\n');
@@ -759,8 +759,8 @@ function getDeprecationDirective(field: CustomFieldConfig): string {
     if (typeof field.deprecated === 'string') {
         // Escape quotes in the deprecation reason
         const escapedReason = field.deprecated.replace(/"/g, '\\"');
-        return ` @deprecated(reason: "${escapedReason}")`;
+        return `@deprecated(reason: "${escapedReason}")`;
     }
 
-    return ' @deprecated';
+    return '@deprecated';
 }

--- a/packages/core/src/api/config/graphql-custom-fields.ts
+++ b/packages/core/src/api/config/graphql-custom-fields.ts
@@ -618,7 +618,8 @@ function mapToFields(
                 return;
             }
             const name = nameFn ? nameFn(field) : field.name;
-            return `${name}: ${type}`;
+            const deprecationDirective = getDeprecationDirective(field);
+            return `${name}: ${type}${deprecationDirective}`;
         })
         .filter(x => x != null);
     return res.join('\n');
@@ -639,6 +640,8 @@ function mapToStructFields(
                 return;
             }
             const name = nameFn ? nameFn(field) : field.name;
+            // Note: Struct fields don't currently support deprecation in the type system,
+            // but we keep this consistent for future extensibility
             return `${name}: ${type}`;
         })
         .filter(x => x != null);
@@ -746,4 +749,18 @@ function getStructInputName(entityName: string, fieldDef: StructCustomFieldConfi
 
 function pascalCase(input: string) {
     return input.charAt(0).toUpperCase() + input.slice(1);
+}
+
+function getDeprecationDirective(field: CustomFieldConfig): string {
+    if (!field.deprecated) {
+        return '';
+    }
+
+    if (typeof field.deprecated === 'string') {
+        // Escape quotes in the deprecation reason
+        const escapedReason = field.deprecated.replace(/"/g, '\\"');
+        return ` @deprecated(reason: "${escapedReason}")`;
+    }
+
+    return ' @deprecated';
 }

--- a/packages/core/src/api/schema/common/custom-field-types.graphql
+++ b/packages/core/src/api/schema/common/custom-field-types.graphql
@@ -8,6 +8,8 @@ interface CustomField {
     internal: Boolean
     nullable: Boolean
     requiresPermission: [Permission!]
+    deprecated: Boolean
+    deprecationReason: String
     ui: JSON
 }
 
@@ -22,6 +24,8 @@ type StringCustomFieldConfig implements CustomField {
     internal: Boolean
     nullable: Boolean
     requiresPermission: [Permission!]
+    deprecated: Boolean
+    deprecationReason: String
     pattern: String
     options: [StringFieldOption!]
     ui: JSON
@@ -43,6 +47,8 @@ type LocaleStringCustomFieldConfig implements CustomField {
     internal: Boolean
     nullable: Boolean
     requiresPermission: [Permission!]
+    deprecated: Boolean
+    deprecationReason: String
     pattern: String
     ui: JSON
 }
@@ -56,6 +62,8 @@ type IntCustomFieldConfig implements CustomField {
     internal: Boolean
     nullable: Boolean
     requiresPermission: [Permission!]
+    deprecated: Boolean
+    deprecationReason: String
     min: Int
     max: Int
     step: Int
@@ -71,6 +79,8 @@ type FloatCustomFieldConfig implements CustomField {
     internal: Boolean
     nullable: Boolean
     requiresPermission: [Permission!]
+    deprecated: Boolean
+    deprecationReason: String
     min: Float
     max: Float
     step: Float
@@ -86,6 +96,8 @@ type BooleanCustomFieldConfig implements CustomField {
     internal: Boolean
     nullable: Boolean
     requiresPermission: [Permission!]
+    deprecated: Boolean
+    deprecationReason: String
     ui: JSON
 }
 """
@@ -102,6 +114,8 @@ type DateTimeCustomFieldConfig implements CustomField {
     internal: Boolean
     nullable: Boolean
     requiresPermission: [Permission!]
+    deprecated: Boolean
+    deprecationReason: String
     min: String
     max: String
     step: Int
@@ -118,6 +132,8 @@ type RelationCustomFieldConfig implements CustomField {
     internal: Boolean
     nullable: Boolean
     requiresPermission: [Permission!]
+    deprecated: Boolean
+    deprecationReason: String
     entity: String!
     scalarFields: [String!]!
     ui: JSON
@@ -133,6 +149,8 @@ type TextCustomFieldConfig implements CustomField {
     internal: Boolean
     nullable: Boolean
     requiresPermission: [Permission!]
+    deprecated: Boolean
+    deprecationReason: String
     ui: JSON
 }
 
@@ -146,6 +164,8 @@ type LocaleTextCustomFieldConfig implements CustomField {
     internal: Boolean
     nullable: Boolean
     requiresPermission: [Permission!]
+    deprecated: Boolean
+    deprecationReason: String
     ui: JSON
 }
 
@@ -244,6 +264,8 @@ type StructCustomFieldConfig implements CustomField {
     internal: Boolean
     nullable: Boolean
     requiresPermission: [Permission!]
+    deprecated: Boolean
+    deprecationReason: String
     ui: JSON
 }
 

--- a/packages/core/src/config/custom-field/custom-field-types.ts
+++ b/packages/core/src/config/custom-field/custom-field-types.ts
@@ -69,7 +69,7 @@ export type BaseTypedCustomFieldConfig<T extends CustomFieldType, C extends Cust
      * the field will be marked as deprecated in the GraphQL schema.
      * If a string is provided, it will be used as the deprecation reason.
      *
-     * @since 3.1.0
+     * @since 3.4.0
      */
     deprecated?: boolean | string;
     ui?: UiComponentConfig<DefaultFormComponentId | string>;

--- a/packages/core/src/config/custom-field/custom-field-types.ts
+++ b/packages/core/src/config/custom-field/custom-field-types.ts
@@ -1,32 +1,32 @@
 import {
-    BooleanCustomFieldConfig as GraphQLBooleanCustomFieldConfig,
     CustomField,
+    BooleanCustomFieldConfig as GraphQLBooleanCustomFieldConfig,
+    BooleanStructFieldConfig as GraphQLBooleanStructFieldConfig,
     DateTimeCustomFieldConfig as GraphQLDateTimeCustomFieldConfig,
+    DateTimeStructFieldConfig as GraphQLDateTimeStructFieldConfig,
     FloatCustomFieldConfig as GraphQLFloatCustomFieldConfig,
+    FloatStructFieldConfig as GraphQLFloatStructFieldConfig,
     IntCustomFieldConfig as GraphQLIntCustomFieldConfig,
+    IntStructFieldConfig as GraphQLIntStructFieldConfig,
     LocaleStringCustomFieldConfig as GraphQLLocaleStringCustomFieldConfig,
     LocaleTextCustomFieldConfig as GraphQLLocaleTextCustomFieldConfig,
-    LocalizedString,
-    Permission,
     RelationCustomFieldConfig as GraphQLRelationCustomFieldConfig,
     StringCustomFieldConfig as GraphQLStringCustomFieldConfig,
-    TextCustomFieldConfig as GraphQLTextCustomFieldConfig,
+    StringStructFieldConfig as GraphQLStringStructFieldConfig,
     StructCustomFieldConfig as GraphQLStructCustomFieldConfig,
     StructField as GraphQLStructField,
-    StringStructFieldConfig as GraphQLStringStructFieldConfig,
-    IntStructFieldConfig as GraphQLIntStructFieldConfig,
+    TextCustomFieldConfig as GraphQLTextCustomFieldConfig,
     TextStructFieldConfig as GraphQLTextStructFieldConfig,
-    FloatStructFieldConfig as GraphQLFloatStructFieldConfig,
-    BooleanStructFieldConfig as GraphQLBooleanStructFieldConfig,
-    DateTimeStructFieldConfig as GraphQLDateTimeStructFieldConfig,
+    LocalizedString,
+    Permission,
 } from '@vendure/common/lib/generated-types';
 import {
     CustomFieldsObject,
     CustomFieldType,
     DefaultFormComponentId,
+    StructFieldType,
     Type,
     UiComponentConfig,
-    StructFieldType,
 } from '@vendure/common/lib/shared-types';
 
 import { RequestContext } from '../../api/common/request-context';
@@ -63,6 +63,15 @@ export type BaseTypedCustomFieldConfig<T extends CustomFieldType, C extends Cust
      * @since 2.2.0
      */
     requiresPermission?: Array<Permission | string> | Permission | string;
+    /**
+     * @description
+     * Marks the custom field as deprecated. When set to `true` or a string,
+     * the field will be marked as deprecated in the GraphQL schema.
+     * If a string is provided, it will be used as the deprecation reason.
+     *
+     * @since 3.1.0
+     */
+    deprecated?: boolean | string;
     ui?: UiComponentConfig<DefaultFormComponentId | string>;
 };
 


### PR DESCRIPTION
# Add support for deprecating custom fields with @deprecated annotation

## Summary

This PR adds support for marking custom fields as deprecated using the `@deprecated` GraphQL directive. This feature enables smooth API evolution by allowing developers to mark fields for future removal while providing clear migration guidance.

## Changes

- **TypeScript Types**: Added `deprecated?: boolean | string` property to custom field configuration
- **GraphQL Schema**: Added deprecation fields to CustomField interface and all implementations
- **Schema Generation**: Custom fields marked as deprecated now generate `@deprecated` directives in the GraphQL schema
- **Resolver Updates**: Global settings resolver now handles deprecation metadata
- **Tests**: Added comprehensive test coverage for deprecation functionality

## Usage

### Simple deprecation
```typescript
{
  name: 'oldField',
  type: 'string',
  deprecated: true
}
```

### Deprecation with reason
```typescript
{
  name: 'legacyField', 
  type: 'text',
  deprecated: 'Use the description field in ProductTranslation instead'
}
```

### Generated GraphQL output
```graphql
type ProductCustomFields {
  oldField: String @deprecated
  legacyField: String @deprecated(reason: "Use the description field in ProductTranslation instead")
}
```

## Benefits

- **API Evolution**: Provides a clear deprecation path for custom fields
- **Developer Experience**: GraphQL tools and IDEs will show deprecation warnings
- **Self-Documenting**: Deprecation reasons provide migration guidance directly in the schema
- **Tooling Integration**: Works with Apollo Client, GraphQL Code Generator, and other GraphQL tooling
- **Backward Compatible**: Existing custom fields continue to work unchanged

## Testing

- All existing tests continue to pass
- Added new tests specifically for deprecation functionality
- Covers both simple deprecation and deprecation with custom reasons

This feature supports Vendure's commitment to API stability while enabling smooth evolution of custom field schemas.