### PR TITLE
fix(create): Fix resolving path in repos using hoisted node_modules

### DIFF
--- a/packages/create/src/create-vendure-app.ts
+++ b/packages/create/src/create-vendure-app.ts
@@ -499,8 +499,6 @@ async function createDirectoryStructure(root: string) {
 async function copyEmailTemplates(root: string) {
     const emailPackageDirname = resolveDirName('@vendure/email-plugin');
     const templateDir = path.join(emailPackageDirname, 'templates');
-    log(pc.bgRedBright(emailPackageDirname));
-    log(pc.bgRedBright(templateDir));
     try {
         await fs.copy(templateDir, path.join(root, 'static', 'email', 'templates'));
     } catch (err: any) {

--- a/packages/create/src/create-vendure-app.ts
+++ b/packages/create/src/create-vendure-app.ts
@@ -302,9 +302,9 @@ export async function createVendureApp(
 
     let superAdminCredentials: { identifier: string; password: string } | undefined;
     try {
-        const { populate } = await import(path.join(resolveDirName('@vendure/core'), '/cli/populate'));
+        const { populate } = await import(path.join(resolveDirName('@vendure/core'), 'cli', 'populate'));
         const { bootstrap, DefaultLogger, LogLevel, JobQueueService, ConfigModule } = await import(
-            path.join(resolveDirName('@vendure/core'), '/dist/index')
+            path.join(resolveDirName('@vendure/core'), 'dist', 'index')
         );
         const { config } = await import(configFile);
         const assetsDir = path.join(__dirname, '../assets');
@@ -498,7 +498,7 @@ async function createDirectoryStructure(root: string) {
  */
 async function copyEmailTemplates(root: string) {
     const emailPackageDirname = resolveDirName('@vendure/email-plugin');
-    const templateDir = path.join(emailPackageDirname, '/templates');
+    const templateDir = path.join(emailPackageDirname, 'templates');
     try {
         await fs.copy(templateDir, path.join(root, 'static', 'email', 'templates'));
     } catch (err: any) {

--- a/packages/create/src/create-vendure-app.ts
+++ b/packages/create/src/create-vendure-app.ts
@@ -24,6 +24,7 @@ import {
     installPackages,
     isSafeToCreateProjectIn,
     isServerPortInUse,
+    resolveDirName,
     scaffoldAlreadyExists,
     startPostgresDatabase,
 } from './helpers';
@@ -69,7 +70,10 @@ void createVendureApp(
     options.useNpm,
     options.verbose ? 'verbose' : options.logLevel || 'info',
     options.ci,
-);
+).catch(err => {
+    log(err);
+    process.exit(1);
+});
 
 export async function createVendureApp(
     name: string | undefined,
@@ -294,13 +298,13 @@ export async function createVendureApp(
 
     // register ts-node so that the config file can be loaded
     // eslint-disable-next-line @typescript-eslint/no-var-requires
-    require(path.join(root, 'node_modules/ts-node')).register();
+    require(path.join(resolveDirName('ts-node'))).register();
 
     let superAdminCredentials: { identifier: string; password: string } | undefined;
     try {
-        const { populate } = await import(path.join(root, 'node_modules/@vendure/core/cli/populate'));
+        const { populate } = await import(path.join(resolveDirName('@vendure/core'), '/cli/populate'));
         const { bootstrap, DefaultLogger, LogLevel, JobQueueService, ConfigModule } = await import(
-            path.join(root, 'node_modules/@vendure/core/dist/index')
+            path.join(resolveDirName('@vendure/core'), '/dist/index')
         );
         const { config } = await import(configFile);
         const assetsDir = path.join(__dirname, '../assets');
@@ -493,10 +497,13 @@ async function createDirectoryStructure(root: string) {
  * Copy the email templates into the app
  */
 async function copyEmailTemplates(root: string) {
-    const templateDir = path.join(root, 'node_modules/@vendure/email-plugin/templates');
+    const emailPackageDirname = resolveDirName('@vendure/email-plugin');
+    const templateDir = path.join(emailPackageDirname, '/templates');
     try {
         await fs.copy(templateDir, path.join(root, 'static', 'email', 'templates'));
     } catch (err: any) {
         log(pc.red('Failed to copy email templates.'));
+        log(err);
+        process.exit(0);
     }
 }

--- a/packages/create/src/create-vendure-app.ts
+++ b/packages/create/src/create-vendure-app.ts
@@ -24,7 +24,7 @@ import {
     installPackages,
     isSafeToCreateProjectIn,
     isServerPortInUse,
-    resolveDirName,
+    resolvePackageRootDir,
     scaffoldAlreadyExists,
     startPostgresDatabase,
 } from './helpers';
@@ -298,13 +298,15 @@ export async function createVendureApp(
 
     // register ts-node so that the config file can be loaded
     // eslint-disable-next-line @typescript-eslint/no-var-requires
-    require(path.join(resolveDirName('ts-node'))).register();
+    require(resolvePackageRootDir('ts-node')).register();
 
     let superAdminCredentials: { identifier: string; password: string } | undefined;
     try {
-        const { populate } = await import(path.join(resolveDirName('@vendure/core'), 'cli', 'populate'));
+        const { populate } = await import(
+            path.join(resolvePackageRootDir('@vendure/core'), 'cli', 'populate')
+        );
         const { bootstrap, DefaultLogger, LogLevel, JobQueueService, ConfigModule } = await import(
-            path.join(resolveDirName('@vendure/core'), 'dist', 'index')
+            path.join(resolvePackageRootDir('@vendure/core'), 'dist', 'index')
         );
         const { config } = await import(configFile);
         const assetsDir = path.join(__dirname, '../assets');
@@ -497,7 +499,7 @@ async function createDirectoryStructure(root: string) {
  * Copy the email templates into the app
  */
 async function copyEmailTemplates(root: string) {
-    const emailPackageDirname = resolveDirName('@vendure/email-plugin');
+    const emailPackageDirname = resolvePackageRootDir('@vendure/email-plugin');
     const templateDir = path.join(emailPackageDirname, 'templates');
     try {
         await fs.copy(templateDir, path.join(root, 'static', 'email', 'templates'));

--- a/packages/create/src/create-vendure-app.ts
+++ b/packages/create/src/create-vendure-app.ts
@@ -499,6 +499,8 @@ async function createDirectoryStructure(root: string) {
 async function copyEmailTemplates(root: string) {
     const emailPackageDirname = resolveDirName('@vendure/email-plugin');
     const templateDir = path.join(emailPackageDirname, 'templates');
+    log(pc.bgRedBright(emailPackageDirname));
+    log(pc.bgRedBright(templateDir));
     try {
         await fs.copy(templateDir, path.join(root, 'static', 'email', 'templates'));
     } catch (err: any) {

--- a/packages/create/src/helpers.ts
+++ b/packages/create/src/helpers.ts
@@ -532,3 +532,13 @@ export function cleanUpDockerResources(name: string) {
         log(pc.yellow(`Could not clean up Docker resources`), { level: 'verbose' });
     }
 }
+
+export function resolveDirName(packageName: string) {
+    const packageDirName = path.dirname(require.resolve(packageName));
+    const packagePath = packageName.split('/').at(-1);
+    let currentPath = packageDirName;
+    while (path.basename(currentPath) !== packagePath) {
+        currentPath = path.join(currentPath, '..');
+    }
+    return currentPath;
+}

--- a/packages/create/src/helpers.ts
+++ b/packages/create/src/helpers.ts
@@ -540,9 +540,11 @@ export function resolveDirName(packageName: string) {
     } catch {
         throw new Error(`Cannot resolve package "${packageName}". Is it installed?`);
     }
+
     const target = packageName.split('/').pop();
     let dir = path.dirname(entry);
     const root = path.parse(dir).root;
+
     while (path.basename(dir) !== target) {
         const next = path.dirname(dir);
         if (next === dir || dir === root) {

--- a/packages/create/src/helpers.ts
+++ b/packages/create/src/helpers.ts
@@ -533,7 +533,7 @@ export function cleanUpDockerResources(name: string) {
     }
 }
 
-export function resolveDirName(packageName: string) {
+export function resolvePackageRootDir(packageName: string) {
     let packageEntryPath: string;
     try {
         packageEntryPath = require.resolve(packageName);

--- a/packages/create/src/helpers.ts
+++ b/packages/create/src/helpers.ts
@@ -538,6 +538,11 @@ export function resolveDirName(packageName: string) {
     try {
         entry = require.resolve(packageName);
     } catch {
+        // Fallback: try to find package in node_modules directly
+        const fallbackPath = path.join(process.cwd(), 'node_modules', packageName);
+        if (fs.existsSync(fallbackPath)) {
+            return fallbackPath;
+        }
         throw new Error(`Cannot resolve package "${packageName}". Is it installed?`);
     }
 

--- a/packages/create/src/helpers.ts
+++ b/packages/create/src/helpers.ts
@@ -534,11 +534,11 @@ export function cleanUpDockerResources(name: string) {
 }
 
 export function resolveDirName(packageName: string) {
-    let entry: string;
+    let packageEntryPath: string;
     try {
-        entry = require.resolve(packageName);
+        packageEntryPath = require.resolve(packageName);
     } catch {
-        // Fallback: try to find package in node_modules directly
+        log(`Falling back to direct node_modules lookup for ${packageName}`);
         const fallbackPath = path.join(process.cwd(), 'node_modules', packageName);
         if (fs.existsSync(fallbackPath)) {
             return fallbackPath;
@@ -547,13 +547,13 @@ export function resolveDirName(packageName: string) {
     }
 
     const target = packageName.split('/').pop();
-    let dir = path.dirname(entry);
+    let dir = path.dirname(packageEntryPath);
     const root = path.parse(dir).root;
 
     while (path.basename(dir) !== target) {
         const next = path.dirname(dir);
         if (next === dir || dir === root) {
-            throw new Error(`Could not locate package root for "${packageName}" from "${entry}".`);
+            throw new Error(`Could not locate package root for "${packageName}" from "${packageEntryPath}".`);
         }
         dir = next;
     }


### PR DESCRIPTION
Fixes #3506 

# Description
This PR adds a new helper function that uses `require.resolve()` to find the package directory instead of using `root + /path-to-package`.

This solves the problem where node_modules are hoisted (moved up the directory tree), causing the hardcoded path approach to fail when packages aren't in the expected location.

**Before:** `root + '/node_modules/package-name'`
**After:** `require.resolve('package-name')` to dynamically locate the package

Also adds `process.exit(0)` on errors to prevent "locking the console".

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [ ] I have added or updated test cases
- [ ] I have updated the README if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - None

- Bug Fixes
  - Added top-level error handling for the app-creation flow with clearer non-zero exit on failure.
  - Email template copying now reports failures and stops instead of failing silently.

- Refactor
  - Replaced hard-coded module location logic with dynamic package-resolution for improved portability.

- Chores
  - Added a helper to robustly resolve package root directories.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->