### PR TITLE
Add 'remove' action for page blocks

### DIFF
--- a/packages/dashboard/src/lib/framework/extension-api/types/layout.ts
+++ b/packages/dashboard/src/lib/framework/extension-api/types/layout.ts
@@ -64,8 +64,7 @@ export interface DashboardActionBarItem {
  * @docsPage page-blocks
  * @since 3.3.0
  */
-export type PageBlockPosition = { blockId: string; order: 'before' | 'after' | 'replace' };
-
+export type PageBlockPosition = { blockId: string; order: 'before' | 'after' | 'replace' | 'remove' };
 /**
  * @description
  * The location of a page block in the dashboard. The location can be found by turning on
@@ -92,10 +91,19 @@ export type PageBlockLocation = {
  * @docsWeight 0
  * @since 3.3.0
  */
-export interface DashboardPageBlockDefinition {
-    id: string;
-    title?: React.ReactNode;
-    location: PageBlockLocation;
-    component: React.FunctionComponent<{ context: PageContextValue }>;
-    requiresPermission?: string | string[];
-}
+export type DashboardPageBlockDefinition =
+    | {
+          id: string;
+          title?: React.ReactNode;
+          location: PageBlockLocation & {
+              position: { blockId: string; order: 'before' | 'after' | 'replace' };
+          };
+          component: React.FunctionComponent<{ context: PageContextValue }>;
+          requiresPermission?: string | string[];
+      }
+    | {
+          id?: string;
+          location: PageBlockLocation & {
+              position: { blockId: string; order: 'remove' };
+          };
+      };

--- a/packages/dashboard/src/lib/framework/layout-engine/page-layout.tsx
+++ b/packages/dashboard/src/lib/framework/layout-engine/page-layout.tsx
@@ -236,22 +236,29 @@ export function PageLayout({ children, className }: Readonly<PageLayoutProps>) {
                 (isOfType(childBlock, CustomFieldsPageBlock) ? 'custom-fields' : undefined);
             const extensionBlock = extensionBlocks.find(block => block.location.position.blockId === blockId);
             if (extensionBlock) {
-                const ExtensionBlock = (
-                    <PageBlock
-                        key={childBlock.key}
-                        column={extensionBlock.location.column}
-                        blockId={extensionBlock.id}
-                        title={extensionBlock.title}
-                    >
-                        {<extensionBlock.component context={page} />}
-                    </PageBlock>
-                );
-                if (extensionBlock.location.position.order === 'before') {
-                    finalChildArray.push(ExtensionBlock, childBlock);
-                } else if (extensionBlock.location.position.order === 'after') {
-                    finalChildArray.push(childBlock, ExtensionBlock);
-                } else if (extensionBlock.location.position.order === 'replace') {
-                    finalChildArray.push(ExtensionBlock);
+                if (extensionBlock.location.position.order === 'remove') {
+                    // Don't push anything - effectively removes the block
+                } else {
+                    const ExtensionBlock = extensionBlock.component ? (
+                        <PageBlock
+                            key={childBlock.key}
+                            column={extensionBlock.location.column}
+                            blockId={extensionBlock.id}
+                            title={extensionBlock.title}
+                        >
+                            {<extensionBlock.component context={page} />}
+                        </PageBlock>
+                    ) : null;
+                    
+                    if (ExtensionBlock) {
+                        if (extensionBlock.location.position.order === 'before') {
+                            finalChildArray.push(ExtensionBlock, childBlock);
+                        } else if (extensionBlock.location.position.order === 'after') {
+                            finalChildArray.push(childBlock, ExtensionBlock);
+                        } else if (extensionBlock.location.position.order === 'replace') {
+                            finalChildArray.push(ExtensionBlock);
+                        }
+                    }
                 }
             } else {
                 finalChildArray.push(childBlock);


### PR DESCRIPTION
Adds ability to remove dashboard blocks without providing replacement components. Only the location field is required when using order: 'remove'.

- Add 'remove' to PageBlockPosition type
- Update DashboardPageBlockDefinition to use discriminated union
- Handle remove action in PageLayout component
- Make id/component/title/permissions optional for remove actions

# Description

This PR adds a new `'remove'` action to the dashboard page block system, allowing developers to hide/remove existing blocks from dashboard pages without needing to provide a replacement component.

**Current behavior:** Developers can use `'before'`, `'after'`, or `'replace'` to customize page blocks, but there's no straightforward way to simply remove a block from a page.

**New behavior:** Using `order: 'remove'` in a block's position configuration will remove that block from the page entirely.

## Changes made:

- Add `'remove'` to `PageBlockPosition` type union
- Update `DashboardPageBlockDefinition` to use discriminated union for type safety
- Handle remove action in `PageLayout` component (early exit without rendering)
- Make `id`, `component`, `title`, and `requiresPermission` optional for remove actions

## Example usage:

```typescript
defineDashboardExtension({
  blocks: [{
    location: {
      pageId: 'order-detail',
      column: 'main',
      position: {
        blockId: 'tax-summary',
        order: 'remove',
      },
    },
    // No id, component, title, or other fields needed!
  }]
})
```

# Breaking changes

None. This is fully backward compatible - just a feature enhancement.

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have checked my own PR

👍 Most of the time:
- [ ] I have added or updated test cases
- [ ] I have updated the README if needed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extensions can now remove existing dashboard page blocks using a new “remove” order.
  * Layout handling updated to support before/after/replace as well as remove.
  * Extension blocks are only inserted when a component is provided; otherwise they are omitted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->