### PR TITLE
fix(dashboard): Add "ring offeset" padding on devmode on hover ring

### DIFF
--- a/packages/dashboard/src/lib/framework/layout-engine/location-wrapper.tsx
+++ b/packages/dashboard/src/lib/framework/layout-engine/location-wrapper.tsx
@@ -74,7 +74,7 @@ export function LocationWrapper({ children, identifier }: Readonly<LocationWrapp
         return (
             <div
                 className={cn(
-                    `ring-2 transition-all delay-50 relative`,
+                    `ring-2 p-2 transition-all delay-50 relative`,
                     isHovered || isPopoverOpen ? 'ring-dev-mode' : 'ring-transparent',
                     isPageWrapper ? 'ring-inset' : '',
                     identifier ? 'rounded-md' : 'rounded-xl',


### PR DESCRIPTION
# Description

The rings in hover mode were touching the text of the elements and it looked very unpolished. 

# Screenshots

after:
<img width="429" height="246" alt="image" src="https://github.com/user-attachments/assets/2ef771c9-65bb-4f11-a8ea-3de2d5b4b35a" />

before: 
<img width="276" height="193" alt="image" src="https://github.com/user-attachments/assets/42296b4a-b182-43e6-a635-ccbccf098382" />


You can add screenshots here if applicable.

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [ ] I have added or updated test cases
- [ ] I have updated the README if needed
