### PR TITLE
chore: Fix docs-link in README

### DIFF
--- a/packages/testing/README.md
+++ b/packages/testing/README.md
@@ -2,5 +2,4 @@
 
 This package contains utilities for writing end-to-end tests for Vendure.
 
-For documentation, see [www.vendure.io/docs/developer-guide/testing/](https://www.vendure.io/docs/developer-guide/testing/)
-
+For documentation, see [https://docs.vendure.io/guides/developer-guide/testing/](https://docs.vendure.io/guides/developer-guide/testing/)

--- a/packages/testing/README.md
+++ b/packages/testing/README.md
@@ -2,4 +2,4 @@
 
 This package contains utilities for writing end-to-end tests for Vendure.
 
-For documentation, see [https://docs.vendure.io/guides/developer-guide/testing/](https://docs.vendure.io/guides/developer-guide/testing/)
+For documentation, see https://docs.vendure.io/guides/developer-guide/testing/


### PR DESCRIPTION
Link was a 404

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the testing package README to link to the new docs site guidance, replacing the outdated Vendure developer guide URL.
  * Improves accuracy and discoverability of testing resources, reducing confusion when following setup and usage instructions.
  * Aligns documentation with the current site structure for consistency across references.
  * No functional changes to the package or APIs; this update solely enhances documentation clarity and developer onboarding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->