### PR TITLE
fix(core): Correct unfulfilled quantity calc for multiple fulfillment lines per orderline

### DIFF
--- a/packages/core/src/service/services/order.service.ts
+++ b/packages/core/src/service/services/order.service.ts
@@ -1532,12 +1532,13 @@ export class OrderService {
             .getMany();
 
         for (const inputLine of input.lines) {
-            const existingFulfillmentLine = existingFulfillmentLines.find(l =>
+            const fulfillmentLinesForOrderLine = existingFulfillmentLines.filter(l =>
                 idsAreEqual(l.orderLineId, inputLine.orderLineId),
             );
-            if (existingFulfillmentLine) {
+            if (fulfillmentLinesForOrderLine.length) {
+                const fulfilledQuantity = summate(fulfillmentLinesForOrderLine, 'quantity');
                 const unfulfilledQuantity =
-                    existingFulfillmentLine.orderLine.quantity - existingFulfillmentLine.quantity;
+                    fulfillmentLinesForOrderLine[0].orderLine.quantity - fulfilledQuantity;
                 if (unfulfilledQuantity < inputLine.quantity) {
                     return true;
                 }


### PR DESCRIPTION
# Description

This PR fixes a bug in the order fulfillment quantity calculation logic. Previously, the code only considered the first fulfillment line when calculating unfulfilled quantities, which could lead to incorrect calculations when an order line had multiple fulfillment lines. The fix ensures that all fulfillment lines for an order line are taken into account by summing their quantities before calculating the remaining unfulfilled quantity.

# Breaking changes

No breaking changes - this is a bug fix that corrects existing functionality without changing the public API.

# Screenshots

You can add screenshots here if applicable.

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved fulfillment quantity checks to accurately account for multiple partial fulfillments on the same order line, preventing over-fulfillment issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->