### PR TITLE
fix(core): ID decoding in nested filter structures

### DIFF
--- a/packages/core/e2e/list-query-builder.e2e-spec.ts
+++ b/packages/core/e2e/list-query-builder.e2e-spec.ts
@@ -976,7 +976,7 @@ describe('ListQueryBuilder', () => {
                                 description: { contains: 'e' },
                             },
                             {
-                                _or: [{ active: { eq: false } }, { ownerId: { eq: '10' } }],
+                                _or: [{ active: { eq: false } }, { ownerId: { eq: 'T_10' } }],
                             },
                         ],
                     },

--- a/packages/core/src/api/common/graphql-value-transformer.ts
+++ b/packages/core/src/api/common/graphql-value-transformer.ts
@@ -187,12 +187,32 @@ export class GraphqlValueTransformer {
     private getChildrenTreeNodes(
         inputType: GraphQLInputObjectType,
         parent: TypeTreeNode,
+        depth = 0,
     ): { [name: string]: TypeTreeNode } {
+        if (depth > 3) return {};
+
         return Object.entries(inputType.getFields()).reduce(
             (result, [key, field]) => {
                 const namedType = getNamedType(field.type);
                 if (namedType === parent.type) {
-                    // prevent recursion-induced stack overflow
+                    // Allow _and/_or self-references in filter types, but limit depth to prevent infinite loops
+                    if (key === '_and' || key === '_or') {
+                        const selfRefChild: TypeTreeNode = {
+                            type: namedType,
+                            isList: this.isList(field.type),
+                            parent,
+                            fragmentRefs: [],
+                            children: {},
+                        };
+                        if (isInputObjectType(namedType)) {
+                            selfRefChild.children = this.getChildrenTreeNodes(
+                                namedType,
+                                selfRefChild,
+                                depth + 1,
+                            );
+                        }
+                        return { ...result, [key]: selfRefChild };
+                    }
                     return result;
                 }
                 const child: TypeTreeNode = {

--- a/packages/core/src/api/common/graphql-value-transformer.ts
+++ b/packages/core/src/api/common/graphql-value-transformer.ts
@@ -211,7 +211,8 @@ export class GraphqlValueTransformer {
                                 depth + 1,
                             );
                         }
-                        return { ...result, [key]: selfRefChild };
+                        result[key] = selfRefChild;
+                        return result;
                     }
                     return result;
                 }


### PR DESCRIPTION
Fixes #3048 

# Description

When using a custom a `entityIdStrategy`, filtering entities with nested ID fields (like filtering product variants by productId) failed because encoded IDs weren't being properly decoded, the ID fields deeper in the structure weren't being detected correctly.

This PR improves how nested filters are handled so that ID fields are properly detected and decoded, even when they appear inside deeper logical operators like `_and` and `_or`.

# Breaking changes

No.

# Screenshots

You can add screenshots here if applicable.

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [x] I have added or updated test cases
- [ ] I have updated the README if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of complex boolean filter conditions to support limited self-referential logic, preventing potential infinite loops in nested filters.
  * Updated test cases to ensure correct filtering behavior with updated identifier formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->