### PR TITLE
fix(dashboard): Custom fields of type select-form-input show no options

### DIFF
--- a/packages/dashboard/src/lib/framework/form-engine/utils.spec.ts
+++ b/packages/dashboard/src/lib/framework/form-engine/utils.spec.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from 'vitest';
 
 import { getOperationVariablesFields } from '../document-introspection/get-document-structure.js';
 
-import { removeEmptyIdFields } from './utils.js';
+import { isStringFieldWithOptions, removeEmptyIdFields } from './utils.js';
 
 const createProductDocument = graphql(`
     mutation CreateProduct($input: CreateProductInput!) {
@@ -33,5 +33,47 @@ describe('removeEmptyIdFields', () => {
         const fields = getOperationVariablesFields(createProductDocument);
         const result = removeEmptyIdFields(values, fields);
         expect(result).toEqual({ input: { translations: [] } });
+    });
+});
+
+describe('isStringFieldWithOptions', () => {
+    it('should return true for minimal custom field', () => {
+        expect(
+            isStringFieldWithOptions({
+                name: 'custom-field',
+                label: [],
+                requiresPermission: [],
+                type: 'string',
+                description: [],
+                defaultValue: null,
+                readonly: null,
+                list: false,
+                options: null,
+                nullable: null,
+                pattern: null,
+                ui: { component: 'select-form-input', options: [{ value: 'custom-value-1' }] },
+            }),
+        ).toBe(true);
+    });
+
+    it('should return false for custom field with missing options', () => {
+        expect(
+            isStringFieldWithOptions({
+                name: 'custom-field',
+                label: [],
+                requiresPermission: [],
+                type: 'string',
+                description: [],
+                defaultValue: null,
+                readonly: null,
+                list: false,
+                options: null,
+                nullable: null,
+                pattern: null,
+                ui: {
+                    component: 'select-form-input',
+                },
+            }),
+        ).toBe(false);
     });
 });

--- a/packages/dashboard/src/lib/framework/form-engine/utils.ts
+++ b/packages/dashboard/src/lib/framework/form-engine/utils.ts
@@ -156,8 +156,8 @@ export function isStringFieldWithOptions(input: ConfigurableFieldDef): input is 
     const isCustomFieldWithOptions =
         input.type === 'string' &&
         isCustomFieldConfig(input) &&
-        input.hasOwnProperty('options') &&
-        Array.isArray((input as any).options);
+        input.ui?.hasOwnProperty('options') &&
+        Array.isArray(input.ui?.options);
     if (isCustomFieldWithOptions) {
         return true;
     }


### PR DESCRIPTION
# Description

Within custom fields, the options reside inside the ui block, not outside of it.

# Breaking changes

no

# Screenshots

<img width="608" height="132" alt="Screenshot from 2025-10-08 17-40-41" src="https://github.com/user-attachments/assets/1cd8c949-106d-48cc-ae18-acde8e8dde7f" />


# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single ~~feature~~ bugfix
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [x] I have added or updated test cases
- [ ] I have updated the README if needed
