### PR TITLE
standardize-flag-names

### DIFF
--- a/packages/cli/e2e/add-command.e2e-spec.ts
+++ b/packages/cli/e2e/add-command.e2e-spec.ts
@@ -76,7 +76,7 @@ describe('Add Command E2E', () => {
         it('adds an entity to the specified plugin', async () => {
             const result = await performAddOperation({
                 entity: 'MyEntity',
-                'selected-plugin': 'MyPlugin',
+                selectedPlugin: 'MyPlugin',
             });
 
             expect(entityRunSpy).toHaveBeenCalledOnce();
@@ -85,7 +85,7 @@ describe('Add Command E2E', () => {
                 isNonInteractive: true,
                 config: undefined,
                 pluginName: 'MyPlugin',
-                'custom-fields': undefined,
+                customFields: undefined,
                 translatable: undefined,
             });
             expect(result.success).toBe(true);
@@ -103,7 +103,7 @@ describe('Add Command E2E', () => {
         it('adds a service to the specified plugin', async () => {
             const result = await performAddOperation({
                 service: 'MyService',
-                'selected-plugin': 'MyPlugin',
+                selectedPlugin: 'MyPlugin',
             });
 
             expect(serviceRunSpy).toHaveBeenCalledOnce();
@@ -117,9 +117,9 @@ describe('Add Command E2E', () => {
 
         it('adds a job-queue when required parameters are provided', async () => {
             const options = {
-                'job-queue': 'MyPlugin',
+                jobQueue: 'MyPlugin',
                 name: 'ReindexJob',
-                'selected-service': 'SearchService',
+                selectedService: 'SearchService',
             } as const;
             const result = await performAddOperation(options);
 
@@ -135,7 +135,7 @@ describe('Add Command E2E', () => {
 
         it('fails when job-queue parameters are incomplete', async () => {
             await expect(
-                performAddOperation({ 'job-queue': true, name: 'JobWithoutService' } as any),
+                performAddOperation({ jobQueue: true, name: 'JobWithoutService' } as any),
             ).rejects.toThrow('Service name is required for job queue');
             expect(jobQueueRunSpy).not.toHaveBeenCalled();
         });
@@ -159,28 +159,28 @@ describe('Add Command E2E', () => {
 
         it('adds an API extension scaffold when queryName is provided', async () => {
             const result = await performAddOperation({
-                'api-extension': 'MyPlugin',
-                'query-name': 'myQuery',
+                apiExtension: 'MyPlugin',
+                queryName: 'myQuery',
             });
 
             expect(apiExtRunSpy).toHaveBeenCalledOnce();
             expect(apiExtRunSpy.mock.calls[0][0]).toMatchObject({
                 pluginName: 'MyPlugin',
-                'query-name': 'myQuery',
-                'mutation-name': undefined,
+                queryName: 'myQuery',
+                mutationName: undefined,
             });
             expect(result.success).toBe(true);
         });
 
         it('fails when neither queryName nor mutationName is provided for API extension', async () => {
-            await expect(performAddOperation({ 'api-extension': true } as any)).rejects.toThrow(
+            await expect(performAddOperation({ apiExtension: true } as any)).rejects.toThrow(
                 'At least one of query-name or mutation-name must be specified',
             );
             expect(apiExtRunSpy).not.toHaveBeenCalled();
         });
 
         it('adds UI extensions when the uiExtensions flag is used', async () => {
-            const result = await performAddOperation({ 'ui-extensions': 'MyPlugin' });
+            const result = await performAddOperation({ uiExtensions: 'MyPlugin' });
 
             expect(uiExtRunSpy).toHaveBeenCalledOnce();
             expect(uiExtRunSpy.mock.calls[0][0]).toMatchObject({ pluginName: 'MyPlugin' });

--- a/packages/cli/e2e/add-command.e2e-spec.ts
+++ b/packages/cli/e2e/add-command.e2e-spec.ts
@@ -76,7 +76,7 @@ describe('Add Command E2E', () => {
         it('adds an entity to the specified plugin', async () => {
             const result = await performAddOperation({
                 entity: 'MyEntity',
-                selectedPlugin: 'MyPlugin',
+                'selected-plugin': 'MyPlugin',
             });
 
             expect(entityRunSpy).toHaveBeenCalledOnce();
@@ -85,7 +85,7 @@ describe('Add Command E2E', () => {
                 isNonInteractive: true,
                 config: undefined,
                 pluginName: 'MyPlugin',
-                customFields: undefined,
+                'custom-fields': undefined,
                 translatable: undefined,
             });
             expect(result.success).toBe(true);
@@ -103,7 +103,7 @@ describe('Add Command E2E', () => {
         it('adds a service to the specified plugin', async () => {
             const result = await performAddOperation({
                 service: 'MyService',
-                selectedPlugin: 'MyPlugin',
+                'selected-plugin': 'MyPlugin',
             });
 
             expect(serviceRunSpy).toHaveBeenCalledOnce();
@@ -117,9 +117,9 @@ describe('Add Command E2E', () => {
 
         it('adds a job-queue when required parameters are provided', async () => {
             const options = {
-                jobQueue: 'MyPlugin',
+                'job-queue': 'MyPlugin',
                 name: 'ReindexJob',
-                selectedService: 'SearchService',
+                'selected-service': 'SearchService',
             } as const;
             const result = await performAddOperation(options);
 
@@ -135,7 +135,7 @@ describe('Add Command E2E', () => {
 
         it('fails when job-queue parameters are incomplete', async () => {
             await expect(
-                performAddOperation({ jobQueue: true, name: 'JobWithoutService' } as any),
+                performAddOperation({ 'job-queue': true, name: 'JobWithoutService' } as any),
             ).rejects.toThrow('Service name is required for job queue');
             expect(jobQueueRunSpy).not.toHaveBeenCalled();
         });
@@ -159,28 +159,28 @@ describe('Add Command E2E', () => {
 
         it('adds an API extension scaffold when queryName is provided', async () => {
             const result = await performAddOperation({
-                apiExtension: 'MyPlugin',
-                queryName: 'myQuery',
+                'api-extension': 'MyPlugin',
+                'query-name': 'myQuery',
             });
 
             expect(apiExtRunSpy).toHaveBeenCalledOnce();
             expect(apiExtRunSpy.mock.calls[0][0]).toMatchObject({
                 pluginName: 'MyPlugin',
-                queryName: 'myQuery',
-                mutationName: undefined,
+                'query-name': 'myQuery',
+                'mutation-name': undefined,
             });
             expect(result.success).toBe(true);
         });
 
         it('fails when neither queryName nor mutationName is provided for API extension', async () => {
-            await expect(performAddOperation({ apiExtension: true } as any)).rejects.toThrow(
-                'At least one of queryName or mutationName must be specified',
+            await expect(performAddOperation({ 'api-extension': true } as any)).rejects.toThrow(
+                'At least one of query-name or mutation-name must be specified',
             );
             expect(apiExtRunSpy).not.toHaveBeenCalled();
         });
 
         it('adds UI extensions when the uiExtensions flag is used', async () => {
-            const result = await performAddOperation({ uiExtensions: 'MyPlugin' });
+            const result = await performAddOperation({ 'ui-extensions': 'MyPlugin' });
 
             expect(uiExtRunSpy).toHaveBeenCalledOnce();
             expect(uiExtRunSpy.mock.calls[0][0]).toMatchObject({ pluginName: 'MyPlugin' });

--- a/packages/cli/src/commands/add/add-operations.ts
+++ b/packages/cli/src/commands/add/add-operations.ts
@@ -145,7 +145,7 @@ export async function performAddOperation(options: AddOperationOptions): Promise
                 !options['selected-service'].trim()
             ) {
                 throw new Error(
-                    'Service name is required for job queue. Usage: vendure add -j [plugin-name] --name <job-name> --selectedService <service-name>',
+                    'Service name is required for job queue. Usage: vendure add -j [plugin-name] --name <job-name> --selected-service <service-name>',
                 );
             }
             await addJobQueueCommand.run({
@@ -194,8 +194,8 @@ export async function performAddOperation(options: AddOperationOptions): Promise
 
             if (!hasValidQueryName && !hasValidMutationName) {
                 throw new Error(
-                    'At least one of queryName or mutationName must be specified as a non-empty string. ' +
-                        'Usage: vendure add -a [plugin-name] --queryName <name> --mutationName <name>',
+                    'At least one of query-name or mutation-name must be specified as a non-empty string. ' +
+                        'Usage: vendure add -a [plugin-name] --query-name <name> --mutation-name <name>',
                 );
             }
 
@@ -203,7 +203,7 @@ export async function performAddOperation(options: AddOperationOptions): Promise
             if (typeof options['api-extension'] === 'string' && !options['api-extension'].trim()) {
                 throw new Error(
                     'Plugin name cannot be empty when specified. ' +
-                        'Usage: vendure add -a [plugin-name] --queryName <name> --mutationName <name>',
+                        'Usage: vendure add -a [plugin-name] --query-name <name> --mutation-name <name>',
                 );
             }
 
@@ -227,7 +227,7 @@ export async function performAddOperation(options: AddOperationOptions): Promise
             // If a string is passed, it should be a valid plugin name
             if (typeof options['ui-extensions'] === 'string' && !options['ui-extensions'].trim()) {
                 throw new Error(
-                    'Plugin name cannot be empty when specified. Usage: vendure add --uiExtensions [plugin-name]',
+                    'Plugin name cannot be empty when specified. Usage: vendure add --ui-extensions [plugin-name]',
                 );
             }
             await addUiExtensionsCommand.run({

--- a/packages/cli/src/commands/add/add-operations.ts
+++ b/packages/cli/src/commands/add/add-operations.ts
@@ -15,33 +15,33 @@ export interface AddOperationOptions {
     /** Add a new service with the given name */
     service?: string;
     /** Add a job-queue handler to the specified plugin */
-    jobQueue?: string | boolean;
+    'job-queue'?: string | boolean;
     /** Add GraphQL codegen configuration to the specified plugin */
     codegen?: string | boolean;
     /** Add an API extension scaffold to the specified plugin */
-    apiExtension?: string | boolean;
+    'api-extension'?: string | boolean;
     /** Add Admin-UI or Storefront UI extensions to the specified plugin */
-    uiExtensions?: string | boolean;
+    'ui-extensions'?: string | boolean;
     /** Specify the path to a custom Vendure config file */
     config?: string;
     /** Name for the job queue (used with jobQueue) */
     name?: string;
     /** Name for the query (used with apiExtension) */
-    queryName?: string;
+    'query-name'?: string;
     /** Name for the mutation (used with apiExtension) */
-    mutationName?: string;
+    'mutation-name'?: string;
     /** Name of the service to use (used with jobQueue) */
-    selectedService?: string;
+    'selected-service'?: string;
     /** Selected plugin name for entity/service commands */
-    selectedPlugin?: string;
+    'selected-plugin'?: string;
     /** Add custom fields support to entity */
-    customFields?: boolean;
+    'custom-fields'?: boolean;
     /** Make entity translatable */
     translatable?: boolean;
     /** Service type: basic or entity */
     type?: string;
     /** Selected entity name for entity service commands */
-    selectedEntity?: string;
+    'selected-entity'?: string;
 }
 
 export interface AddOperationResult {
@@ -79,9 +79,9 @@ export async function performAddOperation(options: AddOperationOptions): Promise
             }
             // Validate that a plugin name was provided for non-interactive mode
             if (
-                !options.selectedPlugin ||
-                typeof options.selectedPlugin !== 'string' ||
-                !options.selectedPlugin.trim()
+                !options['selected-plugin'] ||
+                typeof options['selected-plugin'] !== 'string' ||
+                !options['selected-plugin'].trim()
             ) {
                 throw new Error(
                     'Plugin name is required when running in non-interactive mode. Usage: vendure add -e <entity-name> --selected-plugin <plugin-name>',
@@ -92,13 +92,13 @@ export async function performAddOperation(options: AddOperationOptions): Promise
                 className: options.entity,
                 isNonInteractive: true,
                 config: options.config,
-                pluginName: options.selectedPlugin,
-                customFields: options.customFields,
+                pluginName: options['selected-plugin'],
+                customFields: options['custom-fields'],
                 translatable: options.translatable,
             });
             return {
                 success: true,
-                message: `Entity "${options.entity}" added successfully to plugin "${options.selectedPlugin}"`,
+                message: `Entity "${options.entity}" added successfully to plugin "${options['selected-plugin']}"`,
             };
         }
         if (options.service) {
@@ -110,9 +110,9 @@ export async function performAddOperation(options: AddOperationOptions): Promise
             }
             // Validate that a plugin name was provided for non-interactive mode
             if (
-                !options.selectedPlugin ||
-                typeof options.selectedPlugin !== 'string' ||
-                !options.selectedPlugin.trim()
+                !options['selected-plugin'] ||
+                typeof options['selected-plugin'] !== 'string' ||
+                !options['selected-plugin'].trim()
             ) {
                 throw new Error(
                     'Plugin name is required when running in non-interactive mode. Usage: vendure add -s <service-name> --selected-plugin <plugin-name>',
@@ -122,17 +122,17 @@ export async function performAddOperation(options: AddOperationOptions): Promise
                 serviceName: options.service,
                 isNonInteractive: true,
                 config: options.config,
-                pluginName: options.selectedPlugin,
-                serviceType: options.selectedEntity ? 'entity' : options.type || 'basic',
-                selectedEntityName: options.selectedEntity,
+                pluginName: options['selected-plugin'],
+                serviceType: options['selected-entity'] ? 'entity' : options.type || 'basic',
+                selectedEntityName: options['selected-entity'],
             });
             return {
                 success: true,
-                message: `Service "${options.service}" added successfully to plugin "${options.selectedPlugin}"`,
+                message: `Service "${options.service}" added successfully to plugin "${options['selected-plugin']}"`,
             };
         }
-        if (options.jobQueue) {
-            const pluginName = typeof options.jobQueue === 'string' ? options.jobQueue : undefined;
+        if (options['job-queue']) {
+            const pluginName = typeof options['job-queue'] === 'string' ? options['job-queue'] : undefined;
             // Validate required parameters for job queue
             if (!options.name || typeof options.name !== 'string' || !options.name.trim()) {
                 throw new Error(
@@ -140,9 +140,9 @@ export async function performAddOperation(options: AddOperationOptions): Promise
                 );
             }
             if (
-                !options.selectedService ||
-                typeof options.selectedService !== 'string' ||
-                !options.selectedService.trim()
+                !options['selected-service'] ||
+                typeof options['selected-service'] !== 'string' ||
+                !options['selected-service'].trim()
             ) {
                 throw new Error(
                     'Service name is required for job queue. Usage: vendure add -j [plugin-name] --name <job-name> --selectedService <service-name>',
@@ -153,7 +153,7 @@ export async function performAddOperation(options: AddOperationOptions): Promise
                 config: options.config,
                 pluginName,
                 name: options.name,
-                selectedService: options.selectedService,
+                selectedService: options['selected-service'],
             });
             return {
                 success: true,
@@ -179,15 +179,18 @@ export async function performAddOperation(options: AddOperationOptions): Promise
                 message: 'Codegen configuration added successfully',
             };
         }
-        if (options.apiExtension) {
-            const pluginName = typeof options.apiExtension === 'string' ? options.apiExtension : undefined;
+        if (options['api-extension']) {
+            const pluginName =
+                typeof options['api-extension'] === 'string' ? options['api-extension'] : undefined;
             // Validate that at least one of queryName or mutationName is provided and not empty
             const hasValidQueryName =
-                options.queryName && typeof options.queryName === 'string' && options.queryName.trim() !== '';
+                options['query-name'] &&
+                typeof options['query-name'] === 'string' &&
+                options['query-name'].trim() !== '';
             const hasValidMutationName =
-                options.mutationName &&
-                typeof options.mutationName === 'string' &&
-                options.mutationName.trim() !== '';
+                options['mutation-name'] &&
+                typeof options['mutation-name'] === 'string' &&
+                options['mutation-name'].trim() !== '';
 
             if (!hasValidQueryName && !hasValidMutationName) {
                 throw new Error(
@@ -197,7 +200,7 @@ export async function performAddOperation(options: AddOperationOptions): Promise
             }
 
             // If a string is passed for apiExtension, it should be a valid plugin name
-            if (typeof options.apiExtension === 'string' && !options.apiExtension.trim()) {
+            if (typeof options['api-extension'] === 'string' && !options['api-extension'].trim()) {
                 throw new Error(
                     'Plugin name cannot be empty when specified. ' +
                         'Usage: vendure add -a [plugin-name] --queryName <name> --mutationName <name>',
@@ -208,20 +211,21 @@ export async function performAddOperation(options: AddOperationOptions): Promise
                 isNonInteractive: true,
                 config: options.config,
                 pluginName,
-                queryName: options.queryName,
-                mutationName: options.mutationName,
-                selectedService: options.selectedService,
+                'query-name': options['query-name'],
+                'mutation-name': options['mutation-name'],
+                'selected-service': options['selected-service'],
             });
             return {
                 success: true,
                 message: 'API extension scaffold added successfully',
             };
         }
-        if (options.uiExtensions) {
-            const pluginName = typeof options.uiExtensions === 'string' ? options.uiExtensions : undefined;
+        if (options['ui-extensions']) {
+            const pluginName =
+                typeof options['ui-extensions'] === 'string' ? options['ui-extensions'] : undefined;
             // For UI extensions, if a boolean true is passed, plugin selection will be handled interactively
             // If a string is passed, it should be a valid plugin name
-            if (typeof options.uiExtensions === 'string' && !options.uiExtensions.trim()) {
+            if (typeof options['ui-extensions'] === 'string' && !options['ui-extensions'].trim()) {
                 throw new Error(
                     'Plugin name cannot be empty when specified. Usage: vendure add --uiExtensions [plugin-name]',
                 );

--- a/packages/cli/src/commands/add/add-operations.ts
+++ b/packages/cli/src/commands/add/add-operations.ts
@@ -1,3 +1,6 @@
+import { log } from '@clack/prompts';
+import pc from 'picocolors';
+
 import { addApiExtensionCommand } from './api-extension/add-api-extension';
 import { addCodegenCommand } from './codegen/add-codegen';
 import { addEntityCommand } from './entity/add-entity';
@@ -15,33 +18,33 @@ export interface AddOperationOptions {
     /** Add a new service with the given name */
     service?: string;
     /** Add a job-queue handler to the specified plugin */
-    'job-queue'?: string | boolean;
+    jobQueue?: string | boolean;
     /** Add GraphQL codegen configuration to the specified plugin */
     codegen?: string | boolean;
     /** Add an API extension scaffold to the specified plugin */
-    'api-extension'?: string | boolean;
+    apiExtension?: string | boolean;
     /** Add Admin-UI or Storefront UI extensions to the specified plugin */
-    'ui-extensions'?: string | boolean;
+    uiExtensions?: string | boolean;
     /** Specify the path to a custom Vendure config file */
     config?: string;
     /** Name for the job queue (used with jobQueue) */
     name?: string;
     /** Name for the query (used with apiExtension) */
-    'query-name'?: string;
+    queryName?: string;
     /** Name for the mutation (used with apiExtension) */
-    'mutation-name'?: string;
+    mutationName?: string;
     /** Name of the service to use (used with jobQueue) */
-    'selected-service'?: string;
+    selectedService?: string;
     /** Selected plugin name for entity/service commands */
-    'selected-plugin'?: string;
+    selectedPlugin?: string;
     /** Add custom fields support to entity */
-    'custom-fields'?: boolean;
+    customFields?: boolean;
     /** Make entity translatable */
     translatable?: boolean;
     /** Service type: basic or entity */
     type?: string;
     /** Selected entity name for entity service commands */
-    'selected-entity'?: string;
+    selectedEntity?: string;
 }
 
 export interface AddOperationResult {
@@ -79,9 +82,9 @@ export async function performAddOperation(options: AddOperationOptions): Promise
             }
             // Validate that a plugin name was provided for non-interactive mode
             if (
-                !options['selected-plugin'] ||
-                typeof options['selected-plugin'] !== 'string' ||
-                !options['selected-plugin'].trim()
+                !options.selectedPlugin ||
+                typeof options.selectedPlugin !== 'string' ||
+                !options.selectedPlugin.trim()
             ) {
                 throw new Error(
                     'Plugin name is required when running in non-interactive mode. Usage: vendure add -e <entity-name> --selected-plugin <plugin-name>',
@@ -92,13 +95,13 @@ export async function performAddOperation(options: AddOperationOptions): Promise
                 className: options.entity,
                 isNonInteractive: true,
                 config: options.config,
-                pluginName: options['selected-plugin'],
-                customFields: options['custom-fields'],
+                pluginName: options.selectedPlugin,
+                customFields: options.customFields,
                 translatable: options.translatable,
             });
             return {
                 success: true,
-                message: `Entity "${options.entity}" added successfully to plugin "${options['selected-plugin']}"`,
+                message: `Entity "${options.entity}" added successfully to plugin "${options.selectedPlugin}"`,
             };
         }
         if (options.service) {
@@ -110,9 +113,9 @@ export async function performAddOperation(options: AddOperationOptions): Promise
             }
             // Validate that a plugin name was provided for non-interactive mode
             if (
-                !options['selected-plugin'] ||
-                typeof options['selected-plugin'] !== 'string' ||
-                !options['selected-plugin'].trim()
+                !options.selectedPlugin ||
+                typeof options.selectedPlugin !== 'string' ||
+                !options.selectedPlugin.trim()
             ) {
                 throw new Error(
                     'Plugin name is required when running in non-interactive mode. Usage: vendure add -s <service-name> --selected-plugin <plugin-name>',
@@ -122,17 +125,17 @@ export async function performAddOperation(options: AddOperationOptions): Promise
                 serviceName: options.service,
                 isNonInteractive: true,
                 config: options.config,
-                pluginName: options['selected-plugin'],
-                serviceType: options['selected-entity'] ? 'entity' : options.type || 'basic',
-                selectedEntityName: options['selected-entity'],
+                pluginName: options.selectedPlugin,
+                serviceType: options.selectedEntity ? 'entity' : options.type || 'basic',
+                selectedEntityName: options.selectedEntity,
             });
             return {
                 success: true,
-                message: `Service "${options.service}" added successfully to plugin "${options['selected-plugin']}"`,
+                message: `Service "${options.service}" added successfully to plugin "${options.selectedPlugin}"`,
             };
         }
-        if (options['job-queue']) {
-            const pluginName = typeof options['job-queue'] === 'string' ? options['job-queue'] : undefined;
+        if (options.jobQueue) {
+            const pluginName = typeof options.jobQueue === 'string' ? options.jobQueue : undefined;
             // Validate required parameters for job queue
             if (!options.name || typeof options.name !== 'string' || !options.name.trim()) {
                 throw new Error(
@@ -140,9 +143,9 @@ export async function performAddOperation(options: AddOperationOptions): Promise
                 );
             }
             if (
-                !options['selected-service'] ||
-                typeof options['selected-service'] !== 'string' ||
-                !options['selected-service'].trim()
+                !options.selectedService ||
+                typeof options.selectedService !== 'string' ||
+                !options.selectedService.trim()
             ) {
                 throw new Error(
                     'Service name is required for job queue. Usage: vendure add -j [plugin-name] --name <job-name> --selected-service <service-name>',
@@ -153,7 +156,7 @@ export async function performAddOperation(options: AddOperationOptions): Promise
                 config: options.config,
                 pluginName,
                 name: options.name,
-                selectedService: options['selected-service'],
+                selectedService: options.selectedService,
             });
             return {
                 success: true,
@@ -179,18 +182,15 @@ export async function performAddOperation(options: AddOperationOptions): Promise
                 message: 'Codegen configuration added successfully',
             };
         }
-        if (options['api-extension']) {
-            const pluginName =
-                typeof options['api-extension'] === 'string' ? options['api-extension'] : undefined;
+        if (options.apiExtension) {
+            const pluginName = typeof options.apiExtension === 'string' ? options.apiExtension : undefined;
             // Validate that at least one of queryName or mutationName is provided and not empty
             const hasValidQueryName =
-                options['query-name'] &&
-                typeof options['query-name'] === 'string' &&
-                options['query-name'].trim() !== '';
+                options.queryName && typeof options.queryName === 'string' && options.queryName.trim() !== '';
             const hasValidMutationName =
-                options['mutation-name'] &&
-                typeof options['mutation-name'] === 'string' &&
-                options['mutation-name'].trim() !== '';
+                options.mutationName &&
+                typeof options.mutationName === 'string' &&
+                options.mutationName.trim() !== '';
 
             if (!hasValidQueryName && !hasValidMutationName) {
                 throw new Error(
@@ -200,7 +200,7 @@ export async function performAddOperation(options: AddOperationOptions): Promise
             }
 
             // If a string is passed for apiExtension, it should be a valid plugin name
-            if (typeof options['api-extension'] === 'string' && !options['api-extension'].trim()) {
+            if (typeof options.apiExtension === 'string' && !options.apiExtension.trim()) {
                 throw new Error(
                     'Plugin name cannot be empty when specified. ' +
                         'Usage: vendure add -a [plugin-name] --query-name <name> --mutation-name <name>',
@@ -211,21 +211,20 @@ export async function performAddOperation(options: AddOperationOptions): Promise
                 isNonInteractive: true,
                 config: options.config,
                 pluginName,
-                'query-name': options['query-name'],
-                'mutation-name': options['mutation-name'],
-                'selected-service': options['selected-service'],
+                queryName: options.queryName,
+                mutationName: options.mutationName,
+                selectedService: options.selectedService,
             });
             return {
                 success: true,
                 message: 'API extension scaffold added successfully',
             };
         }
-        if (options['ui-extensions']) {
-            const pluginName =
-                typeof options['ui-extensions'] === 'string' ? options['ui-extensions'] : undefined;
+        if (options.uiExtensions) {
+            const pluginName = typeof options.uiExtensions === 'string' ? options.uiExtensions : undefined;
             // For UI extensions, if a boolean true is passed, plugin selection will be handled interactively
             // If a string is passed, it should be a valid plugin name
-            if (typeof options['ui-extensions'] === 'string' && !options['ui-extensions'].trim()) {
+            if (typeof options.uiExtensions === 'string' && !options.uiExtensions.trim()) {
                 throw new Error(
                     'Plugin name cannot be empty when specified. Usage: vendure add --ui-extensions [plugin-name]',
                 );
@@ -254,9 +253,24 @@ export async function performAddOperation(options: AddOperationOptions): Promise
         ) {
             throw error;
         }
-        return {
-            success: false,
-            message: error.message ?? 'Add operation failed',
-        };
+        // For other errors, log them in a more user-friendly way
+        // For validation errors, show the full error with stack trace
+        if (error.message.includes('Plugin name is required')) {
+            // Extract error message and stack trace
+            const errorMessage = error.message;
+            const stackLines = error.stack.split('\n');
+            const stackTrace = stackLines.slice(1).join('\n'); // Remove first line (error message)
+
+            // Display stack trace first, then colored error message at the end
+            log.error(stackTrace);
+            log.error(''); // Add empty line for better readability
+            log.error(pc.red('Error:') + ' ' + String(errorMessage));
+        } else {
+            log.error(error.message as string);
+            if (error.stack) {
+                log.error(error.stack);
+            }
+        }
+        process.exit(1);
     }
 }

--- a/packages/cli/src/commands/add/api-extension/add-api-extension.ts
+++ b/packages/cli/src/commands/add/api-extension/add-api-extension.ts
@@ -32,11 +32,11 @@ const cancelledMessage = 'Add API extension cancelled';
 export interface AddApiExtensionOptions {
     plugin?: VendurePluginRef;
     pluginName?: string;
-    queryName?: string;
-    mutationName?: string;
+    'query-name'?: string;
+    'mutation-name'?: string;
     config?: string;
     isNonInteractive?: boolean;
-    selectedService?: string;
+    'selected-service'?: string;
 }
 
 export const addApiExtensionCommand = new CliCommand({
@@ -64,8 +64,8 @@ async function addApiExtension(
 
     // In non-interactive mode, we need all required values upfront
     if (options?.isNonInteractive) {
-        const hasValidQueryName = options?.queryName && options.queryName.trim() !== '';
-        const hasValidMutationName = options?.mutationName && options.mutationName.trim() !== '';
+        const hasValidQueryName = options?.['query-name'] && options['query-name'].trim() !== '';
+        const hasValidMutationName = options?.['mutation-name'] && options['mutation-name'].trim() !== '';
 
         if (!hasValidQueryName && !hasValidMutationName) {
             throw new Error(
@@ -92,14 +92,14 @@ async function addApiExtension(
 
     if (options?.isNonInteractive) {
         // Validate that a service has been specified
-        if (!options.selectedService || options.selectedService.trim() === '') {
+        if (!options['selected-service'] || options['selected-service'].trim() === '') {
             throw new Error(
                 'Service must be specified in non-interactive mode.\n' +
                     'Usage: npx vendure add -a <PluginName> --queryName <name> --mutationName <name> --selectedService <service-name>',
             );
         }
 
-        const selectedService = services.find(sr => sr.name === options.selectedService);
+        const selectedService = services.find(sr => sr.name === options['selected-service']);
 
         if (!selectedService) {
             const availableServices = services.map(sr => sr.name);
@@ -110,7 +110,7 @@ async function addApiExtension(
                 );
             }
             throw new Error(
-                `Service "${options.selectedService}" not found in plugin "${plugin.name}". Available services:\n` +
+                `Service "${options['selected-service']}" not found in plugin "${plugin.name}". Available services:\n` +
                     availableServices.map(name => `  - ${name}`).join('\n'),
             );
         }
@@ -150,14 +150,17 @@ async function addApiExtension(
     if (!serviceEntityRef) {
         if (options?.isNonInteractive) {
             // Use provided values - we already validated at least one exists and is non-empty
-            queryName = options?.queryName && options.queryName.trim() !== '' ? options.queryName.trim() : '';
+            queryName =
+                options?.['query-name'] && options['query-name'].trim() !== ''
+                    ? options['query-name'].trim()
+                    : '';
             mutationName =
-                options?.mutationName && options.mutationName.trim() !== ''
-                    ? options.mutationName.trim()
+                options?.['mutation-name'] && options['mutation-name'].trim() !== ''
+                    ? options['mutation-name'].trim()
                     : '';
         } else {
             const queryNameResult =
-                options?.queryName ??
+                options?.['query-name'] ??
                 (await text({
                     message: 'Enter a name for the new query',
                     initialValue: 'myNewQuery',
@@ -166,9 +169,9 @@ async function addApiExtension(
                 queryName = queryNameResult;
             }
             const mutationNameResult =
-                options?.mutationName ??
+                options?.['mutation-name'] ??
                 (await text({
-                    message: 'Enter a name for the new mutation',
+                    message: 'Enter a new name for the new mutation',
                     initialValue: 'myNewMutation',
                 }));
             if (!isCancel(mutationNameResult)) {

--- a/packages/cli/src/commands/add/api-extension/add-api-extension.ts
+++ b/packages/cli/src/commands/add/api-extension/add-api-extension.ts
@@ -32,11 +32,11 @@ const cancelledMessage = 'Add API extension cancelled';
 export interface AddApiExtensionOptions {
     plugin?: VendurePluginRef;
     pluginName?: string;
-    'query-name'?: string;
-    'mutation-name'?: string;
+    queryName?: string;
+    mutationName?: string;
     config?: string;
     isNonInteractive?: boolean;
-    'selected-service'?: string;
+    selectedService?: string;
 }
 
 export const addApiExtensionCommand = new CliCommand({
@@ -64,8 +64,8 @@ async function addApiExtension(
 
     // In non-interactive mode, we need all required values upfront
     if (options?.isNonInteractive) {
-        const hasValidQueryName = options?.['query-name'] && options['query-name'].trim() !== '';
-        const hasValidMutationName = options?.['mutation-name'] && options['mutation-name'].trim() !== '';
+        const hasValidQueryName = options?.queryName && options.queryName.trim() !== '';
+        const hasValidMutationName = options?.mutationName && options.mutationName.trim() !== '';
 
         if (!hasValidQueryName && !hasValidMutationName) {
             throw new Error(
@@ -92,14 +92,14 @@ async function addApiExtension(
 
     if (options?.isNonInteractive) {
         // Validate that a service has been specified
-        if (!options['selected-service'] || options['selected-service'].trim() === '') {
+        if (!options.selectedService || options.selectedService.trim() === '') {
             throw new Error(
                 'Service must be specified in non-interactive mode.\n' +
                     'Usage: npx vendure add -a <PluginName> --query-name <name> --mutation-name <name> --selected-service <service-name>',
             );
         }
 
-        const selectedService = services.find(sr => sr.name === options['selected-service']);
+        const selectedService = services.find(sr => sr.name === options.selectedService);
 
         if (!selectedService) {
             const availableServices = services.map(sr => sr.name);
@@ -110,7 +110,7 @@ async function addApiExtension(
                 );
             }
             throw new Error(
-                `Service "${options['selected-service']}" not found in plugin "${plugin.name}". Available services:\n` +
+                `Service "${options.selectedService}" not found in plugin "${plugin.name}". Available services:\n` +
                     availableServices.map(name => `  - ${name}`).join('\n'),
             );
         }
@@ -150,17 +150,14 @@ async function addApiExtension(
     if (!serviceEntityRef) {
         if (options?.isNonInteractive) {
             // Use provided values - we already validated at least one exists and is non-empty
-            queryName =
-                options?.['query-name'] && options['query-name'].trim() !== ''
-                    ? options['query-name'].trim()
-                    : '';
+            queryName = options?.queryName && options.queryName.trim() !== '' ? options.queryName.trim() : '';
             mutationName =
-                options?.['mutation-name'] && options['mutation-name'].trim() !== ''
-                    ? options['mutation-name'].trim()
+                options?.mutationName && options.mutationName.trim() !== ''
+                    ? options.mutationName.trim()
                     : '';
         } else {
             const queryNameResult =
-                options?.['query-name'] ??
+                options?.queryName ??
                 (await text({
                     message: 'Enter a name for the new query',
                     initialValue: 'myNewQuery',
@@ -169,7 +166,7 @@ async function addApiExtension(
                 queryName = queryNameResult;
             }
             const mutationNameResult =
-                options?.['mutation-name'] ??
+                options?.mutationName ??
                 (await text({
                     message: 'Enter a new name for the new mutation',
                     initialValue: 'myNewMutation',

--- a/packages/cli/src/commands/add/api-extension/add-api-extension.ts
+++ b/packages/cli/src/commands/add/api-extension/add-api-extension.ts
@@ -69,8 +69,8 @@ async function addApiExtension(
 
         if (!hasValidQueryName && !hasValidMutationName) {
             throw new Error(
-                'At least one of queryName or mutationName must be specified as a non-empty string in non-interactive mode.\n' +
-                    'Usage: npx vendure add -a <PluginName> --queryName <name> --mutationName <name>',
+                'At least one of query-name or mutation-name must be specified as a non-empty string in non-interactive mode.\n' +
+                    'Usage: npx vendure add -a <PluginName> --query-name <name> --mutation-name <name>',
             );
         }
     }
@@ -95,7 +95,7 @@ async function addApiExtension(
         if (!options['selected-service'] || options['selected-service'].trim() === '') {
             throw new Error(
                 'Service must be specified in non-interactive mode.\n' +
-                    'Usage: npx vendure add -a <PluginName> --queryName <name> --mutationName <name> --selectedService <service-name>',
+                    'Usage: npx vendure add -a <PluginName> --query-name <name> --mutation-name <name> --selected-service <service-name>',
             );
         }
 

--- a/packages/cli/src/commands/command-declarations.ts
+++ b/packages/cli/src/commands/command-declarations.ts
@@ -94,12 +94,12 @@ export const cliCommands: CliCommandDefinition[] = [
                 required: false,
                 subOptions: [
                     {
-                        long: '--queryName <name>',
+                        long: '--query-name <name>',
                         description: 'Name for the query (used with -a)',
                         required: false,
                     },
                     {
-                        long: '--mutationName <name>',
+                        long: '--mutation-name <name>',
                         description: 'Name for the mutation (used with -a)',
                         required: false,
                     },


### PR DESCRIPTION
# Description

Fix 2 inconsistent flag names in the vendure add CLI command.

# Breaking changes

`--mutationName` turns into `--mutation-name`
`--queryName` turns into `--query-name`

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [x] I have added or updated test cases
- [x] I have updated the README if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated CLI option flags and related prompts from camelCase to kebab-case for improved consistency. For example, options like `--queryName` and `--mutationName` are now `--query-name` and `--mutation-name`.
  * Renamed internal option keys in CLI commands and tests to kebab-case, enhancing naming consistency across the interface.
  * Improved error handling in the CLI with clearer, formatted error messages and immediate process termination on failure for better user feedback.

* **Style**
  * Adjusted naming conventions in CLI commands and prompts to use kebab-case, aligning with common CLI standards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->