### PR TITLE
fix: Filter for only settled refunds and adapt test cases

### DIFF
--- a/packages/core/src/service/helpers/utils/order-utils.spec.ts
+++ b/packages/core/src/service/helpers/utils/order-utils.spec.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import { Order } from '../../../entity/order/order.entity';
 import { Payment } from '../../../entity/payment/payment.entity';
+import { Refund } from '../../../entity/refund/refund.entity';
 
 import { totalCoveredByPayments } from './order-utils';
 
@@ -85,5 +86,66 @@ describe('totalCoveredByPayments()', () => {
         });
 
         expect(totalCoveredByPayments(order, ['Settled', 'Authorized'])).toBe(800);
+    });
+
+    it('single payment, refunds with different states', () => {
+        const order = new Order({
+            payments: [
+                new Payment({
+                    state: 'Settled',
+                    amount: 500,
+                    refunds: [
+                        new Refund({ state: 'Settled', total: 100 }),
+                        new Refund({ state: 'Pending', total: 200 }),
+                    ],
+                }),
+            ],
+        });
+
+        expect(totalCoveredByPayments(order, ['Settled', 'Authorized'])).toBe(400);
+    });
+
+    it('single payment, refunds with different states', () => {
+        const order = new Order({
+            payments: [
+                new Payment({
+                    state: 'Settled',
+                    amount: 500,
+                    refunds: [
+                        new Refund({ state: 'Settled', total: 100 }),
+                        new Refund({ state: 'Pending', total: 200 }),
+                    ],
+                }),
+            ],
+        });
+
+        expect(totalCoveredByPayments(order, ['Settled', 'Authorized'])).toBe(400);
+    });
+
+    it('multiple payments, refunds with different states', () => {
+        const order = new Order({
+            payments: [
+                new Payment({
+                    state: 'Settled',
+                    amount: 500,
+                    refunds: [
+                        new Refund({ state: 'Settled', total: 100 }),
+                        new Refund({ state: 'Pending', total: 200 }),
+                        new Refund({ state: 'Settled', total: 100 }),
+                    ],
+                }),
+                new Payment({
+                    state: 'Settled',
+                    amount: 500,
+                    refunds: [
+                        new Refund({ state: 'Settled', total: 100 }),
+                        new Refund({ state: 'Failed', total: 200 }),
+                        new Refund({ state: 'Pending', total: 200 }),
+                    ],
+                }),
+            ],
+        });
+
+        expect(totalCoveredByPayments(order, ['Settled', 'Authorized'])).toBe(700);
     });
 });


### PR DESCRIPTION
ref: #3670 

# Description

When calculating `totalCoveredByPayments`, we had before considered refunds regardless of their status. This PR introduces a change where we only consider refunds if their status is `Settled`. We also add 2 test cases that would cover the various refund states that are defined, and test with both single and multiple payments.

# Breaking changes

None.

# Screenshots

You can add screenshots here if applicable.

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [x] I have added or updated test cases
- [x] I have updated the README if needed
