### PR TITLE
fix(dashboard): Add missing order property to nav menu items

### DIFF
--- a/packages/dashboard/src/lib/framework/extension-api/logic/navigation.ts
+++ b/packages/dashboard/src/lib/framework/extension-api/logic/navigation.ts
@@ -25,6 +25,7 @@ export function registerNavigationExtensions(
                     url: route.navMenuItem.url ?? route.path,
                     id: route.navMenuItem.id ?? route.path,
                     title: route.navMenuItem.title ?? route.path,
+                    order: route.navMenuItem.order,
                 };
                 addNavMenuItem(item, route.navMenuItem.sectionId);
             }


### PR DESCRIPTION
# Description

This PR fixes an issue where the `order` property was not being passed through when registering navigation menu items via extensions. The `order` property was already supported in the nav menu system and properly sorted items, but it was not being included when converting route navigation items to menu items.

# Breaking changes

No breaking changes.

# Screenshots

N/A - This is a code fix that doesn't affect the UI appearance, only the ordering behavior.

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [ ] I have added or updated test cases
- [x] I have updated the README if needed (not needed for this fix)

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The navigation menu now supports custom ordering of items, allowing for improved organization and display order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->