### PR TITLE
fix(cli): Allow comments in tsconfig for the migrate command

### DIFF
--- a/packages/cli/src/commands/migrate/load-vendure-config-file.ts
+++ b/packages/cli/src/commands/migrate/load-vendure-config-file.ts
@@ -30,7 +30,6 @@ export async function loadVendureConfigFile(
 
         let tsConfigFileContent: string;
         let tsConfigJson: any;
-        let compilerOptions: any;
 
         try {
             tsConfigFileContent = readFileSync(tsConfigPath, 'utf-8');
@@ -46,14 +45,7 @@ export async function loadVendureConfigFile(
             throw new Error(`Failed to parse TypeScript config file at ${tsConfigPath}: ${errorMessage}`);
         }
 
-        try {
-            compilerOptions = tsConfigJson.compilerOptions ?? {};
-        } catch (error: unknown) {
-            const errorMessage = error instanceof Error ? error.message : String(error);
-            throw new Error(
-                `Failed to access compilerOptions in TypeScript config file at ${tsConfigPath}: ${errorMessage}`,
-            );
-        }
+        const compilerOptions = tsConfigJson.compilerOptions;
 
         register({
             compilerOptions: { ...compilerOptions, moduleResolution: 'NodeNext', module: 'NodeNext' },

--- a/packages/cli/src/commands/migrate/load-vendure-config-file.ts
+++ b/packages/cli/src/commands/migrate/load-vendure-config-file.ts
@@ -28,9 +28,32 @@ export async function loadVendureConfigFile(
             tsConfigPath = path.join(process.cwd(), tsConfigFile);
         }
 
-        const tsConfigFileContent = readFileSync(tsConfigPath, 'utf-8');
-        const tsConfigJson = JSON.parse(stripJsonComments(tsConfigFileContent));
-        const compilerOptions = tsConfigJson.compilerOptions;
+        let tsConfigFileContent: string;
+        let tsConfigJson: any;
+        let compilerOptions: any;
+
+        try {
+            tsConfigFileContent = readFileSync(tsConfigPath, 'utf-8');
+        } catch (error: unknown) {
+            const errorMessage = error instanceof Error ? error.message : String(error);
+            throw new Error(`Failed to read TypeScript config file at ${tsConfigPath}: ${errorMessage}`);
+        }
+
+        try {
+            tsConfigJson = JSON.parse(stripJsonComments(tsConfigFileContent));
+        } catch (error: unknown) {
+            const errorMessage = error instanceof Error ? error.message : String(error);
+            throw new Error(`Failed to parse TypeScript config file at ${tsConfigPath}: ${errorMessage}`);
+        }
+
+        try {
+            compilerOptions = tsConfigJson.compilerOptions ?? {};
+        } catch (error: unknown) {
+            const errorMessage = error instanceof Error ? error.message : String(error);
+            throw new Error(
+                `Failed to access compilerOptions in TypeScript config file at ${tsConfigPath}: ${errorMessage}`,
+            );
+        }
 
         register({
             compilerOptions: { ...compilerOptions, moduleResolution: 'NodeNext', module: 'NodeNext' },


### PR DESCRIPTION
# Description

## This is a fix for the error: 

```
■  xxx/vendure-demo/tsconfig.json: Expected property name or '}' in JSON at position 29 (line 3 column 5)
│
■  SyntaxError: xxx/vendure-demo/tsconfig.json: Expected property name or '}' in JSON at position 29 (line 3 column 5)
│      at parse (<anonymous>)
│      at Module._extensions..json (node:internal/modules/cjs/loader:1703:39)
│      at Module.load (node:internal/modules/cjs/loader:1317:32)
│      at Module._load (node:internal/modules/cjs/loader:1127:12)
│      at TracingChannel.traceSync (node:diagnostics_channel:315:14)
│      at wrapModuleLoad (node:internal/modules/cjs/loader:217:24)
│      at Module.require (node:internal/modules/cjs/loader:1339:12)
│      at require (node:internal/modules/helpers:126:16)
│      at loadVendureConfigFile (xxx/vendure-demo/node_modules/@vendure/cli/dist/commands/migrate/load-vendure-config-file.js:55:33)
│      at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
```

Error was caused to errors in the tsconfig file (JSON).

### Known failcases: 

* `/*anytext*/` in paths
* comment-like patterns `//nameOfOption:` or `someConfig: this will be // removed`
* nested comments: nested comments will result in left over outer comment closer `*/`  

### alternatives:

* using a parser for a more robust solution (but we didn't want 1 more dependency for this 1 edge case)

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of TypeScript configuration files with comments, ensuring compatibility and preventing errors during migration commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->