### PR TITLE
fix(core): Roles query pagination

### DIFF
--- a/packages/core/e2e/role.e2e-spec.ts
+++ b/packages/core/e2e/role.e2e-spec.ts
@@ -11,7 +11,7 @@ import path from 'path';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
 import { initialData } from '../../../e2e-common/e2e-initial-data';
-import { testConfig, TEST_SETUP_TIMEOUT_MS } from '../../../e2e-common/test-config';
+import { TEST_SETUP_TIMEOUT_MS, testConfig } from '../../../e2e-common/test-config';
 
 import { ROLE_FRAGMENT } from './graphql/fragments';
 import * as Codegen from './graphql/generated-e2e-admin-types';
@@ -448,8 +448,8 @@ describe('Role resolver', () => {
 
     // https://github.com/vendure-ecommerce/vendure/issues/1874
     describe('role escalation', () => {
-        let defaultChannel: Codegen.GetChannelsQuery['channels'][number];
-        let secondChannel: Codegen.GetChannelsQuery['channels'][number];
+        let defaultChannel: Codegen.GetChannelsQuery['channels']['items'][number];
+        let secondChannel: Codegen.GetChannelsQuery['channels']['items'][number];
         let limitedAdmin: Codegen.CreateAdministratorMutation['createAdministrator'];
         let orderReaderRole: Codegen.CreateRoleMutation['createRole'];
         let adminCreatorRole: Codegen.CreateRoleMutation['createRole'];
@@ -680,6 +680,82 @@ describe('Role resolver', () => {
                 });
             }, 'Active user does not have sufficient permissions'),
         );
+    });
+
+    describe('roles query', () => {
+        let limitedChannelAdmin: Codegen.CreateAdministratorMutation['createAdministrator'];
+
+        beforeAll(async () => {
+            adminClient.setChannelToken(E2E_DEFAULT_CHANNEL_TOKEN);
+            await adminClient.asSuperAdmin();
+
+            // Create roles that will be hidden from limited admin
+            await adminClient.query<Codegen.CreateRoleMutation, Codegen.CreateRoleMutationVariables>(
+                CREATE_ROLE,
+                {
+                    input: {
+                        code: 'hidden-role',
+                        description: 'Hidden role',
+                        // Some permission the limited admin user doesn't have, so the role is hidden
+                        permissions: [Permission.ReadOrder],
+                    },
+                },
+            );
+
+            // Create a role to assign to the limited admin user
+            const visibleRole = await adminClient.query<
+                Codegen.CreateRoleMutation,
+                Codegen.CreateRoleMutationVariables
+            >(CREATE_ROLE, {
+                input: {
+                    code: 'visible-role',
+                    description: 'Visible role',
+                    permissions: [Permission.ReadAdministrator],
+                },
+            });
+
+            const { createAdministrator } = await adminClient.query<
+                Codegen.CreateAdministratorMutation,
+                Codegen.CreateAdministratorMutationVariables
+            >(CREATE_ADMINISTRATOR, {
+                input: {
+                    firstName: 'Limited',
+                    lastName: 'Admin',
+                    emailAddress: 'limited@test.com',
+                    roleIds: [visibleRole.createRole.id],
+                    password: 'test',
+                },
+            });
+            limitedChannelAdmin = createAdministrator;
+        });
+
+        it('should return only visible roles with correct pagination', async () => {
+            // Login as limited admin
+            await adminClient.asUserWithCredentials(limitedChannelAdmin.emailAddress, 'test');
+
+            // Query first page with pagination, sorted by createdAt ASC
+            const result = await adminClient.query<Codegen.GetRolesQuery, Codegen.GetRolesQueryVariables>(
+                GET_ROLES,
+                {
+                    options: {
+                        take: 2,
+                    },
+                },
+            );
+
+            // Should have at least visible role and test role created earlier
+            expect(result.roles.items).toHaveLength(2);
+            expect(result.roles.totalItems).toBe(2);
+
+            // The returned role should be one that the limited admin can see
+            const roleCodes = result.roles.items.map(r => r.code);
+            expect(roleCodes).toContain('visible-role');
+            expect(roleCodes).not.toContain('hidden-role');
+        });
+
+        afterAll(async () => {
+            await adminClient.asSuperAdmin();
+        });
     });
 });
 


### PR DESCRIPTION
# Description

This PR fixes the roles query pagination which returned a wrong totalItems count due to post query filtering of visible roles.

# Breaking changes

No

# Screenshots

You can add screenshots here if applicable.

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [x] I have added or updated test cases
- [ ] I have updated the README if needed
