### PR TITLE
fix(core): Fix addGraphQLCustomFields to support translatable types and JSON scalar for translations

### DIFF
--- a/packages/core/src/api/config/__snapshots__/graphql-custom-fields.spec.ts.snap
+++ b/packages/core/src/api/config/__snapshots__/graphql-custom-fields.spec.ts.snap
@@ -36,6 +36,21 @@ type ProductCustomFields {
 }"
 `;
 
+exports[`addGraphQLCustomFields() > extends a type that implements translatable 1`] = `
+"type ProductTranslation {
+  id: ID
+  customFields: ProductTranslationCustomFields
+}
+
+scalar JSON
+
+scalar DateTime
+
+type ProductTranslationCustomFields {
+  available: Boolean
+}"
+`;
+
 exports[`addGraphQLCustomFields() > extends a type with FilterParameters 1`] = `
 "type Product {
   name: String
@@ -280,6 +295,17 @@ scalar DateTime
 type ProductCustomFields {
   available: Boolean
 }"
+`;
+
+exports[`addGraphQLCustomFields() > uses JSON scalar for translation if no custom fields defined 1`] = `
+"type ProductTranslation {
+  id: ID
+  customFields: JSON
+}
+
+scalar JSON
+
+scalar DateTime"
 `;
 
 exports[`addGraphQLCustomFields() > uses JSON scalar if no custom fields defined 1`] = `

--- a/packages/core/src/api/config/graphql-custom-fields.spec.ts
+++ b/packages/core/src/api/config/graphql-custom-fields.spec.ts
@@ -24,6 +24,32 @@ describe('addGraphQLCustomFields()', () => {
         expect(printSchema(result)).toMatchSnapshot();
     });
 
+    it('uses JSON scalar for translation if no custom fields defined', () => {
+        const input = `
+            type ProductTranslation {
+                id: ID
+            }
+        `;
+        const customFieldConfig: CustomFields = {
+            Product: [],
+        };
+        const result = addGraphQLCustomFields(input, customFieldConfig, false);
+        expect(printSchema(result)).toMatchSnapshot();
+    });
+
+    it('extends a type that implements translatable', () => {
+        const input = `
+            type ProductTranslation {
+                id: ID
+            }
+        `;
+        const customFieldConfig: CustomFields = {
+            ProductTranslation: [{ name: 'available', type: 'boolean' }],
+        };
+        const result = addGraphQLCustomFields(input, customFieldConfig, false);
+        expect(printSchema(result)).toMatchSnapshot();
+    });
+
     // regression test for
     // https://github.com/vendure-ecommerce/vendure/issues/3158
     it('uses JSON scalar in UpdateActiveAdministratorInput if only internal custom fields defined on Administrator', () => {

--- a/packages/core/src/api/config/graphql-custom-fields.ts
+++ b/packages/core/src/api/config/graphql-custom-fields.ts
@@ -129,16 +129,24 @@ export function addGraphQLCustomFields(
             }
         }
 
-        if (localizedFields.length && schema.getType(`${entityName}Translation`)) {
-            customFieldTypeDefs += `
+        if (schema.getType(`${entityName}Translation`)) {
+            if (localizedFields.length) {
+                customFieldTypeDefs += `
                     type ${entityName}TranslationCustomFields {
-                         ${mapToFields(localizedFields, wrapListType(getGraphQlType(entityName)))}
+                        ${mapToFields(localizedFields, wrapListType(getGraphQlType(entityName)))}
                     }
 
                     extend type ${entityName}Translation {
                         customFields: ${entityName}TranslationCustomFields
                     }
                 `;
+            } else {
+                customFieldTypeDefs += `
+                    extend type ${entityName}Translation {
+                        customFields: JSON
+                    }
+                `;
+            }
         }
 
         const hasCreateInputType = schema.getType(`Create${entityName}Input`);


### PR DESCRIPTION
# Update

Investigated further and recognize that translation entities are not supposed to be extended manually. When extending an entity, say Product, the `ProductTranslation` entity is only supposed to be extended when Product itself is extended by `localeString` and `localeText`.

My initial approach in the PR would lead to duplicates resulting in an error when validating the SDL. 

That behavior can be seen in this unit test:

https://github.com/vendure-ecommerce/vendure/blob/f546d22fa34bf9d7cd2f983378c2c20dafbe18bb/packages/core/src/api/config/graphql-custom-fields.spec.ts#L63-L82

Closing the issue since this seems to be intended.

---

<details><summary>Original Issue Description</summary>
<p>

# Description

While working on extendable and, specifically relevant for this PR, **translatable** entities (#3798) I noticed that they dont seem to be extended like the general types so I investigated.

I'm going to use `Product` as an example but this is relevant for other types too.

`Product` implements `HasCustomFields` and the field shows up in the generated types:

https://github.com/vendure-ecommerce/vendure/blob/f546d22fa34bf9d7cd2f983378c2c20dafbe18bb/packages/common/src/generated-types.ts#L4686-L4692

See that `ProductTranslation` does implement `HasCustomFields` too:

https://github.com/vendure-ecommerce/vendure/blob/f546d22fa34bf9d7cd2f983378c2c20dafbe18bb/packages/core/src/entity/product/product-translation.entity.ts#L13

But as you can see in the generated types, there is no `customFields` field on the type:

https://github.com/vendure-ecommerce/vendure/blob/f546d22fa34bf9d7cd2f983378c2c20dafbe18bb/packages/common/src/generated-types.ts#L4825-L4834

This PR fixes that and properly extends the types.

TODO: Right now the `<EntityName>Translation`-Entities also get extended if only their base type `<EntityName>` gets extended.

Looking at translatable-saver customfield relations dont seem to be persisted automatically:

https://github.com/vendure-ecommerce/vendure/blob/f546d22fa34bf9d7cd2f983378c2c20dafbe18bb/packages/core/src/service/helpers/translatable-saver/translatable-saver.ts#L64-L86

And its also missing from the beforeSave handler:

https://github.com/vendure-ecommerce/vendure/blob/f546d22fa34bf9d7cd2f983378c2c20dafbe18bb/packages/core/src/service/services/product.service.ts#L235-L241

TODO try out custom fields on translatable entities

**NOTE:** Specifically did not regenerate types in this PR!

# Breaking changes

Not technically breaking but people will receive new types after running codegen.

# Screenshots

Irrelevant.

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [x] I have added or updated test cases
- [ ] I have updated the README if needed


</p>
</details> 

