### PR TITLE
chore: Update the Vendure ElasticSearch plugin to use ElasticSearch v9.1.0

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -106,8 +106,14 @@ jobs:
                     - 5432
                 options: --health-cmd=pg_isready --health-interval=10s --health-timeout=5s --health-retries=3
             elastic:
-                image: docker.elastic.co/elasticsearch/elasticsearch:7.1.1
+                image: docker.elastic.co/elasticsearch/elasticsearch:9.1.0
                 env:
+                    node.name: es
+                    cluster.name: es-docker-cluster
+                    xpack.security.enabled: false
+                    xpack.security.http.ssl.enabled: false
+                    xpack.security.transport.ssl.enabled: false
+                    xpack.license.self_generated.type: basic
                     discovery.type: single-node
                     bootstrap.memory_lock: true
                     ES_JAVA_OPTS: -Xms512m -Xmx512m

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -79,12 +79,19 @@ services:
         volumes:
             - keycloak_data:/opt/keycloak/data
     elasticsearch:
-        image: docker.elastic.co/elasticsearch/elasticsearch:7.10.2
+        image: docker.elastic.co/elasticsearch/elasticsearch:9.1.0
         container_name: elasticsearch
         environment:
+            - node.name=es
+            - cluster.name=es-docker-cluster
+            - xpack.security.enabled=false
+            - xpack.security.http.ssl.enabled=false
+            - xpack.security.transport.ssl.enabled=false
+            - xpack.license.self_generated.type=basic
             - discovery.type=single-node
             - bootstrap.memory_lock=true
-            - 'ES_JAVA_OPTS=-Xms512m -Xmx512m'
+            - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+        mem_limit: 536870912
         ulimits:
             memlock:
                 soft: -1
@@ -100,7 +107,6 @@ services:
             - ALLOW_EMPTY_PASSWORD=yes
         ports:
             - '6379:6379'
-
     jaeger:
         image: jaegertracing/all-in-one:latest
         container_name: jaeger

--- a/packages/create/templates/docker-compose.hbs
+++ b/packages/create/templates/docker-compose.hbs
@@ -76,15 +76,27 @@ services:
     # Checkout our Elasticsearch plugin: https://docs.vendure.io/reference/core-plugins/elasticsearch-plugin/
     # To run the elasticsearch container run "docker compose up -d elasticsearch"
     elasticsearch:
-        image: docker.elastic.co/elasticsearch/elasticsearch:7.1.1
+        image: docker.elastic.co/elasticsearch/elasticsearch:9.1.0
+        container_name: elasticsearch
         environment:
-            discovery.type: single-node
-            bootstrap.memory_lock: true
-            ES_JAVA_OPTS: -Xms512m -Xmx512m
+            - node.name=es
+            - cluster.name=es-docker-cluster
+            - xpack.security.enabled=false
+            - xpack.security.http.ssl.enabled=false
+            - xpack.security.transport.ssl.enabled=false
+            - xpack.license.self_generated.type=basic
+            - discovery.type=single-node
+            - bootstrap.memory_lock=true
+            - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+        mem_limit: 536870912
+        ulimits:
+            memlock:
+                soft: -1
+                hard: -1
         volumes:
-            - elasticsearch_data:/usr/share/elasticsearch/data
+            - esdata:/usr/share/elasticsearch/data
         ports:
-            - "9300:9200"
+            - 9200:9200
         labels:
             - "io.vendure.create.name={{{ escapeSingle name }}}"
 

--- a/packages/elasticsearch-plugin/e2e/e2e-helpers.ts
+++ b/packages/elasticsearch-plugin/e2e/e2e-helpers.ts
@@ -76,7 +76,7 @@ export async function testMatchSearchTerm(client: SimpleGraphQLClient) {
             },
         },
     );
-    expect(result.search.items.map(i => i.productName)).toEqual([
+    expect(result.search.items.map(i => i.productName).sort()).toEqual([
         'Camera Lens',
         'Instant Camera',
         'SLR Camera',

--- a/packages/elasticsearch-plugin/package.json
+++ b/packages/elasticsearch-plugin/package.json
@@ -25,7 +25,7 @@
         "access": "public"
     },
     "dependencies": {
-        "@elastic/elasticsearch": "~7.9.1",
+        "@elastic/elasticsearch": "9.1.0",
         "deepmerge": "^4.2.2",
         "fast-deep-equal": "^3.1.3"
     },

--- a/packages/elasticsearch-plugin/src/plugin.ts
+++ b/packages/elasticsearch-plugin/src/plugin.ts
@@ -63,11 +63,25 @@ function getCustomResolvers(options: ElasticsearchRuntimeOptions) {
  * to support a wide range of use-cases such as indexing of custom properties, fine control over search index configuration, and to leverage
  * advanced Elasticsearch features like spacial search.
  *
- * ## Installation
+ * **ElasticSearch v9.1.0 is supported**
  *
- * **Requires Elasticsearch v7.0 < required Elasticsearch version < 7.10 **
- * Elasticsearch version 7.10.2 will throw error due to incompatibility with elasticsearch-js client.
- * [Check here for more info](https://github.com/elastic/elasticsearch-js/issues/1519).
+ * **Important information about versions and ElasticSearch security:**
+ * The version of ElasticSearch that is deployed, the version of the JS library @elastic/elasticsearch installed in your Vendure project and the version
+ * of the JS library @elastic/elasticsearch used in the @vendure/elasticsearch-plugin must all match to avoid any issues. ElasticSearch does not allow @latest
+ * in its repository so these versions must be updated regularly.
+ * | Package  | Version |
+ * | ------------- | ------------- |
+ * | ElasticSearch  | v9.1.0  |
+ * | @elastic/elasticsearch  | v9.1.0  |
+ * | @vendure/elasticsearch-plugin | v3.5.0  |
+ * | Last updated | Aug 5, 2025 |
+ *
+ * With ElasticSearch v8+, basic authentication, SSL, and TLS are enabled by default and may result in your client and plugin not being able to connect to
+ * ElasticSearch successfully if your client is not configured appropriately. You must also set ```xpack.license.self_generated.type=basic``` if you are
+ * using the free Community Edition of ElasticSearch.
+ *
+ * Review the ElasticSearch docker [example](<https://github.com/vendure-ecommerce/vendure/blob/master/docker-compose.yml>) here for development
+ * and testing without authentication and security enabled. Refer to ElasticSearch documentation to enable authentication and security in production.
  *
  * `yarn add \@elastic/elasticsearch \@vendure/elasticsearch-plugin`
  *


### PR DESCRIPTION
# Description

Vendure has had a limitation on the version of ElasticSearch that can be used because of a licensing issue in v7.11 which has since been resolved. Therefore we can now use v9.1.0 as long as the plugin and the Vendure project use the new ES deployment and matching library.

# Breaking changes

Does this PR include any breaking changes we should be aware of?
**YES - Breaking change** - ElasticSearch must be updated to v9.1.0, using the new client and plugin with the older v7 version of ES will FAIL.

Upgrading ElasticSearch is a one-way process, migrating the DB schema from v7.10.2 to v9.1.0 with no option to downgrade.

The ES instance and the client library in both the plugin and Vendure project package.json must match the upgraded ES instance version (v9.1.0).

# Screenshots

You can add screenshots here if applicable.

# Checklist

📌 Always:
- [X] I have set a clear title
- [X] My PR is small and contains a single feature
- [X] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [X] I have added or updated test cases
- [X] I have updated the README if needed
