### PR TITLE
fix(llm-txt-plugin): erase index path at the end

### DIFF
--- a/docs/src/plugins/llm-txt-plugin.js
+++ b/docs/src/plugins/llm-txt-plugin.js
@@ -60,7 +60,7 @@ module.exports = function (context) {
             const docsRecords = Object.entries(currentVersionDocsRoutes)
                 .filter(([path, record]) => record.id !== 'TODO')
                 .map(([path, record]) => {
-                    return `- [${record.title}](${DOCS_BASE_URL}/${path}): ${record.description}`;
+                    return `- [${record.title}](${DOCS_BASE_URL}/${path.replace(/\/index\/?$/, '')}): ${record.description}`;
                 });
 
             // Build up llms.txt file


### PR DESCRIPTION
# Description

Currently this plugin generates markdown with url such as `https://docs.vendure.io/guides/core-concepts/auth/index` which shows 404 page. Erasing the last `/index` seems to solve this issue.

# Breaking changes

Does this PR include any breaking changes we should be aware of?
No

# Screenshots

You can add screenshots here if applicable.

### With `/index`

<img width="1205" height="495" alt="image" src="https://github.com/user-attachments/assets/982fa96c-7b79-4dcd-9ab7-7aac376c8f32" />

### Without `/index`

<img width="1066" height="683" alt="image" src="https://github.com/user-attachments/assets/fa6a6921-6a0e-4512-8257-a98932591207" />


# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [ ] I have added or updated test cases
- [ ] I have updated the README if needed
