### PR TITLE
fix(dashboard): api 'auto' options

### DIFF
--- a/packages/dashboard/src/lib/graphql/api.ts
+++ b/packages/dashboard/src/lib/graphql/api.ts
@@ -4,8 +4,8 @@ import { DocumentNode, print } from 'graphql';
 import { uiConfig } from 'virtual:vendure-ui-config';
 
 const API_URL =
-    uiConfig.api.host +
-    (uiConfig.api.port !== 'auto' ? `:${uiConfig.api.port}` : '') +
+    (uiConfig.api.host !== "auto" ? uiConfig.api.host : `${window.location.protocol}//${window.location.hostname}`) +
+    `:${(uiConfig.api.port !== 'auto' ? uiConfig.api.port : window.location.port)}` +
     `/${uiConfig.api.adminApiPath}`;
 
 export const SELECTED_CHANNEL_TOKEN_KEY = 'vendure-selected-channel-token';


### PR DESCRIPTION
# Description

Ensure that the 'auto' settings are correctly resolved. 

_We need to use the `window.location` because further below in the `fetch` function, we initialize a `URL` class which can't accept e.g. `/dashboard/`, which `fetch` does support._


# Breaking changes

Nope

# Screenshots

You can add screenshots here if applicable.

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [ ] I have added or updated test cases
- [ ] I have updated the README if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Dashboard now auto-detects the API host and port from UI settings and the current browser location when set to auto, improving connectivity across environments (custom domains, varying ports, reverse proxies). The admin API path handling remains unchanged. No user-facing configuration changes are required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->