### PR TITLE
fix(dashboard): Fix handling of more types of path alias

### DIFF
--- a/packages/dashboard/vite/tests/fixtures-path-alias/aliased-plugin/index.ts
+++ b/packages/dashboard/vite/tests/fixtures-path-alias/aliased-plugin/index.ts
@@ -1,1 +1,0 @@
-export * from './src/aliased.plugin';

--- a/packages/dashboard/vite/tests/fixtures-path-alias/js-aliased/index.ts
+++ b/packages/dashboard/vite/tests/fixtures-path-alias/js-aliased/index.ts
@@ -1,0 +1,1 @@
+export * from './src/js-aliased.plugin';

--- a/packages/dashboard/vite/tests/fixtures-path-alias/js-aliased/src/js-aliased.plugin.ts
+++ b/packages/dashboard/vite/tests/fixtures-path-alias/js-aliased/src/js-aliased.plugin.ts
@@ -1,0 +1,8 @@
+import { PluginCommonModule, VendurePlugin } from '@vendure/core';
+
+@VendurePlugin({
+    imports: [PluginCommonModule],
+    providers: [],
+    dashboard: './dashboard/index.tsx',
+})
+export class JsAliasedPlugin {}

--- a/packages/dashboard/vite/tests/fixtures-path-alias/star-aliased/index.ts
+++ b/packages/dashboard/vite/tests/fixtures-path-alias/star-aliased/index.ts
@@ -1,0 +1,1 @@
+export * from './src/star-aliased.plugin';

--- a/packages/dashboard/vite/tests/fixtures-path-alias/star-aliased/src/star-aliased.plugin.ts
+++ b/packages/dashboard/vite/tests/fixtures-path-alias/star-aliased/src/star-aliased.plugin.ts
@@ -5,4 +5,4 @@ import { PluginCommonModule, VendurePlugin } from '@vendure/core';
     providers: [],
     dashboard: './dashboard/index.tsx',
 })
-export class AliasedPlugin {}
+export class StarAliasedPlugin {}

--- a/packages/dashboard/vite/tests/fixtures-path-alias/ts-aliased/index.ts
+++ b/packages/dashboard/vite/tests/fixtures-path-alias/ts-aliased/index.ts
@@ -1,0 +1,1 @@
+export * from './src/ts-aliased.plugin';

--- a/packages/dashboard/vite/tests/fixtures-path-alias/ts-aliased/src/ts-aliased.plugin.ts
+++ b/packages/dashboard/vite/tests/fixtures-path-alias/ts-aliased/src/ts-aliased.plugin.ts
@@ -1,0 +1,8 @@
+import { PluginCommonModule, VendurePlugin } from '@vendure/core';
+
+@VendurePlugin({
+    imports: [PluginCommonModule],
+    providers: [],
+    dashboard: './dashboard/index.tsx',
+})
+export class TsAliasedPlugin {}

--- a/packages/dashboard/vite/tests/fixtures-path-alias/vendure-config.ts
+++ b/packages/dashboard/vite/tests/fixtures-path-alias/vendure-config.ts
@@ -1,6 +1,7 @@
+import { JsAliasedPlugin } from '@other/js-aliased';
+import { TsAliasedPlugin } from '@other/ts-aliased';
+import { StarAliasedPlugin } from '@plugins/star-aliased';
 import { VendureConfig } from '@vendure/core';
-
-import { AliasedPlugin } from './aliased-plugin';
 
 export const config: VendureConfig = {
     apiOptions: {
@@ -15,5 +16,5 @@ export const config: VendureConfig = {
     paymentOptions: {
         paymentMethodHandlers: [],
     },
-    plugins: [AliasedPlugin],
+    plugins: [StarAliasedPlugin, TsAliasedPlugin, JsAliasedPlugin],
 };

--- a/packages/dashboard/vite/tests/path-alias.spec.ts
+++ b/packages/dashboard/vite/tests/path-alias.spec.ts
@@ -16,17 +16,45 @@ describe('detecting plugins using tsconfig path aliases', () => {
                 outputPath: tempDir,
                 vendureConfigPath: join(__dirname, 'fixtures-path-alias', 'vendure-config.ts'),
                 logger: process.env.LOG ? debugLogger : noopLogger,
+                pathAdapter: {
+                    transformTsConfigPathMappings: ({ phase, patterns }) => {
+                        if (phase === 'loading') {
+                            return patterns.map(pattern => {
+                                return pattern.replace(/\/fixtures-path-alias/, '').replace(/.ts$/, '.js');
+                            });
+                        } else {
+                            return patterns;
+                        }
+                    },
+                },
             });
 
-            expect(result.pluginInfo).toHaveLength(1);
-            expect(result.pluginInfo[0].name).toBe('AliasedPlugin');
-            expect(result.pluginInfo[0].dashboardEntryPath).toBe('./dashboard/index.tsx');
-            expect(result.pluginInfo[0].sourcePluginPath).toBe(
-                join(__dirname, 'fixtures-path-alias', 'aliased-plugin', 'src', 'aliased.plugin.ts'),
+            const plugins = result.pluginInfo.sort((a, b) => a.name.localeCompare(b.name));
+
+            expect(plugins).toHaveLength(3);
+
+            expect(plugins[0].name).toBe('JsAliasedPlugin');
+            expect(plugins[0].dashboardEntryPath).toBe('./dashboard/index.tsx');
+            expect(plugins[0].sourcePluginPath).toBe(
+                join(__dirname, 'fixtures-path-alias', 'js-aliased', 'src', 'js-aliased.plugin.ts'),
             );
-            expect(result.pluginInfo[0].pluginPath).toBe(
-                join(tempDir, 'aliased-plugin', 'src', 'aliased.plugin.js'),
+            expect(plugins[0].pluginPath).toBe(join(tempDir, 'js-aliased', 'src', 'js-aliased.plugin.js'));
+
+            expect(plugins[1].name).toBe('StarAliasedPlugin');
+            expect(plugins[1].dashboardEntryPath).toBe('./dashboard/index.tsx');
+            expect(plugins[1].sourcePluginPath).toBe(
+                join(__dirname, 'fixtures-path-alias', 'star-aliased', 'src', 'star-aliased.plugin.ts'),
             );
+            expect(plugins[1].pluginPath).toBe(
+                join(tempDir, 'star-aliased', 'src', 'star-aliased.plugin.js'),
+            );
+
+            expect(plugins[2].name).toBe('TsAliasedPlugin');
+            expect(plugins[2].dashboardEntryPath).toBe('./dashboard/index.tsx');
+            expect(plugins[2].sourcePluginPath).toBe(
+                join(__dirname, 'fixtures-path-alias', 'ts-aliased', 'src', 'ts-aliased.plugin.ts'),
+            );
+            expect(plugins[2].pluginPath).toBe(join(tempDir, 'ts-aliased', 'src', 'ts-aliased.plugin.js'));
         },
         { timeout: 10_000 },
     );

--- a/packages/dashboard/vite/tests/tsconfig.json
+++ b/packages/dashboard/vite/tests/tsconfig.json
@@ -1,11 +1,21 @@
 {
-    "compilerOptions": {
-        "module": "NodeNext",
-        "sourceMap": true,
-        "jsx": "react-jsx",
-        "paths": {
-            "@plugins/*": ["./fixtures-path-alias/*"]
-        }
-    },
-    "exclude": ["node_modules"]
+  "compilerOptions": {
+    "module": "NodeNext",
+    "sourceMap": true,
+    "jsx": "react-jsx",
+    "paths": {
+      "@plugins/*": [
+        "./fixtures-path-alias/*"
+      ],
+      "@other/ts-aliased": [
+        "./fixtures-path-alias/ts-aliased/index.ts"
+      ],
+      "@other/js-aliased": [
+        "./fixtures-path-alias/js-aliased/index.js"
+      ]
+    }
+  },
+  "exclude": [
+    "node_modules"
+  ]
 }

--- a/packages/dashboard/vite/utils/plugin-discovery.ts
+++ b/packages/dashboard/vite/utils/plugin-discovery.ts
@@ -232,8 +232,11 @@ export async function analyzeSourceFiles(
                     importPath + '.js',
                     path.join(importPath, 'index.ts'),
                     path.join(importPath, 'index.js'),
+                    importPath,
                 ];
-
+                if (importPath.endsWith('.js')) {
+                    possiblePaths.push(importPath.replace(/.js$/, '.ts'));
+                }
                 // Try each possible path
                 let found = false;
                 for (const possiblePath of possiblePaths) {


### PR DESCRIPTION
# Description

Handles some extra cases of tsconfig path aliases that were not covered. Also adds tests for these.

Relates to #3669

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new plugins with support for different path aliasing methods.
  * Expanded configuration to support multiple plugin path aliases.
* **Bug Fixes**
  * Improved source file resolution for plugins by considering both `.js` and `.ts` file extensions.
* **Tests**
  * Enhanced test coverage to verify detection and correct handling of multiple aliased plugins.
* **Chores**
  * Updated TypeScript configuration to include additional path aliases.
  * Refactored plugin imports in configuration for better clarity and flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->