### PR TITLE
feat: 🎸 Add support for custom TypeScript transformers

### DIFF
--- a/packages/dashboard/vite/utils/compiler.ts
+++ b/packages/dashboard/vite/utils/compiler.ts
@@ -28,6 +28,7 @@ export interface CompilerOptions {
     pathAdapter?: PathAdapter;
     logger?: Logger;
     pluginPackageScanner?: PackageScannerConfig;
+    customTransformers?: ts.CustomTransformers;
 }
 
 export interface CompileResult {
@@ -41,7 +42,14 @@ export interface CompileResult {
  * and in node_modules.
  */
 export async function compile(options: CompilerOptions): Promise<CompileResult> {
-    const { vendureConfigPath, outputPath, pathAdapter, logger = noopLogger, pluginPackageScanner } = options;
+    const {
+        vendureConfigPath,
+        outputPath,
+        pathAdapter,
+        logger = noopLogger,
+        pluginPackageScanner,
+        customTransformers,
+    } = options;
     const getCompiledConfigPath =
         pathAdapter?.getCompiledConfigPath ?? defaultPathAdapter.getCompiledConfigPath;
     const transformTsConfigPathMappings =
@@ -54,6 +62,7 @@ export async function compile(options: CompilerOptions): Promise<CompileResult> 
         outputPath,
         logger,
         transformTsConfigPathMappings,
+        customTransformers,
     });
     logger.info(`TypeScript compilation completed in ${Date.now() - compileStart}ms`);
 
@@ -134,11 +143,13 @@ async function compileTypeScript({
     outputPath,
     logger,
     transformTsConfigPathMappings,
+    customTransformers,
 }: {
     inputPath: string;
     outputPath: string;
     logger: Logger;
     transformTsConfigPathMappings: Required<PathAdapter>['transformTsConfigPathMappings'];
+    customTransformers?: ts.CustomTransformers;
 }): Promise<void> {
     await fs.ensureDir(outputPath);
 
@@ -189,7 +200,7 @@ async function compileTypeScript({
     logger.debug(`tsConfig baseUrl: ${tsConfigInfo?.baseUrl ?? 'UNKNOWN'}`);
 
     // Create a custom transformer to rewrite the output paths
-    const customTransformers: ts.CustomTransformers = {
+    const defaultCustomTransformers: ts.CustomTransformers = {
         after: [
             context => {
                 return sourceFile => {
@@ -204,8 +215,14 @@ async function compileTypeScript({
         ],
     };
 
+    // Merge custom transformers with default ones
+    const mergedCustomTransformers: ts.CustomTransformers = {
+        before: [...(customTransformers?.before ?? []), ...(defaultCustomTransformers.before ?? [])],
+        after: [...(customTransformers?.after ?? []), ...(defaultCustomTransformers.after ?? [])],
+    };
+
     const program = ts.createProgram([inputPath], compilerOptions);
-    const emitResult = program.emit(undefined, undefined, undefined, undefined, customTransformers);
+    const emitResult = program.emit(undefined, undefined, undefined, undefined, mergedCustomTransformers);
 
     // Only log actual emit errors, not type errors
     if (emitResult.emitSkipped) {

--- a/packages/dashboard/vite/vite-plugin-vendure-dashboard.ts
+++ b/packages/dashboard/vite/vite-plugin-vendure-dashboard.ts
@@ -2,6 +2,7 @@ import tailwindcss from '@tailwindcss/vite';
 import { TanStackRouterVite } from '@tanstack/router-plugin/vite';
 import react from '@vitejs/plugin-react';
 import path from 'path';
+import ts from 'typescript';
 import { PluginOption } from 'vite';
 
 import { PathAdapter } from './types.js';
@@ -86,6 +87,12 @@ export type VitePluginVendureDashboardOptions = {
      * the location based on the location of the `@vendure/core` package.
      */
     pluginPackageScanner?: PackageScannerConfig;
+    /**
+     * @description
+     * Custom TypeScript transformers to apply during compilation of the Vendure config.
+     * This allows you to customize the TypeScript compilation process for advanced use cases.
+     */
+    customTransformers?: ts.CustomTransformers;
 } & UiConfigPluginOptions &
     ThemeVariablesPluginOptions;
 
@@ -129,6 +136,7 @@ export function vendureDashboardPlugin(options: VitePluginVendureDashboardOption
             outputPath: tempDir,
             pathAdapter: options.pathAdapter,
             pluginPackageScanner: options.pluginPackageScanner,
+            customTransformers: options.customTransformers,
         }),
         viteConfigPlugin({ packageRoot }),
         adminApiSchemaPlugin(),


### PR DESCRIPTION
✅ Closes: #3727

feat: Add support for custom TypeScript transformers in Vendure dashboard plugin

This update introduces a new option for custom TypeScript transformers in the Vite plugin, allowing users to customize the TypeScript compilation process. The changes include updates to the `CompilerOptions` interface and the compilation logic to merge user-defined transformers with default ones.