### PR TITLE
fix(admin-ui): better Spanish translation for "locale"

### DIFF
--- a/packages/admin-ui/src/lib/static/i18n-messages/es.json
+++ b/packages/admin-ui/src/lib/static/i18n-messages/es.json
@@ -267,7 +267,7 @@
     "launch-extension": "Ejecutar extensión",
     "list-items-and-n-more": "{ items } y {nMore} más",
     "live-update": "Actualización en vivo",
-    "locale": "Idioma",
+    "locale": "Región",
     "log-out": "Salir",
     "login": "Entrar",
     "login-image-title": "Hola de nuevo!",


### PR DESCRIPTION
# Description

I'm choosing a better Spanish translation for the word "locale". I chose "Región" (as in Region) because "Localización" seems too forced (nobody uses that word so many admins may not know what it means). Other options are "Configuración regional" or "Ajuste regional" (as in "regional settings") but in my opinion, those translations are not needed because it should already be clear to the user that they are changing settings.

# Breaking changes

No breaking change.

# Screenshots

This is the current config modal. It's confusing having two fields with the same label.
<img width="861" height="388" alt="image" src="https://github.com/user-attachments/assets/1c0e476e-3fb9-43da-945c-cedd89ddcf31" />

# Checklist

📌 Always:
- [ ] I have set a clear title
- [ ] My PR is small and contains a single feature
- [ ] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [ ] I have added or updated test cases
- [ ] I have updated the README if needed
