### PR TITLE
fix(core): Handle foreign key violations during order merge

### DIFF
--- a/packages/core/src/service/helpers/utils/db-errors.ts
+++ b/packages/core/src/service/helpers/utils/db-errors.ts
@@ -1,0 +1,15 @@
+/**
+ * Returns true if the given error represents a foreign key constraint violation
+ * across supported drivers (Postgres, MySQL/MariaDB, SQLite).
+ */
+export function isForeignKeyViolationError(e: unknown): boolean {
+    const err: any = e || {};
+    const code = err.code ?? err.driverError?.code ?? err.errno ?? err.driverError?.errno;
+
+    // Postgres: 23503, MySQL/MariaDB: 1451/1452, SQLite: SQLITE_CONSTRAINT_FOREIGNKEY,
+    if (code === '23503' || code === 1451 || code === 1452 || code === 'SQLITE_CONSTRAINT_FOREIGNKEY') {
+        return true;
+    }
+    const msg = String(err.message ?? err.driverError?.message ?? '');
+    return /\bforeign key\b/i.test(msg);
+}

--- a/packages/core/src/service/services/order.service.ts
+++ b/packages/core/src/service/services/order.service.ts
@@ -117,6 +117,7 @@ import { RefundState } from '../helpers/refund-state-machine/refund-state';
 import { RefundStateMachine } from '../helpers/refund-state-machine/refund-state-machine';
 import { ShippingCalculator } from '../helpers/shipping-calculator/shipping-calculator';
 import { TranslatorService } from '../helpers/translator/translator.service';
+import { isForeignKeyViolationError } from '../helpers/utils/db-errors';
 import { getOrdersFromLines, totalCoveredByPayments } from '../helpers/utils/order-utils';
 import { patchEntity } from '../helpers/utils/patch-entity';
 
@@ -1895,10 +1896,7 @@ export class OrderService {
                     await this.deleteOrder(innerCtx, orderToDelete);
                 });
             } catch (e: any) {
-                const message: string = e?.message ?? '';
-                const isForeignKeyViolation = /foreign key/i.test(message);
-
-                if (!isForeignKeyViolation) throw e;
+                if (!isForeignKeyViolationError(e)) throw e;
                 if (!order)
                     throw new Error(
                         `Cannot complete order merge: active order not found, while cancelling order ${orderToDelete.id}`,

--- a/packages/core/src/service/services/order.service.ts
+++ b/packages/core/src/service/services/order.service.ts
@@ -1899,13 +1899,12 @@ export class OrderService {
                 const isForeignKeyViolation = /foreign key/i.test(message);
 
                 if (!isForeignKeyViolation) throw e;
+                if (!order) throw new Error('Cannot complete order merge: active order not found');
 
                 // If the order has a foreign key violation (e.g. with cancelled payments),
                 // instead of deleting it we cancel the order and leave a note with an explanation.
                 // This way the previous order and all its information are preserved.
                 await this.cancelOrder(ctx, { orderId: orderToDelete.id });
-
-                if (!order) throw e;
 
                 const note = [
                     'This order was cancelled during user sign-in because merging with the active order was not possible.',

--- a/packages/core/src/service/services/order.service.ts
+++ b/packages/core/src/service/services/order.service.ts
@@ -1899,7 +1899,10 @@ export class OrderService {
                 const isForeignKeyViolation = /foreign key/i.test(message);
 
                 if (!isForeignKeyViolation) throw e;
-                if (!order) throw new Error('Cannot complete order merge: active order not found');
+                if (!order)
+                    throw new Error(
+                        `Cannot complete order merge: active order not found, while cancelling order ${orderToDelete.id}`,
+                    );
 
                 // If the order has a foreign key violation (e.g. with cancelled payments),
                 // instead of deleting it we cancel the order and leave a note with an explanation.


### PR DESCRIPTION
Fixes #3773

# Description

This PR fixes an issue where logging in with items in a guest cart could fail if the user’s existing order was empty and had a failed or cancelled payment. In this case, instead of deleting the existing empty order (which caused the FK error), we set it to a `Cancelled` state and add a note with an explanation in the order history. This way the cancelled/errored payment is not deleted on the existing order.

# Breaking changes

Does this PR include any breaking changes we should be aware of?
No.

# Screenshots

You can add screenshots here if applicable.

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [ ] I have added or updated test cases
- [ ] I have updated the README if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of order merging in edge cases to prevent unexpected failures.
  * When a merge cannot complete due to reference constraints, the affected order is now preserved (cancelled) instead of deleted to avoid disruptions.

* **Improvements**
  * Adds a non-public history note to preserved orders explaining why the merge did not proceed, aiding support and traceability.
  * Provides clearer error feedback when an expected active order cannot be found during a merge.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->