### PR TITLE
fix(dashboard): Update Money component to use 'currency' prop 

### DIFF
--- a/packages/dashboard/src/app/routes/_authenticated/_customers/components/customer-order-table.tsx
+++ b/packages/dashboard/src/app/routes/_authenticated/_customers/components/customer-order-table.tsx
@@ -40,7 +40,7 @@ export function CustomerOrderTable({ customerId }: Readonly<CustomerOrderTablePr
                     cell: ({ cell, row }) => {
                         const value = cell.getValue();
                         const currencyCode = row.original.currencyCode;
-                        return <Money value={value} currencyCode={currencyCode} />;
+                        return <Money value={value} currency={currencyCode} />;
                     },
                 },
                 totalWithTax: {
@@ -48,7 +48,7 @@ export function CustomerOrderTable({ customerId }: Readonly<CustomerOrderTablePr
                     cell: ({ cell, row }) => {
                         const value = cell.getValue();
                         const currencyCode = row.original.currencyCode;
-                        return <Money value={value} currencyCode={currencyCode} />;
+                        return <Money value={value} currency={currencyCode} />;
                     },
                 },
                 state: {

--- a/packages/dashboard/src/app/routes/_authenticated/_orders/components/money-gross-net.tsx
+++ b/packages/dashboard/src/app/routes/_authenticated/_orders/components/money-gross-net.tsx
@@ -10,10 +10,10 @@ export function MoneyGrossNet({ priceWithTax, price, currencyCode }: Readonly<Mo
     return (
         <div className="flex flex-col gap-1">
             <div>
-                <Money value={priceWithTax} currencyCode={currencyCode} />
+                <Money value={priceWithTax} currency={currencyCode} />
             </div>
             <div className="text-xs text-muted-foreground">
-                <Money value={price} currencyCode={currencyCode} />
+                <Money value={price} currency={currencyCode} />
             </div>
         </div>
     );

--- a/packages/dashboard/src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx
+++ b/packages/dashboard/src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx
@@ -48,7 +48,7 @@ export function ShippingMethodSelector({
                                     <span className="text-sm font-medium">
                                         <Trans>Price</Trans>
                                     </span>
-                                    <Money value={method.priceWithTax} currencyCode={currencyCode} />
+                                    <Money value={method.priceWithTax} currency={currencyCode} />
                                 </div>
                             </div>
                         </CardContent>

--- a/packages/dashboard/src/app/routes/_authenticated/_orders/orders.tsx
+++ b/packages/dashboard/src/app/routes/_authenticated/_orders/orders.tsx
@@ -61,7 +61,7 @@ function OrderListPage() {
                     cell: ({ cell, row }) => {
                         const value = cell.getValue();
                         const currencyCode = row.original.currencyCode;
-                        return <Money value={value} currencyCode={currencyCode} />;
+                        return <Money value={value} currency={currencyCode} />;
                     },
                 },
                 totalWithTax: {
@@ -69,7 +69,7 @@ function OrderListPage() {
                     cell: ({ cell, row }) => {
                         const value = cell.getValue();
                         const currencyCode = row.original.currencyCode;
-                        return <Money value={value} currencyCode={currencyCode} />;
+                        return <Money value={value} currency={currencyCode} />;
                     },
                 },
                 state: {


### PR DESCRIPTION
# Description

This PR fixes issue [3643](https://github.com/vendure-ecommerce/vendure/issues/3643) an inconsistency in how the `<Money>` component is being used across the codebase. Some components were passing the prop `currencyCode` to `<Money>`, but the component internally expects the prop as `currency` (`rest.currency`).

The fix replaces all usages of:

```tsx
<Money value={value} currencyCode={currencyCode} />
```

with:

```tsx
<Money value={value} currency={currencyCode} />
```

This ensures the `currency` prop is correctly passed down and aligns with the implementation of the `Money` component:

```ts
export function Money(props: { value: any; [key: string]: any }) {
    const { value, ...rest } = props;
    const currency = rest.currency || 'USD'; // Default currency if none provided
    return MoneyInternal({ value, currency });
}
```

---

# Breaking changes

✅ No breaking changes.
This is a **non-breaking change** since it only corrects how the prop is passed in consuming components.

---

# Screenshots

N/A – This change does not affect UI rendering directly.

---

# Checklist

📌 Always:

* [x] I have set a clear title
* [x] My PR is small and contains a single feature
* [x] I have [[checked my own PR](#)]

👍 Most of the time:

* [ ] I have added or updated test cases (N/A – no new logic to test)
* [ ] I have updated the README if needed (N/A)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the display of currency values by updating the currency prop name in order and customer tables, as well as related components. This ensures that monetary amounts are shown with the correct currency formatting throughout the dashboard.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->