### PR TITLE
docs(cli): update flag from --plugin to --selected-plugin for entity/service commands

### DIFF
--- a/docs/docs/guides/developer-guide/cli/index.md
+++ b/docs/docs/guides/developer-guide/cli/index.md
@@ -185,7 +185,7 @@ yarn vendure add -p MyPlugin --config ./custom-vendure.config.ts
 - `--mutationName <n>`: Name for the GraphQL mutation
 
 :::info
-**Validation**: Entity and service commands validate that the specified plugin exists in your project. If the plugin is not found, the command will list all available plugins in the error message. Both commands require the `--plugin` parameter when running in non-interactive mode.
+**Validation**: Entity and service commands validate that the specified plugin exists in your project. If the plugin is not found, the command will list all available plugins in the error message. Both commands require the `--selected-plugin` parameter when running in non-interactive mode.
 :::
 
 ## The Migrate Command


### PR DESCRIPTION
Update the CLI documentation to reflect the renamed/non-interactive flag for entity/service commands.

What changed: Replaced --plugin with --selected-plugin in the developer guide CLI docs (docs/docs/guides/developer-guide/cli/index.md).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated CLI Developer Guide: In the Add command’s validation note for non-interactive mode, the required flag for Entity and Service commands is now --selected-plugin (replacing --plugin). This clarifies correct flag usage in scripts and automation. No changes to application behavior or APIs; documentation text only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->