### PR TITLE
fix(core): Fix scheduled task registration to avoid entity ID errors

### DIFF
--- a/packages/core/src/plugin/default-scheduler-plugin/default-scheduler-strategy.ts
+++ b/packages/core/src/plugin/default-scheduler-plugin/default-scheduler-strategy.ts
@@ -241,6 +241,9 @@ export class DefaultSchedulerStrategy implements SchedulerStrategy {
                 .insert()
                 .into(ScheduledTaskRecord)
                 .values({ taskId })
+                // Fix for versions lower than MariaDB v10.5 and MySQL: updateEntity(false) prevents TypeORM from
+                // using the RETURNING clause after an INSERT. Keep in mind that this query won't return the id of the inserted record.
+                .updateEntity(false)
                 .orIgnore()
                 .execute();
 


### PR DESCRIPTION
Fixes #3573

# Description

The scheduled task registration was failing with `"Cannot update entity because entity id is not set"` errors when using a lower version of MariaDB v10.5 or MySQL. This occurs because TypeORM's by default tries to use the `RETURNING` clause after `INSERT` operations, but these database versions don't seem to support it.

MariaDB [added support in v10.5](https://mariadb.com/docs/server/reference/sql-statements/data-manipulation/inserting-loading-data/insertreturning)

People [have requested support](https://bugs.mysql.com/bug.php?id=117915) of the `RETURNING` clause for MySQL, so it may be supported in the future.

I added `.updateEntity(false)` of the insert query of the scheduled task registration. This prevents TypeORM from attempting to return the inserted entity data.

# Breaking changes

No

# Screenshots

You can add screenshots here if applicable.

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [ ] I have added or updated test cases
- [ ] I have updated the README if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved errors when registering scheduled tasks on older MariaDB/MySQL by adjusting insert behavior to avoid using a RETURNING clause. Improves reliability of task scheduling across diverse database versions, ensuring smoother startup and plugin operation in legacy environments. No API or configuration changes required. Backwards-compatible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->