### PR TITLE
fix(core): Emit c`CollectionEvent` after moving a collection

### DIFF
--- a/packages/core/src/service/services/collection.service.ts
+++ b/packages/core/src/service/services/collection.service.ts
@@ -609,6 +609,7 @@ export class CollectionService implements OnModuleInit {
         await this.triggerApplyFiltersJob(ctx, {
             collectionIds: [target.id],
         });
+        await this.eventBus.publish(new CollectionEvent(ctx, target, 'updated'));
         return assertFound(this.findOne(ctx, input.collectionId));
     }
 


### PR DESCRIPTION
# Description

A `CollectionEvent` should be emitted when a collection is moved. This PR implements emitting a `CollectionEvent` for the target collection.

Use case:
We do SSG building for some shops, and when a collection is moved, we want to trigger a rebuild. Currently, there is no way of knowing if an administrator moved a collection.

# Checklist

📌 Always:
- [ ] I have set a clear title
- [ ] My PR is small and contains a single feature
- [ ] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [ ] I have added or updated test cases
- [ ] I have updated the README if needed
