### PR TITLE
fix(core): Make findOneBySlug also filter by channel

### DIFF
--- a/packages/core/src/service/services/product.service.ts
+++ b/packages/core/src/service/services/product.service.ts
@@ -202,7 +202,9 @@ export class ProductService {
             .andWhere('_product_translation.slug = :slug', { slug });
 
         qb.leftJoin('product.translations', 'translation')
+            .leftJoin('product.channels', 'channel')
             .andWhere('product.deletedAt IS NULL')
+            .andWhere('channel.id = :channelId', { channelId: ctx.channelId })
             .andWhere('product.id IN (' + translationQb.getQuery() + ')')
             .setParameters(translationQb.getParameters())
             .select('product.id', 'id')


### PR DESCRIPTION
# Description

Fixes Issue #2924 by also filtering for the channel in findOneBySlug so products with identical slugs in different channels can be found.

# Breaking changes

no

# Screenshots

![image](https://github.com/user-attachments/assets/637ba8f6-b948-4622-977a-76655711211b)
![image](https://github.com/user-attachments/assets/5c20e43b-41b9-42b0-a71a-09f980ecbcdb)


# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [ ] I have added or updated test cases
- [ ] I have updated the README if needed
