### PR TITLE
fix(core): Update validation for session if we work with relationLoadStrategy query

### DIFF
--- a/packages/core/src/service/services/auth.service.ts
+++ b/packages/core/src/service/services/auth.service.ts
@@ -100,7 +100,7 @@ export class AuthService {
             await this.sessionService.deleteSessionsByActiveOrderId(ctx, ctx.session.activeOrderId);
         }
         user.lastLogin = new Date();
-        await this.connection.getRepository(ctx, User).save(user, { reload: false });
+        await this.connection.getRepository(ctx, User).save(user);
         const session = await this.sessionService.createNewAuthenticatedSession(
             ctx,
             user,

--- a/packages/core/src/service/services/session.service.ts
+++ b/packages/core/src/service/services/session.service.ts
@@ -398,6 +398,6 @@ export class SessionService implements EntitySubscriberInterface, OnApplicationB
     }
 
     private isAuthenticatedSession(session: Session): session is AuthenticatedSession {
-        return session.hasOwnProperty('user');
+        return session.hasOwnProperty('user') && !!(session as AuthenticatedSession).user;
     }
 }


### PR DESCRIPTION


# Description

When trying to enable the `relationLoadStrategy query` strategy, the error user.id not found appeared because when the strategy was changed, the user remained null and was not saved in the session. Due to the fact that the check only checked the existence of the variable, a data validation error occurred and the user null was considered authorized

# Breaking changes

I think no.

# Checklist

📌 Always:
- [ ] I have set a clear title
- [ ] My PR is small and contains a single feature
- [ ] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [ ] I have added or updated test cases
- [ ] I have updated the README if needed
